### PR TITLE
zcu104: add fully working SO-DIMM config

### DIFF
--- a/litex_boards/platforms/zcu104.py
+++ b/litex_boards/platforms/zcu104.py
@@ -43,47 +43,7 @@ _io = [
         IOStandard("LVCMOS18")
     ),
 
-    ("ddram_32", 0,
-        Subsignal("a",       Pins(
-            "AH16 AG14 AG15 AF15 AF16 AJ14 AH14 AF17",
-            "AK17 AJ17 AK14 AK15 AL18 AK18"),
-            IOStandard("SSTL12_DCI")),
-        Subsignal("ba",      Pins("AL15 AL16"), IOStandard("SSTL12_DCI")),
-        Subsignal("bg",      Pins("AC16 AB16"), IOStandard("SSTL12_DCI")),
-        Subsignal("ras_n",   Pins("AD15"), IOStandard("SSTL12_DCI")), # A16
-        Subsignal("cas_n",   Pins("AA14"), IOStandard("SSTL12_DCI")), # A15
-        Subsignal("we_n",    Pins("AA16"), IOStandard("SSTL12_DCI")), # A14
-        Subsignal("cs_n",    Pins("AA15"), IOStandard("SSTL12_DCI")), # also AL17 AN17 AN16 for larger SODIMMs
-        Subsignal("act_n",   Pins("AC17"), IOStandard("SSTL12_DCI")),
-        #Subsignal("alert_n", Pins("AB15"), IOStandard("SSTL12_DCI")),
-        #Subsignal("par",     Pins("AD16"), IOStandard("SSTL12_DCI")),
-        Subsignal("dm",      Pins("AF11 AH12 AK13 AN12"),
-            IOStandard("POD12_DCI")),
-        Subsignal("dq",      Pins(
-            "AC13 AB13 AF12 AE12 AF13 AE13 AE14 AD14",
-            "AG8  AF8  AG10 AG11 AH13 AG13 AJ11 AH11",
-            "AK9  AJ9  AK10 AJ10 AL12 AK12 AL10 AL11",
-            "AM8  AM9  AM10 AM11 AP11 AN11 AP9  AP10"),
-            IOStandard("POD12_DCI"),
-            Misc("PRE_EMPHASIS=RDRV_240"),
-            Misc("EQUALIZATION=EQ_LEVEL2")),
-        Subsignal("dqs_p",   Pins("AC12 AG9 AK8 AN9"),
-            IOStandard("DIFF_POD12_DCI"),
-            Misc("PRE_EMPHASIS=RDRV_240"),
-            Misc("EQUALIZATION=EQ_LEVEL2")),
-        Subsignal("dqs_n",   Pins("AD12 AH9 AL8 AN8"),
-            IOStandard("DIFF_POD12_DCI"),
-            Misc("PRE_EMPHASIS=RDRV_240"),
-            Misc("EQUALIZATION=EQ_LEVEL2")),
-        Subsignal("clk_p",   Pins("AF18"), IOStandard("DIFF_SSTL12_DCI")), # also AJ16 for larger SODIMMs
-        Subsignal("clk_n",   Pins("AG18"), IOStandard("DIFF_SSTL12_DCI")), # also AJ15 for larger SODIMMs
-        Subsignal("cke",     Pins("AD17"), IOStandard("SSTL12_DCI")), # also AM15 for larger SODIMMs
-        Subsignal("odt",     Pins("AE15"), IOStandard("SSTL12_DCI")), # also AM16 for larger SODIMMs
-        Subsignal("reset_n", Pins("AB14"), IOStandard("LVCMOS12")),
-        Misc("SLEW=FAST"),
-    ),
-
-    ("ddram_64", 0, # FIXME: not yet working
+    ("ddram", 0,
         Subsignal("a",       Pins(
             "AH16 AG14 AG15 AF15 AF16 AJ14 AH14 AF17",
             "AK17 AJ17 AK14 AK15 AL18 AK18"),

--- a/litex_boards/targets/zcu104.py
+++ b/litex_boards/targets/zcu104.py
@@ -15,7 +15,7 @@ from litex.soc.integration.soc_core import *
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
 
-from litedram.modules import KVR21SE15S84
+from litedram.modules import MTA4ATF51264HZ
 from litedram.phy import usddrphy
 
 # CRG ----------------------------------------------------------------------------------------------
@@ -59,7 +59,7 @@ class BaseSoC(SoCCore):
 
         # DDR4 SDRAM -------------------------------------------------------------------------------
         if not self.integrated_main_ram_size:
-            self.submodules.ddrphy = usddrphy.USPDDRPHY(platform.request("ddram_32"), # FIXME: use ddram_64
+            self.submodules.ddrphy = usddrphy.USPDDRPHY(platform.request("ddram"),
                 memtype          = "DDR4",
                 sys_clk_freq     = sys_clk_freq,
                 iodelay_clk_freq = 500e6,
@@ -69,7 +69,7 @@ class BaseSoC(SoCCore):
             self.add_constant("USDDRPHY_DEBUG")
             self.add_sdram("sdram",
                 phy                     = self.ddrphy,
-                module                  = KVR21SE15S84(sys_clk_freq, "1:4"),
+                module                  = MTA4ATF51264HZ(sys_clk_freq, "1:4"),
                 origin                  = self.mem_map["main_ram"],
                 size                    = kwargs.get("max_sdram_size", 0x40000000),
                 l2_cache_size           = kwargs.get("l2_size", 8192),


### PR DESCRIPTION
Depends on enjoy-digital/litedram#172

This PR adds fully working 64-bit SO-DIMM config for ZCU104 that was tested in #49