### PR TITLE
ZCU104: add I2C

### DIFF
--- a/litex_boards/platforms/zcu104.py
+++ b/litex_boards/platforms/zcu104.py
@@ -43,6 +43,12 @@ _io = [
         IOStandard("LVCMOS18")
     ),
 
+    ("i2c", 1,
+        Subsignal("sda", Pins("P12")),
+        Subsignal("scl", Pins("N12")),
+        IOStandard("LVCMOS33")
+    ),
+
     ("ddram", 0,
         Subsignal("a",       Pins(
             "AH16 AG14 AG15 AF15 AF16 AJ14 AH14 AF17",

--- a/litex_boards/platforms/zcu104.py
+++ b/litex_boards/platforms/zcu104.py
@@ -43,7 +43,7 @@ _io = [
         IOStandard("LVCMOS18")
     ),
 
-    ("i2c", 1,
+    ("i2c", 0,
         Subsignal("sda", Pins("P12")),
         Subsignal("scl", Pins("N12")),
         IOStandard("LVCMOS33")

--- a/litex_boards/targets/zcu104.py
+++ b/litex_boards/targets/zcu104.py
@@ -16,6 +16,7 @@ from litex.soc.integration.soc_core import *
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
 from litex.soc.cores.led import LedChaser
+from litex.soc.cores.bitbang import I2CMaster
 
 from litedram.modules import MTA4ATF51264HZ
 from litedram.phy import usddrphy
@@ -76,6 +77,9 @@ class BaseSoC(SoCCore):
                 l2_cache_min_data_width = kwargs.get("min_l2_data_width", 128),
                 l2_cache_reverse        = True
             )
+
+            self.submodules.i2c = I2CMaster(platform.request("i2c", 1))
+            self.add_csr("i2c")
 
         # Leds -------------------------------------------------------------------------------------
         self.submodules.leds = LedChaser(

--- a/litex_boards/targets/zcu104.py
+++ b/litex_boards/targets/zcu104.py
@@ -78,7 +78,7 @@ class BaseSoC(SoCCore):
                 l2_cache_reverse        = True
             )
 
-            self.submodules.i2c = I2CMaster(platform.request("i2c", 1))
+            self.submodules.i2c = I2CMaster(platform.request("i2c"))
             self.add_csr("i2c")
 
         # Leds -------------------------------------------------------------------------------------


### PR DESCRIPTION
This adds I2C for the ZCU104 board, to be able to read SPD EEPROM from SO-DIMM modules.