### PR TITLE
orangecrab: Fix r0.1 user_led mapping

### DIFF
--- a/litex_boards/platforms/orangecrab.py
+++ b/litex_boards/platforms/orangecrab.py
@@ -21,8 +21,8 @@ _io_r0_1 = [
     ),
 
     ("user_led", 0, Pins("V17"), IOStandard("LVCMOS33")), # rgb_led.r
-    ("user_led", 1, Pins("V17"), IOStandard("LVCMOS33")), # rgb_led.g
-    ("user_led", 2, Pins("V17"), IOStandard("LVCMOS33")), # rgb_led.b
+    ("user_led", 1, Pins("T17"), IOStandard("LVCMOS33")), # rgb_led.g
+    ("user_led", 2, Pins("J3"),  IOStandard("LVCMOS33")), # rgb_led.b
 
     ("ddram", 0,
         Subsignal("a", Pins(


### PR DESCRIPTION
On r0.1, all three user_leds are mapped to the same pin.
Fix this by mapping them to the pins connected to the individual
channels of the RGB LED, to match the comments, the schematics, and the
spirit of r0.2.

Untested on real hardware (I have r0.2 only).

Fixes: c94cbae0c04bbda3 ("orangecrab: add user_led (RGB leds), DFUProg and --load support.")
Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>