### PR TITLE
alveo_u250: Add PCIe x4 support

### DIFF
--- a/litex_boards/platforms/alveo_u250.py
+++ b/litex_boards/platforms/alveo_u250.py
@@ -275,6 +275,17 @@ _io = [
             "AP7 AR9 AT7 AU9 AV7 BB5 BD5 BF5")),
     ),
 
+    # pcie
+    ("pcie_x4", 0,
+        Subsignal("rst_n", Pins("BD21"), IOStandard("LVCMOS12")),
+        Subsignal("clk_n", Pins("AM10")),
+        Subsignal("clk_p", Pins("AM11")),
+        Subsignal("rx_n",  Pins("AF1 AG3 AH1 AJ3")),
+        Subsignal("rx_p",  Pins("AF2 AG4 AH2 AJ4")),
+        Subsignal("tx_n",  Pins("AF6 AG8 AH6 AJ8")),
+        Subsignal("tx_p",  Pins("AF7 AG9 AH7 AJ9")),
+    ),
+
     # qsfp28
     ("qsfp28", 0,
         Subsignal("clk_n", Pins("K10")),


### PR DESCRIPTION
Based on the implementation in xcu1525.

Note that enjoy-digital/litepcie#39 needs to be fixed before this builds out-of-the-box.

scratch_test seems to work correctly:
```
$ ./litepcie_util scratch_test
Write 0x12345678 to scratch register:
Read: 0x12345678
Write 0xdeadbeef to scratch register:
Read: 0xdeadbeef
```
I haven't tested any further than that. I also found I needed to reboot for the device to appear correctly, but my setup is somewhat unusual as it involves Thunderbolt on a X399 motherboard without the proper BIOS support.
