### PR TITLE
Changes to acorn-cle-215 platform/target files.

### DIFF
--- a/litex_boards/platforms/acorn_cle_215.py
+++ b/litex_boards/platforms/acorn_cle_215.py
@@ -33,6 +33,16 @@ _io = [
         IOStandard("LVCMOS33")
     ),
 
+    # spisdcard (requires adapter off P2)
+    ("spisdcard", 0,
+        Subsignal("clk",  Pins("J2")),
+        Subsignal("mosi", Pins("J5"), Misc("PULLUP True")),
+        Subsignal("cs_n", Pins("H5"), Misc("PULLUP True")),
+        Subsignal("miso", Pins("K2"), Misc("PULLUP True")),
+        Misc("SLEW=FAST"),
+        IOStandard("LVCMOS33"),
+    ),
+
     # pcie
     ("pcie_clkreq_n", 0, Pins("G1"), IOStandard("LVCMOS33")),
     ("pcie_x4", 0,


### PR DESCRIPTION
I am not sure if these changes would be desirable to be upstream. But I am working on adding support under linux-on-litex-vexriscv to build for the acorn-cle-215 and part of this change is needed to keep the implementation in the linux-on-litex-vexriscv changes simple.
This would be to move the platform call within the init statement of the target file. The other change is to add optional support for hanging an sd card in spi mode off the 6-pin P2 header on the acorn. This requires a simple passive adapter easily soldered up in an afternoon. Its a welcomed addition for running Linux or loading firmware off a dedicated storage device.

Original Commit Message: Moved platform call inside of BaseSoC init for compatibility with linux-on-litex-vexriscv support. Added optional spi-sdcard support over P2 header.