### PR TITLE
add sys clock freq flag, uses same method as current versa code

### DIFF
--- a/litex_boards/partner/targets/ulx3s.py
+++ b/litex_boards/partner/targets/ulx3s.py
@@ -53,9 +53,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCSDRAM):
-    def __init__(self, device="LFE5U-45F", toolchain="diamond", **kwargs):
+    def __init__(self, device="LFE5U-45F", toolchain="diamond", sys_clk_freq=int(50e6), **kwargs):
         platform = ulx3s.Platform(device=device, toolchain=toolchain)
-        sys_clk_freq = int(50e6)
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
                           integrated_rom_size=0x8000,
                           **kwargs)
@@ -77,11 +76,15 @@ def main():
         help='gateware toolchain to use, diamond (default) or  trellis')
     parser.add_argument("--device", dest="device", default="LFE5U-45F",
         help='FPGA device, ULX3S can be populated with LFE5U-45F (default) or LFE5U-85F')
+    parser.add_argument("--sys-clk-freq", default=50e6,
+                        help="system clock frequency (default=50MHz)")
     builder_args(parser)
     soc_sdram_args(parser)
     args = parser.parse_args()
 
-    soc = BaseSoC(device=args.device, toolchain=args.toolchain, **soc_sdram_argdict(args))
+    soc = BaseSoC(device=args.device, toolchain=args.toolchain,
+        sys_clk_freq=int(float(args.sys_clk_freq)),
+        **soc_sdram_argdict(args))
     builder = Builder(soc, **builder_argdict(args))
     builder.build()
 


### PR DESCRIPTION
Allows setting system clock frequency via command-line argument.  Uses the same code/method as the versa-ecp5 target.  This is useful when building rocket synthesis doesn't pass the default timing of 50mhz. 