### PR TITLE
Improve compatability with colorlight 5a-75b v6.1

### DIFF
--- a/litex_boards/platforms/colorlight_5a_75b.py
+++ b/litex_boards/platforms/colorlight_5a_75b.py
@@ -19,6 +19,15 @@ _io_v6_1 = [ # Documented by @smunaut
     # btn
     ("user_btn_n", 0, Pins("R16"), IOStandard("LVCMOS33")),
 
+    # serial
+    ("serial", 0,
+        Subsignal("tx", Pins("U16")), # led (J19 DATA_LED-)
+        Subsignal("rx", Pins("R16")), # btn (J19 KEY+)
+        # It seems there's some capacitance on the KEY+ pin, so bigger baudrates
+        # may not work
+        IOStandard("LVCMOS33")
+    ),
+
     # spi flash (GD25Q16CSIG)
     ("spiflash", 0,
         Subsignal("cs_n", Pins("R2")),
@@ -68,8 +77,8 @@ _io_v6_1 = [ # Documented by @smunaut
     ),
 
     ("eth_clocks", 1,
-        Subsignal("tx", Pins("")),
-        Subsignal("rx", Pins("")),
+        Subsignal("tx", Pins("U19")),
+        Subsignal("rx", Pins("L19")),
         IOStandard("LVCMOS33")
     ),
     ("eth", 1,

--- a/litex_boards/platforms/colorlight_5a_75b.py
+++ b/litex_boards/platforms/colorlight_5a_75b.py
@@ -33,7 +33,7 @@ _io_v6_1 = [ # Documented by @smunaut
     ("sdram", 0,
         Subsignal("a", Pins(
             "B13 C14 A16 A17 B16 B15 A14 A13",
-            "A12 A11 B12 A11")),
+            "A12 A11 B12")),
         Subsignal("dq", Pins(
             "D15 E14 E13 D12 E12 D11 C10 B17",
             "B8  A8  C7  A7  A6  B6  A5  B5",
@@ -44,6 +44,7 @@ _io_v6_1 = [ # Documented by @smunaut
         Subsignal("cas_n", Pins("A9")),
         #Subsignal("cs_n", Pins("")), # gnd
         #Subsignal("cke",  Pins("")), # 3v3
+        Subsignal("ba",    Pins("B11")), # sdram pin a11 is ba
         #Subsignal("dm",   Pins("")), # gnd
         IOStandard("LVCMOS33"),
         Misc("SLEWRATE=FAST")

--- a/litex_boards/targets/colorlight_5a_75b.py
+++ b/litex_boards/targets/colorlight_5a_75b.py
@@ -7,7 +7,7 @@
 #
 # 1) SoC with regular UART and optional Ethernet connected to the CPU:
 # Connect a USB/UART to J19: TX of the FPGA is DATA_LED-, RX of the FPGA is KEY+.
-# ./colorlight_5a_75b.py (add --with-ethernet to add Ethernet capability)
+# ./colorlight_5a_75b.py --uart-baudrate 9600 (add --with-ethernet to add Ethernet capability)
 # ./colorlight_5a_75b.py --load
 # You should see the LiteX BIOS and be able to interact with it.
 #


### PR DESCRIPTION
Things done:
- Add `ba` pin for v6.1, since it won't build otherwise. According to the datasheet, A11 is the bank activate pin. Memtest is ok.
- Add eth_clocks 1. Simply used the pins documented in the chubby75 repo.

Also added serial pins, similar to v7.0. At 115200 baud, there was some strange behavior on the rx pin & it's loopback output, which I suspect may have to do with the capacitor that seems to be connected to the button. I changed the baud rate for the example to 9600 baud, since that works (for me).