### PR TITLE
switch trellis to SoCCore, then add sdcard support

### DIFF
--- a/litex_boards/targets/trellisboard.py
+++ b/litex_boards/targets/trellisboard.py
@@ -22,6 +22,11 @@ from litedram.phy import ECP5DDRPHY
 
 from liteeth.phy.ecp5rgmii import LiteEthPHYRGMII
 
+from litesdcard.phy import SDPHY
+from litesdcard.core import SDCore
+from litesdcard.bist import BISTBlockGenerator, BISTBlockChecker
+from litex.soc.cores.timer import Timer
+
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(Module):
@@ -31,6 +36,8 @@ class _CRG(Module):
         self.clock_domains.cd_sys     = ClockDomain()
         self.clock_domains.cd_sys2x   = ClockDomain()
         self.clock_domains.cd_sys2x_i = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sd      = ClockDomain()
+        self.clock_domains.cd_sd_fb   = ClockDomain()
 
         # # #
 
@@ -54,6 +61,7 @@ class _CRG(Module):
         pll.register_clkin(clk12, 12e6)
         pll.create_clkout(self.cd_sys2x_i, 2*sys_clk_freq)
         pll.create_clkout(self.cd_init, 25e6)
+        pll.create_clkout(self.cd_sd, 10e6)
         self.specials += [
             Instance("ECLKBRIDGECS",
                 i_CLK0   = self.cd_sys2x_i.clk,
@@ -113,6 +121,32 @@ class BaseSoC(SoCCore):
             self.add_csr("ethphy")
             self.add_ethernet(phy=self.ethphy)
 
+    def add_sdcard(self):
+        sdcard_pads = self.platform.request("sdcard")
+        if hasattr(sdcard_pads, "rst"):
+            self.comb += sdcard_pads.rst.eq(0)
+        self.submodules.sdphy = SDPHY(sdcard_pads, self.platform.device)
+        self.submodules.sdcore = SDCore(self.sdphy)
+        self.submodules.sdtimer = Timer()
+        self.add_csr("sdphy")
+        self.add_csr("sdcore")
+        self.add_csr("sdtimer")
+
+        self.submodules.bist_generator = BISTBlockGenerator(random=True)
+        self.submodules.bist_checker = BISTBlockChecker(random=True)
+        self.add_csr("bist_generator")
+        self.add_csr("bist_checker")
+        self.comb += [
+            self.sdcore.source.connect(self.bist_checker.sink),
+            self.bist_generator.source.connect(self.sdcore.sink)
+        ]
+        self.platform.add_period_constraint(self.crg.cd_sd.clk, period_ns(self.sys_clk_freq))
+        self.platform.add_period_constraint(self.crg.cd_sd_fb.clk, period_ns(self.sys_clk_freq))
+        self.platform.add_false_path_constraints(
+            self.crg.cd_sys.clk,
+            self.crg.cd_sd.clk,
+            self.crg.cd_sd_fb.clk)
+
 # Build --------------------------------------------------------------------------------------------
 
 def main():
@@ -128,6 +162,8 @@ def main():
                         help="enable Ethernet support")
     parser.add_argument("--with-spi-sdcard", action="store_true",
                         help="enable SPI-mode SDCard support")
+    parser.add_argument("--with-sdcard", action="store_true",
+                        help="enable SDCard support")
     args = parser.parse_args()
 
     soc = BaseSoC(sys_clk_freq=int(float(args.sys_clk_freq)),
@@ -135,6 +171,10 @@ def main():
         **soc_sdram_argdict(args))
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()
+    if args.with_sdcard:
+        if args.with_spi_sdcard:
+            raise ValueError("'--with-spi-sdcard' and '--with-sdcard' are mutually exclusive!")
+        soc.add_sdcard()
     builder = Builder(soc, **builder_argdict(args))
     builder_kargs = trellis_argdict(args) if args.toolchain == "trellis" else {}
     builder.build(**builder_kargs)

--- a/litex_boards/targets/vcu118.py
+++ b/litex_boards/targets/vcu118.py
@@ -33,7 +33,7 @@ class _CRG(Module):
         self.comb += pll.reset.eq(platform.request("cpu_reset"))
         pll.register_clkin(platform.request("clk125"), 125e6)
         pll.create_clkout(self.cd_pll4x, sys_clk_freq*4, buf=None, with_reset=False)
-        pll.create_clkout(self.cd_clk500, 200e6, with_reset=False)
+        pll.create_clkout(self.cd_clk500, 500e6, with_reset=False)
 
         self.specials += [
             Instance("BUFGCE_DIV", name="main_bufgce_div",


### PR DESCRIPTION
@enjoy-digital: please don't apply yet. This *should* (but doesn't) work at the moment -- let's wait until we figure it out...

**Edit**: switching targets/trellisboard.py to LiteXSoC/SoCCore and using its built-in `add_ethernet()` method are now part of a different PR (#58). Once that's applied, I'll force-push this PR again with just the part that adds LiteSDCard support, as a pending RFC dependent on https://github.com/enjoy-digital/litesdcard/pull/10 (which still needs some work, probably timing related). -- Thanks!