### PR TITLE
de10nano add in support for MiSTer secondary sd card

### DIFF
--- a/litex_boards/platforms/de10nano.py
+++ b/litex_boards/platforms/de10nano.py
@@ -101,6 +101,15 @@ _mister_sdram_module_io = [
         Subsignal("we_n", Pins("AA19")),
         IOStandard("3.3-V LVTTL")
     ),
+
+    # SPI SD CARD HARDWARE BITBANGING
+    ("spi",0,
+        Subsignal("clk", Pins("AH26")),                                      
+        Subsignal("mosi", Pins("AF27")),                                    
+        Subsignal("cs_n", Pins("AF28")),                                    
+        Subsignal("miso", Pins("AF25")),                                    
+        IOStandard("3.3-V LVTTL")
+    ),
 ]
 
 # Platform -----------------------------------------------------------------------------------------

--- a/litex_boards/targets/de10nano.py
+++ b/litex_boards/targets/de10nano.py
@@ -17,6 +17,9 @@ from litex.soc.integration.builder import *
 from litedram.modules import AS4C16M16
 from litedram.phy import GENSDRPHY
 
+#SPI SD CARD HARDWARE BITBANGING
+from litex.soc.cores.spi import SPIMaster
+
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(Module):
@@ -102,6 +105,12 @@ class MiSTerSDRAMSoC(SoCSDRAM):
             self.register_sdram(self.sdrphy,
                 geom_settings   = sdram_module.geom_settings,
                 timing_settings = sdram_module.timing_settings)
+
+        # SPI SDCARD HARDWARE BITBANGING
+        spi_pads = self.platform.request("spi")
+        self.add_csr("spi")
+        spi_clk_freq = 400e3
+        self.submodules.spi = SPIMaster(spi_pads, 8, sys_clk_freq, spi_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
The de10nano in a MiSTer setup has a secondary sd card attached to gpio pins. This patch, along with proposed patches to the litex bios allow the loading of the Linux images from this secondary sd card, partition 1 formatted as a FAT16 partition.