### PR TITLE
Take Ethernet PHY out of reset so default clock is 125 Mhz

### DIFF
--- a/litex_boards/platforms/pano_logic_g2.py
+++ b/litex_boards/platforms/pano_logic_g2.py
@@ -98,6 +98,7 @@ _io = [
         Subsignal("odt", Pins("J6"), IOStandard("SSTL18_II")),
     ),
     # Ethernet phy reset (clk125 is 25 Mhz instead of 125 Mhz if reset is active)
+    # See https://github.com/tomverbeure/panologic-g2#fpga-external-clocking-architecture
     ("gmii_rst_n", 0, Pins("R11"), IOStandard("LVCMOS33")),
 
 ]

--- a/litex_boards/platforms/pano_logic_g2.py
+++ b/litex_boards/platforms/pano_logic_g2.py
@@ -97,6 +97,9 @@ _io = [
         Subsignal("cke", Pins("D2"), IOStandard("SSTL18_II")),
         Subsignal("odt", Pins("J6"), IOStandard("SSTL18_II")),
     ),
+    # Ethernet phy reset (clk125 is 25 Mhz instead of 125 Mhz if reset is active)
+    ("gmii_rst_n", 0, Pins("R11"), IOStandard("LVCMOS33")),
+
 ]
 
 # Platform -----------------------------------------------------------------------------------------

--- a/litex_boards/targets/pano_logic_g2.py
+++ b/litex_boards/targets/pano_logic_g2.py
@@ -46,6 +46,12 @@ class BaseSoC(SoCCore):
             sys_clk_freq = sys_clk_freq)
         self.add_csr("leds")
 
+        # Take Ethernet Phy out of reset for SYSCLK of 125 Mhz
+        gmii_rst_n = platform.request("gmii_rst_n")
+        self.comb += [
+            gmii_rst_n.eq(1)
+        ]
+
 # Build --------------------------------------------------------------------------------------------
 
 def main():


### PR DESCRIPTION
Without this change the terminal baud rate is 23,941 (measured by a scope) since the default clock is 25 Mhz instead of the expected 125 Mhz.  

The master clock on the Pano comes from the Ethernet PHY which is normally 125Mhz, but it is 25 Mhz while the PHY is in reset.  The active low reset pin is driven by FPGA pin R11. 

See https://github.com/tomverbeure/panologic-g2#fpga-external-clocking-architecture