### PR TITLE
ADD: KX2 and DDR3 support

### DIFF
--- a/litex_boards/community/platforms/kx2.py
+++ b/litex_boards/community/platforms/kx2.py
@@ -1,0 +1,79 @@
+# This file is Copyright (c) 2018-2019 Florent Kermarrec <florent@enjoy-digital.fr>
+# License: BSD
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import XilinxPlatform, VivadoProgrammer
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    ("user_led", 0, Pins("U9"), IOStandard("LVCMOS15")),
+    ("user_led", 1, Pins("V12"), IOStandard("LVCMOS15")),
+    ("user_led", 2, Pins("V13"), IOStandard("LVCMOS15")),
+    ("user_led", 3, Pins("W13"), IOStandard("LVCMOS15")),
+
+    ("cpu_reset_n", 0, Pins("G9"), IOStandard("LVCMOS25")),
+
+    ("clk200", 0,
+     Subsignal("p", Pins("AB11"), IOStandard("LVDS")),
+     Subsignal("n", Pins("AC11"), IOStandard("LVDS"))
+     ),
+
+    ("serial", 0,
+     Subsignal("tx", Pins("W11")),
+     Subsignal("rx", Pins("AB16")),
+     IOStandard("LVCMOS15")  # maybe LVCMOS15 or 33
+     ),
+
+    ("ddram", 0,
+     Subsignal("a", Pins(
+         "AE11 AF9 AD10 AB10 AA9 AB9 AA8 AC8",
+         "AA7 AE8 AF10 AD8 AE10 AF8 AC7"),
+               IOStandard("SSTL15")),
+     Subsignal("ba", Pins("AD11 AA10 AF12"), IOStandard("SSTL15")),
+     Subsignal("ras_n", Pins("AE13"), IOStandard("SSTL15")),
+     Subsignal("cas_n", Pins("AE12"), IOStandard("SSTL15")),
+     Subsignal("we_n", Pins("AA12"), IOStandard("SSTL15")),
+     Subsignal("cs_n", Pins("Y12"), IOStandard("SSTL15")),
+     Subsignal("dm", Pins("Y3 U5 AD4 AC4 AF19 AC16 AB19 V14"),
+               IOStandard("SSTL15")),
+     Subsignal("dq", Pins(
+         "AA2 Y2 AB2 V1 Y1 W1 AC2 V2",
+         "W3 V3 U1 U7 U6 V4 V6 U2",
+         "AE3 AE6 AF3 AD1 AE1 AE2 AF2 AE5",
+         "AD5 Y5 AC6 Y6 AB4 AD6 AB6 AC3",
+         "AD16 AE17 AF15 AF20 AD15 AF14 AE15 AF17",
+         "AA14 AA15 AC14 AD14 AB14 AB15 AA17 AA18",
+         "AB20 AD19 AC19 AA20 AA19 AC17 AD18 AB17",
+         "W15 W16 W14 V16 V19 V17 V18 Y17"),
+               IOStandard("SSTL15_T_DCI")),
+     Subsignal("dqs_p", Pins("AB1 W6 AF5 AA5 AE18 Y15 AD20 W18"),
+               IOStandard("DIFF_SSTL15")),
+     Subsignal("dqs_n", Pins("AC1 W5 AF4 AB5 AF18 Y16 AE20 W19"),
+               IOStandard("DIFF_SSTL15")),
+     Subsignal("clk_p", Pins("AB12"), IOStandard("DIFF_SSTL15")),
+     Subsignal("clk_n", Pins("AC12"), IOStandard("DIFF_SSTL15")),
+     Subsignal("cke", Pins("AA13"), IOStandard("SSTL15")),
+     Subsignal("odt", Pins("AD13"), IOStandard("SSTL15")),
+     Subsignal("reset_n", Pins("AB7"), IOStandard("LVCMOS15")),
+     Misc("SLEW=FAST"),
+     Misc("VCCAUX_IO=HIGH")
+     ),
+
+]
+
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(XilinxPlatform):
+    default_clk_name = "clk200"
+    default_clk_period = 1e9 / 200e6
+
+    def __init__(self):
+        XilinxPlatform.__init__(self, " xc7k160tffg676-2", _io, toolchain="vivado")
+
+    def create_programmer(self):
+        return VivadoProgrammer()
+
+    def do_finalize(self, fragment):
+        XilinxPlatform.do_finalize(self, fragment)

--- a/litex_boards/community/targets/kx2.py
+++ b/litex_boards/community/targets/kx2.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+# This file is Copyright (c) 2014-2015 Sebastien Bourdeauducq <sb@m-labs.hk>
+# This file is Copyright (c) 2014-2019 Florent Kermarrec <florent@enjoy-digital.fr>
+# This file is Copyright (c) 2014-2015 Yann Sionneau <ys@m-labs.hk>
+# License: BSD
+
+import argparse
+
+from migen import *
+
+from litex.boards.platforms import kx2
+
+from litex.soc.cores.clock import *
+from litex.soc.integration.soc_sdram import *
+from litex.soc.integration.builder import *
+
+from litedram.modules import H5TC4G63CFR
+from litedram.phy import s7ddrphy
+
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sys4x = ClockDomain(reset_less=True)
+        self.clock_domains.cd_clk200 = ClockDomain()
+
+        # # #
+
+        self.submodules.pll = pll = S7MMCM(speedgrade=-2)
+        self.comb += pll.reset.eq(~platform.request("cpu_reset_n"))
+        pll.register_clkin(platform.request("clk200"), 200e6)
+        pll.create_clkout(self.cd_sys, sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x, 4 * sys_clk_freq)
+        pll.create_clkout(self.cd_clk200, 200e6)
+
+        self.submodules.idelayctrl = S7IDELAYCTRL(self.cd_clk200)
+
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCSDRAM):
+    def __init__(self, sys_clk_freq=int(125e6), integrated_rom_size=0x8000, **kwargs):
+        platform = kx2.Platform()
+
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
+                          integrated_rom_size=integrated_rom_size,
+                          integrated_sram_size=0x8000,
+                          **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.submodules.ddrphy = s7ddrphy.K7DDRPHY(platform.request("ddram"),
+                                                       memtype="DDR3",
+                                                       nphases=4,
+                                                       sys_clk_freq=sys_clk_freq)
+            self.add_csr("ddrphy")
+            sdram_module = H5TC4G63CFR(sys_clk_freq, "1:4")
+            self.register_sdram(self.ddrphy,
+                                geom_settings=sdram_module.geom_settings,
+                                timing_settings=sdram_module.timing_settings)
+
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on KX2")
+    builder_args(parser)
+    soc_sdram_args(parser)
+    # parser.add_argument(action="store_true")
+    args = parser.parse_args()
+
+    soc = BaseSoC(**soc_sdram_argdict(args))
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds support for the enclustra KX2 board including DDR3 Memory support as specified here:
https://www.enclustra.com/en/products/fpga-modules/mercury-kx2/