### PR TITLE
Add Mimas A7 board support

### DIFF
--- a/litex_boards/community/platforms/mimas_a7.py
+++ b/litex_boards/community/platforms/mimas_a7.py
@@ -1,0 +1,191 @@
+# This file is Copyright (c) 2015 Yann Sionneau <yann.sionneau@gmail.com>
+# This file is Copyright (c) 2015-2019 Florent Kermarrec <florent@enjoy-digital.fr>
+# This file is Copyright (c) 2020 Feliks Montez <feliks.montez@gmail.com>
+# License: BSD
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import XilinxPlatform, VivadoProgrammer
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    ("user_led", 0, Pins("K17"), IOStandard("LVCMOS33")),
+    ("user_led", 1, Pins("J17"), IOStandard("LVCMOS33")),
+    ("user_led", 2, Pins("L14"), IOStandard("LVCMOS33")),
+    ("user_led", 3, Pins("L15"), IOStandard("LVCMOS33")),
+    ("user_led", 4, Pins("L16"), IOStandard("LVCMOS33")),
+    ("user_led", 5, Pins("K16"), IOStandard("LVCMOS33")),
+    ("user_led", 6, Pins("M15"), IOStandard("LVCMOS33")),
+    ("user_led", 7, Pins("M16"), IOStandard("LVCMOS33")),
+
+    ("user_sw", 0, Pins("B21"), IOStandard("LVCMOS33")),
+    ("user_sw", 1, Pins("A21"), IOStandard("LVCMOS33")),
+    ("user_sw", 2, Pins("E22"), IOStandard("LVCMOS33")),
+    ("user_sw", 3, Pins("D22"), IOStandard("LVCMOS33")),
+    ("user_sw", 4, Pins("E21"), IOStandard("LVCMOS33")),
+    ("user_sw", 5, Pins("D21"), IOStandard("LVCMOS33")),
+    ("user_sw", 6, Pins("G21"), IOStandard("LVCMOS33")),
+    ("user_sw", 7, Pins("G22"), IOStandard("LVCMOS33")),
+
+    ("user_btn", 0, Pins("P20"), IOStandard("LVCMOS33")),
+    ("user_btn", 1, Pins("P19"), IOStandard("LVCMOS33")),
+    ("user_btn", 2, Pins("P17"), IOStandard("LVCMOS33")),
+    ("user_btn", 3, Pins("N17"), IOStandard("LVCMOS33")),
+
+    ("clk100", 0, Pins("H4"), IOStandard("LVCMOS33")),
+
+    ("cpu_reset", 0, Pins("M2"), IOStandard("LVCMOS33")),
+
+    # Not usable unless EEPROM is reprogrammed to set Channel A of FT2232H to ASYNC Serial (UART) mode
+    # ("serial", 0,
+    #     Subsignal("tx", Pins("Y22")),
+    #     Subsignal("rx", Pins("Y21")),
+    #     IOStandard("LVCMOS33")
+    # ),
+
+    # Not usable unless EEPROM is reprogrammed to set Channel A of FT2232H to ASYNC FIFO 245 mode
+    # Host can interface with this as if it were UART--See issue https://github.com/enjoy-digital/litex/issues/231 for more info
+    ("usb_fifo", 0,
+        Subsignal("data", Pins("Y22 Y21 AB22 AA21 AB21 AA20 AB20 AA18")),
+        Subsignal("rxf_n", Pins("W21")),
+        Subsignal("txe_n", Pins("V22")),
+        Subsignal("rd_n", Pins("AA19")),
+        Subsignal("wr_n", Pins("W22")),
+        Subsignal("siwua", Pins("U21")),
+        Subsignal("oe_n", Pins("T21")),
+        IOStandard("LVCMOS33"), Drive(8), Misc("SLEW=FAST")
+    ),
+
+    ("spiflash4x", 0,
+        Subsignal("cs_n", Pins("T19")),
+        Subsignal("clk", Pins("L12")),
+        Subsignal("dq", Pins("P22", "R22", "P21", "R21")),
+        IOStandard("LVCMOS33")
+    ),
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("T19")),
+        Subsignal("clk", Pins("L12")),
+        Subsignal("mosi", Pins("P22")),
+        Subsignal("miso", Pins("R22")),
+        Subsignal("wp", Pins("P21")),
+        Subsignal("hold", Pins("R21")),
+        IOStandard("LVCMOS33"),
+    ),
+
+    # DDR3 MT41J128M16XX-125
+    # freq: 400MHz, data width: 16
+    ("ddram", 0,
+        Subsignal("a", Pins(
+            "U6 T5 Y6 T6 V2 T4 Y2 R2",
+            "Y1 R4 W5 W1 AA6 U2"),
+            IOStandard("SSTL15")),
+        Subsignal("ba", Pins("W6 U5 R6"), IOStandard("SSTL15")),
+        Subsignal("ras_n", Pins("V5"), IOStandard("SSTL15")),
+        Subsignal("cas_n", Pins("T1"), IOStandard("SSTL15")),
+        Subsignal("we_n", Pins("R3"), IOStandard("SSTL15")),
+        Subsignal("cs_n", Pins("T3"), IOStandard("SSTL15")),
+        Subsignal("dm", Pins("Y7 AA1"), IOStandard("SSTL15")),
+        Subsignal("dq", Pins(
+            "Y8 AB6 W9 AA8 AB7 V7 AB8 W7",
+            "V4 AB2 AA5 AB3 AB5 W4 AB1 AA4"),
+            IOStandard("SSTL15")),
+        Subsignal("dqs_p", Pins("V9 Y3"), IOStandard("DIFF_SSTL15")),
+        Subsignal("dqs_n", Pins("V8 AA3"), IOStandard("DIFF_SSTL15")),
+        Subsignal("clk_p", Pins("U3"), IOStandard("DIFF_SSTL15")),
+        Subsignal("clk_n", Pins("V3"), IOStandard("DIFF_SSTL15")),
+        Subsignal("cke", Pins("U1"), IOStandard("SSTL15")),
+        Subsignal("odt", Pins("W2"), IOStandard("SSTL15")),
+        Subsignal("reset_n", Pins("U7"), IOStandard("SSTL15")),
+        Misc("SLEW=FAST"),
+    ),
+
+    # Seven Seg display not yet mapped here
+
+    # 24AA02E48T EEPROM
+    ("eeprom", 0,
+        Subsignal("scl", Pins("N5")),
+        Subsignal("sda", Pins("P6")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # Micro SD not yet mapped here
+
+    # FIXME not sure how to map ethernet. Is this RGMII?
+    ("eth_clocks", 0,
+        Subsignal("tx", Pins("U20")),
+        Subsignal("rx", Pins("W19")),
+        IOStandard("LVCMOS33")
+    ),
+    ("eth", 0,
+        Subsignal("rst_n", Pins("R14")),
+        # Subsignal("int_n", Pins("Y14")), # usually RGMII has the int_n pin
+        Subsignal("mdio", Pins("P16"), Misc("SLEW=FAST")),
+        Subsignal("mdc", Pins("R19"), Misc("SLEW=FAST")),
+        Subsignal("rx_ctl", Pins("Y19")),
+        Subsignal("rx_data", Pins("AB18 W20 W17 V20")),
+        Subsignal("tx_ctl", Pins("T20"), Misc("SLEW=FAST")),
+        Subsignal("tx_data", Pins("V18 U18 V17 U17"), Misc("SLEW=FAST")),
+        IOStandard("LVCMOS33")
+    ),
+
+    ("hdmi_in", 0,
+        Subsignal("clk_p", Pins("K4"), IOStandard("TMDS_33")),
+        Subsignal("clk_n", Pins("J4"), IOStandard("TMDS_33")),
+        Subsignal("data0_p", Pins("K1"), IOStandard("TMDS_33")),
+        Subsignal("data0_n", Pins("J1"), IOStandard("TMDS_33")),
+        Subsignal("data1_p", Pins("M1"), IOStandard("TMDS_33")),
+        Subsignal("data1_n", Pins("L1"), IOStandard("TMDS_33")),
+        Subsignal("data2_p", Pins("P2"), IOStandard("TMDS_33")),
+        Subsignal("data2_n", Pins("N2"), IOStandard("TMDS_33")),
+        Subsignal("scl", Pins("J2"), IOStandard("LVCMOS33")),
+        Subsignal("sda", Pins("H2"), IOStandard("LVCMOS33")),
+        Subsignal("hpd_en", Pins("G2"), IOStandard("LVCMOS33")), # FIXME not sure if this is the hdmi_rx_hpa pin
+        Subsignal("cec", Pins("K2"), IOStandard("LVCMOS33")),
+        # Subsignal("txen", Pins("R3"), IOStandard("LVCMOS33")),  # not sure if we need this
+    ),
+
+    ("hdmi_out", 0,
+        Subsignal("clk_p", Pins("L3"), IOStandard("TMDS_33")),
+        Subsignal("clk_n", Pins("K3"), IOStandard("TMDS_33")),
+        Subsignal("data0_p", Pins("B1"), IOStandard("TMDS_33")),
+        Subsignal("data0_n", Pins("A1"), IOStandard("TMDS_33")),
+        Subsignal("data1_p", Pins("E1"), IOStandard("TMDS_33")),
+        Subsignal("data1_n", Pins("D1"), IOStandard("TMDS_33")),
+        Subsignal("data2_p", Pins("G1"), IOStandard("TMDS_33")),
+        Subsignal("data2_n", Pins("F1"), IOStandard("TMDS_33")),
+        Subsignal("scl", Pins("D2"), IOStandard("LVCMOS33")),
+        Subsignal("sda", Pins("C2"), IOStandard("LVCMOS33")),
+        Subsignal("cec", Pins("E2"), IOStandard("LVCMOS33")),
+        Subsignal("hdp", Pins("B2"), IOStandard("LVCMOS25")), # FIXME should this be hpd?
+    ),
+
+    # Mini display ports not yet mapped here
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = [
+    ("P12", "J20 J21 K21 K22 H20 G20 J19 H19 J22 H22 K18 K19 L19 L20 M21 N22 N20 M20 M18 L18 N18 N19 H17 H18 G17 G18 G15 G16 J15 H15 K13 K14 M13 K14 M13 L13 J14 H14 H13 G13"),
+    ("P13", "F19 F20 E19 D19 D20 C20 C22 B22 F18 E18 C18 C19 D17 C17 B20 A20 B17 B18 A18 A19 E16 D16 B15 B16 A15 A16 C14 C15 A13 A14 C13 B13 D14 D15 E13 E14 F13 F14 F16 E17")
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(XilinxPlatform):
+    default_clk_name = "clk100"
+    default_clk_period = 1e9/100e6
+
+    def __init__(self, variant="50t"):
+        device = {
+            "50t":  "xc7a50tfgg484-1"
+        }[variant]
+        XilinxPlatform.__init__(self, device, _io, _connectors, toolchain="vivado")
+        self.toolchain.bitstream_commands = \
+            ["set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]"]
+        self.toolchain.additional_commands = \
+            ["write_cfgmem -force -format bin -interface spix4 -size 16 "
+             "-loadbit \"up 0x0 {build_name}.bit\" -file {build_name}.bin"]
+        self.add_platform_command("set_property INTERNAL_VREF 0.675 [get_iobanks 34]")
+
+    def create_programmer(self):
+        return VivadoProgrammer(flash_part="n25q128-3.3v-spi-x1_x2_x4")

--- a/litex_boards/community/targets/mimas_a7.py
+++ b/litex_boards/community/targets/mimas_a7.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+# This file is Copyright (c) 2015-2019 Florent Kermarrec <florent@enjoy-digital.fr>
+# This file is Copyright (c) 2020 Feliks Montez <feliks.montez@gmail.com>
+# License: BSD
+
+import argparse
+
+from migen import *
+
+from litex_boards.platforms import mimas_a7
+from litex.build.xilinx.vivado import vivado_build_args, vivado_build_argdict
+
+from litex.soc.cores.clock import *
+from litex.soc.integration.soc_sdram import *
+from litex.soc.integration.builder import *
+
+from litedram.modules import MT41J128M16
+from litedram.phy import s7ddrphy
+
+from liteeth.phy.s7rgmii import LiteEthPHYRGMII
+from liteeth.mac import LiteEthMAC
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.clock_domains.cd_sys       = ClockDomain()
+        self.clock_domains.cd_sys4x     = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
+        self.clock_domains.cd_clk200    = ClockDomain()
+
+        # # #
+
+        self.submodules.pll = pll = S7PLL(speedgrade=-1)
+        self.comb += pll.reset.eq(platform.request("cpu_reset"))
+        pll.register_clkin(platform.request("clk100"), 100e6)
+        pll.create_clkout(self.cd_sys,       sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x,     4*sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x_dqs, 4*sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_clk200,    200e6)
+
+        self.submodules.idelayctrl = S7IDELAYCTRL(self.cd_clk200)
+
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCSDRAM):
+    def __init__(self, sys_clk_freq=int(100e6), integrated_rom_size=0x8000, uart_name="usb_fifo", **kwargs):
+        platform = mimas_a7.Platform()
+
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
+                         integrated_rom_size=integrated_rom_size,
+                         integrated_sram_size=0x8000,
+                         uart_name=uart_name,
+                         **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.submodules.ddrphy = s7ddrphy.A7DDRPHY(platform.request("ddram"),
+                memtype      = "DDR3",
+                nphases      = 4,
+                sys_clk_freq = sys_clk_freq)
+            self.add_csr("ddrphy")
+            sdram_module = MT41J128M16(sys_clk_freq, "1:4")
+            self.register_sdram(self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings)
+
+# EthernetSoC --------------------------------------------------------------------------------------
+
+class EthernetSoC(BaseSoC):
+    mem_map = {
+        "ethmac": 0xb0000000,
+    }
+    mem_map.update(BaseSoC.mem_map)
+
+    def __init__(self, **kwargs):
+        BaseSoC.__init__(self, integrated_rom_size=0x10000, **kwargs)
+
+        self.submodules.ethphy = LiteEthPHYRGMII(self.platform.request("eth_clocks"),
+                                               self.platform.request("eth"))
+        self.add_csr("ethphy")
+        self.submodules.ethmac = LiteEthMAC(phy=self.ethphy, dw=32,
+            interface="wishbone", endianness=self.cpu.endianness)
+        self.add_wb_slave(self.mem_map["ethmac"], self.ethmac.bus, 0x2000)
+        self.add_memory_region("ethmac", self.mem_map["ethmac"], 0x2000, type="io")
+        self.add_csr("ethmac")
+        self.add_interrupt("ethmac")
+
+        self.platform.add_period_constraint(self.ethphy.crg.cd_eth_rx.clk, 1e9/12.5e6)
+        self.platform.add_period_constraint(self.ethphy.crg.cd_eth_tx.clk, 1e9/12.5e6)
+        self.platform.add_false_path_constraints(
+            self.crg.cd_sys.clk,
+            self.ethphy.crg.cd_eth_rx.clk,
+            self.ethphy.crg.cd_eth_tx.clk)
+
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on Mimas A7")
+    builder_args(parser)
+    soc_sdram_args(parser)
+    vivado_build_args(parser)
+    parser.add_argument("--with-ethernet", action="store_true",
+                        help="enable Ethernet support")
+    args = parser.parse_args()
+
+    cls = EthernetSoC if args.with_ethernet else BaseSoC
+    soc = cls(**soc_sdram_argdict(args))
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build(**vivado_build_argdict(args))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds basic platform constraints and LiteX `BaseSoc` and `EthernetSoC` target files for the Numato Lab Mimas A7 FPGA development board. Not all of the board's constraints are mapped over yet, but this is good chunk of them. Ethernet has not been tested yet.