### PR TITLE
platforms/colorlight_5a_75b.py: fix sdram_clock and sdram a pins

### DIFF
--- a/litex_boards/platforms/colorlight_5a_75b.py
+++ b/litex_boards/platforms/colorlight_5a_75b.py
@@ -94,10 +94,10 @@ _io_v7_0 = [ # Documented by @miek
     ("user_btn_n", 0, Pins("M13"), IOStandard("LVCMOS33")),
 
     # sdram (M12616161A)
-    ("sdram_clock", 0, Pins("B9"), IOStandard("LVCMOS33")),
+    ("sdram_clock", 0, Pins("C6"), IOStandard("LVCMOS33")),
     ("sdram", 0,
         Subsignal("a", Pins(
-            "A9 E10 B12 D13 C1 D11 D10 E9",
+            "A9 E10 B12 D13 C12 D11 D10 E9",
             "D9 B7 C8")),
         Subsignal("dq", Pins(
             "B13 C11 C10 A11 C9 E8  B6  B9",


### PR DESCRIPTION
Fix two SDRAM pins:
- SDRAM clock is C6 not B9 (used for DQ7)
- typo in chubby75 repo take A4 connected to C1 instead of C12.

Tested with memtest