### PR TITLE
Fix numato csr headers

### DIFF
--- a/litex_boards/partner/targets/aller.py
+++ b/litex_boards/partner/targets/aller.py
@@ -179,8 +179,8 @@ class AllerSoC(SoCSDRAM):
         ]
 
     def generate_software_header(self, filename):
-        csr_header = get_csr_header(self.get_csr_regions(),
-                                    self.get_constants(),
+        csr_header = get_csr_header(self.csr_regions,
+                                    self.constants,
                                     with_access_functions=False,
                                     with_shadow_base=False)
         tools.write_to_file(filename, csr_header)

--- a/litex_boards/partner/targets/aller.py
+++ b/litex_boards/partner/targets/aller.py
@@ -181,8 +181,7 @@ class AllerSoC(SoCSDRAM):
     def generate_software_header(self, filename):
         csr_header = get_csr_header(self.csr_regions,
                                     self.constants,
-                                    with_access_functions=False,
-                                    with_shadow_base=False)
+                                    with_access_functions=False)
         tools.write_to_file(filename, csr_header)
 
 

--- a/litex_boards/partner/targets/nereid.py
+++ b/litex_boards/partner/targets/nereid.py
@@ -178,8 +178,7 @@ class NereidSoC(SoCSDRAM):
     def generate_software_header(self, filename):
         csr_header = get_csr_header(self.csr_regions,
                                     self.constants,
-                                    with_access_functions=False,
-                                    with_shadow_base=False)
+                                    with_access_functions=False)
         tools.write_to_file(filename, csr_header)
 
 

--- a/litex_boards/partner/targets/nereid.py
+++ b/litex_boards/partner/targets/nereid.py
@@ -176,8 +176,8 @@ class NereidSoC(SoCSDRAM):
         ]
 
     def generate_software_header(self, filename):
-        csr_header = get_csr_header(self.get_csr_regions(),
-                                    self.get_constants(),
+        csr_header = get_csr_header(self.csr_regions,
+                                    self.constants,
                                     with_access_functions=False,
                                     with_shadow_base=False)
         tools.write_to_file(filename, csr_header)

--- a/litex_boards/partner/targets/tagus.py
+++ b/litex_boards/partner/targets/tagus.py
@@ -179,8 +179,7 @@ class TagusSoC(SoCSDRAM):
     def generate_software_header(self, filename):
         csr_header = get_csr_header(self.csr_regions,
                                     self.constants,
-                                    with_access_functions=False,
-                                    with_shadow_base=False)
+                                    with_access_functions=False)
         tools.write_to_file(filename, csr_header)
 
 

--- a/litex_boards/partner/targets/tagus.py
+++ b/litex_boards/partner/targets/tagus.py
@@ -177,8 +177,8 @@ class TagusSoC(SoCSDRAM):
         ]
 
     def generate_software_header(self, filename):
-        csr_header = get_csr_header(self.get_csr_regions(),
-                                    self.get_constants(),
+        csr_header = get_csr_header(self.csr_regions,
+                                    self.constants,
                                     with_access_functions=False,
                                     with_shadow_base=False)
         tools.write_to_file(filename, csr_header)


### PR DESCRIPTION
Commit https://github.com/enjoy-digital/litex/commit/8be5824e258b84df240d34636aaa539124b92c65 simplified the handling of csr regions and constants. These target files need to be updated to the new API.

They also still use the `with_shadow_base` parameter to `get_csr_header` which was removed/deprecated in https://github.com/enjoy-digital/litex/commit/a4ef9b29b9781f576caba316c7920c902a8d8c8f. I'm nearly positive that the new default behavior matches the previous behavior that the Numato targets were using.

Longer discussion in https://github.com/litex-hub/litex-boards/issues/25