### PR TITLE
Add optional OLED peripheral to ULX3S target

### DIFF
--- a/litex_boards/platforms/ulx3s.py
+++ b/litex_boards/platforms/ulx3s.py
@@ -100,6 +100,17 @@ _io = [
         Subsignal("pullup", Pins("B12 C12")),
         IOStandard("LVCMOS33")
     ),
+    ("oled_spi", 0,
+        Subsignal("clk",  Pins("P4")),
+        Subsignal("mosi", Pins("P3")),
+        IOStandard("LVCMOS33"),
+    ),
+    ("oled_ctl", 0,
+        Subsignal("dc",   Pins("P1")),
+        Subsignal("resn", Pins("P2")),
+        Subsignal("csn",  Pins("N2")),
+        IOStandard("LVCMOS33"),
+    ),
 ]
 
 # Platform -----------------------------------------------------------------------------------------


### PR DESCRIPTION
The ULX3S comes with a dedicated header where the user can plug in a SSD1331 or SSD1306 OLED display panel. So while not a built-in part of the board, these pins are definitely specifically for this display. They are also present in the official lpf: https://github.com/emard/ulx3s/blob/master/doc/constraints/ulx3s_v20.lpf

I made the choice to use the SPI mode of the display, rather than the less common I2C mode. In particular since LiteX does not come with an official I2C core, I think this is a defensible choice.

I am not 100% sure if the way I split the pins for the SPI and GPIO lines is idiomatic, but it is convenient. I think the way I faked the MISO is a bit ugly, but not too bad. I chose not to include the CS pin with the SPI pins because as far as I can tell it just becomes a separate register.

It is of course up to the maintainers of this project if support for this extra peripheral should be included. I have just added it for my own pleasure, and figured I'd share the code if it is of interest.