### PR TITLE
Move trellisboard target to SoCCore, add SPI-mode SDCard support

### DIFF
--- a/litex_boards/platforms/trellisboard.py
+++ b/litex_boards/platforms/trellisboard.py
@@ -140,11 +140,19 @@ _io = [
         Subsignal("uart_cts_n", Pins("P7"), IOStandard("LVCMOS33"))
     ),
 
+    ("spisdcard", 0,
+        Subsignal("clk",  Pins("AK3")),
+        Subsignal("mosi", Pins("AH3"), Misc("PULLMODE=UP")),
+        Subsignal("cs_n", Pins("AK1"), Misc("PULLMODE=UP")),
+        Subsignal("miso", Pins("AG1"), Misc("PULLMODE=UP")),
+        IOStandard("LVCMOS33"), Misc("SLEW=FAST")
+    ),
+
     ("sdcard", 0,
-        Subsignal("data", Pins("AG1 AJ1 AH1 AK1")),
         Subsignal("clk", Pins("AK3")),
-        Subsignal("cmd", Pins("AH3")),
-        IOStandard("LVCMOS33")
+        Subsignal("cmd", Pins("AH3"), Misc("PULLMODE=UP")),
+        Subsignal("data", Pins("AG1 AJ1 AH1 AK1"), Misc("PULLMODE=UP")),
+        IOStandard("LVCMOS33"), Misc("SLEW=FAST")
     ),
 
     ("spiflash4x", 0,

--- a/litex_boards/targets/trellisboard.py
+++ b/litex_boards/targets/trellisboard.py
@@ -126,11 +126,15 @@ def main():
                         help="system clock frequency (default=75MHz)")
     parser.add_argument("--with-ethernet", action="store_true",
                         help="enable Ethernet support")
+    parser.add_argument("--with-spi-sdcard", action="store_true",
+                        help="enable SPI-mode SDCard support")
     args = parser.parse_args()
 
     soc = BaseSoC(sys_clk_freq=int(float(args.sys_clk_freq)),
         with_ethernet=args.with_ethernet,
         **soc_sdram_argdict(args))
+    if args.with_spi_sdcard:
+        soc.add_spi_sdcard()
     builder = Builder(soc, **builder_argdict(args))
     builder_kargs = trellis_argdict(args) if args.toolchain == "trellis" else {}
     builder.build(**builder_kargs)


### PR DESCRIPTION
@enjoy-digital: this, unlike my earlier LiteSDCard based PR **works** -- successfully booted a boot.bin (bbl blob containing kernel and busybox) on the trellisboard. Please review and pull!

Thanks,
--G