### PR TITLE
switch ULX3S to OpenFPGALoader

### DIFF
--- a/litex_boards/platforms/ulx3s.py
+++ b/litex_boards/platforms/ulx3s.py
@@ -3,7 +3,7 @@
 
 from litex.build.generic_platform import *
 from litex.build.lattice import LatticePlatform
-from litex.build.lattice.programmer import UJProg
+from litex.build.openfpgaloader import OpenFPGALoader
 
 # IOs ----------------------------------------------------------------------------------------------
 
@@ -113,7 +113,7 @@ class Platform(LatticePlatform):
         LatticePlatform.__init__(self, device + "-6BG381C", _io, **kwargs)
 
     def create_programmer(self):
-        return UJProg()
+        return OpenFPGALoader('ulx3s')
 
     def do_finalize(self, fragment):
         LatticePlatform.do_finalize(self, fragment)

--- a/litex_boards/targets/ulx3s.py
+++ b/litex_boards/targets/ulx3s.py
@@ -143,7 +143,7 @@ def main():
 
     if args.load:
         prog = soc.platform.create_programmer()
-        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".svf"))
+        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".bit"))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The ULX3S target currently uses the board-specific ujprog, which does not compile out of the box for me.
This PR changes it to use openFPGALoader, which is a more generic and broadly supported option.
This PR depends on https://github.com/enjoy-digital/litex/pull/615