### PR TITLE
platforms/nexys4ddr: add option to build with spi-mode sdcard support

### DIFF
--- a/litex_boards/targets/nexys4ddr.py
+++ b/litex_boards/targets/nexys4ddr.py
@@ -95,13 +95,16 @@ def main():
     parser.add_argument("--load",  action="store_true", help="Load bitstream")
     builder_args(parser)
     soc_sdram_args(parser)
-    parser.add_argument("--sys-clk-freq",  default=75e6,        help="System clock frequency (default=75MHz)")
-    parser.add_argument("--with-ethernet", action="store_true", help="Enable Ethernet support")
+    parser.add_argument("--sys-clk-freq",  default=75e6,          help="System clock frequency (default=75MHz)")
+    parser.add_argument("--with-ethernet", action="store_true",   help="Enable Ethernet support")
+    parser.add_argument("--with-spi-sdcard", action="store_true", help="enable SPI-mode SDCard support")
     args = parser.parse_args()
 
     soc = BaseSoC(sys_clk_freq=int(float(args.sys_clk_freq)),
         with_ethernet=args.with_ethernet,
         **soc_sdram_argdict(args))
+    if args.with_spi_sdcard:
+        soc.add_spi_sdcard()
     builder = Builder(soc, **builder_argdict(args))
     builder.build(run=args.build)
 


### PR DESCRIPTION
this already exists and has been pretty thoroughly tested in the `litex/boards/targets` version