### PR TITLE
Fix Microwatt on Versa board

### DIFF
--- a/litex_boards/platforms/versa_ecp5.py
+++ b/litex_boards/platforms/versa_ecp5.py
@@ -221,8 +221,8 @@ class Platform(LatticePlatform):
     default_clk_name   = "clk100"
     default_clk_period = 1e9/100e6
 
-    def __init__(self, **kwargs):
-        LatticePlatform.__init__(self, "LFE5UM5G-45F-8BG381C", _io, _connectors, **kwargs)
+    def __init__(self, device="LFE5UM5G-45F-8BG381C", **kwargs):
+        LatticePlatform.__init__(self, device, _io, _connectors, **kwargs)
 
     def create_programmer(self):
         return OpenOCDJTAGProgrammer("openocd_versa_ecp5.cfg")

--- a/litex_boards/targets/versa_ecp5.py
+++ b/litex_boards/targets/versa_ecp5.py
@@ -76,6 +76,12 @@ class BaseSoC(SoCCore):
     def __init__(self, sys_clk_freq=int(75e6), with_ethernet=False, toolchain="trellis", **kwargs):
         platform = versa_ecp5.Platform(toolchain=toolchain)
 
+        # Fix ROM size for Microwatt
+        if with_ethernet:
+            kwargs["integrated_rom_size"]  = 0xb000
+        else:
+            kwargs["integrated_rom_size"]  = 0x9000
+
         # SoCCore -----------------------------------------_----------------------------------------
         SoCCore.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
 

--- a/litex_boards/targets/versa_ecp5.py
+++ b/litex_boards/targets/versa_ecp5.py
@@ -73,8 +73,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(75e6), with_ethernet=False, toolchain="trellis", **kwargs):
-        platform = versa_ecp5.Platform(toolchain=toolchain)
+    def __init__(self, sys_clk_freq=int(75e6), device="LFE5UM5G-45F-8BG381C", with_ethernet=False, toolchain="trellis", **kwargs):
+        platform = versa_ecp5.Platform(toolchain=toolchain, device=device)
 
         # Fix ROM size for Microwatt
         if with_ethernet:
@@ -129,11 +129,12 @@ def main():
     builder_args(parser)
     soc_sdram_args(parser)
     trellis_args(parser)
-    parser.add_argument("--sys-clk-freq",  default=75e6,        help="System clock frequency (default=75MHz)")
-    parser.add_argument("--with-ethernet", action="store_true", help="Enable Ethernet support")
+    parser.add_argument("--sys-clk-freq",  default=75e6,                   help="System clock frequency (default=75MHz)")
+    parser.add_argument("--device",        default="LFE5UM5G-45F-8BG381C", help="ECP5 device (default=LFE5UM5G-45F-8BG381C)")
+    parser.add_argument("--with-ethernet", action="store_true",            help="Enable Ethernet support")
     args = parser.parse_args()
 
-    soc = BaseSoC(sys_clk_freq=int(float(args.sys_clk_freq)), with_ethernet=args.with_ethernet, toolchain=args.toolchain, **soc_sdram_argdict(args))
+    soc = BaseSoC(sys_clk_freq=int(float(args.sys_clk_freq)), device=args.device, with_ethernet=args.with_ethernet, toolchain=args.toolchain, **soc_sdram_argdict(args))
     builder = Builder(soc, **builder_argdict(args))
     builder_kargs = trellis_argdict(args) if args.toolchain == "trellis" else {}
     builder.build(**builder_kargs, run=args.build)


### PR DESCRIPTION
Verified to compile and load on a POWER system with the ECP5 Versa (non-5G) variant when `--device=LFE5UM-45F-8BG381C` is passed to ` ./versa_ecp5.py`