### PR TITLE
Add initial support for Trenz TEC0117 board

### DIFF
--- a/litex_boards/platforms/tec0117.py
+++ b/litex_boards/platforms/tec0117.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+from migen import *
+
+from litex.build.generic_platform import *
+from litex.build.gowin.platform import GowinPlatform
+from litex.build.openfpgaloader import OpenFPGALoader
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    ("user_led",  0, Pins("86"), IOStandard("LVCMOS33")),
+    ("clk12", 0, Pins("35"), IOStandard("LVCMOS33")),
+    ("rst",   0, Pins("77"), IOStandard("LVCMOS33")),
+
+    ("user_led", 0, Pins("86"), IOStandard("LVCMOS33")),
+    ("user_led", 1, Pins("85"), IOStandard("LVCMOS33")),
+    ("user_led", 2, Pins("84"), IOStandard("LVCMOS33")),
+    ("user_led", 3, Pins("83"), IOStandard("LVCMOS33")),
+    ("user_led", 4, Pins("82"), IOStandard("LVCMOS33")),
+    ("user_led", 5, Pins("81"), IOStandard("LVCMOS33")),
+    ("user_led", 6, Pins("80"), IOStandard("LVCMOS33")),
+    ("user_led", 7, Pins("79"), IOStandard("LVCMOS33")),
+
+    ("serial", 0,
+        Subsignal("tx", Pins("15"), IOStandard("LVCMOS33")),
+        Subsignal("rx", Pins("16"), IOStandard("LVCMOS33"))
+    ),
+
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("51"), IOStandard("LVCMOS33")),
+        Subsignal("clk",  Pins("49"), IOStandard("LVCMOS33")),
+        Subsignal("miso", Pins("53"), IOStandard("LVCMOS33")),
+        Subsignal("mosi", Pins("48"), IOStandard("LVCMOS33")),
+        Subsignal("wp",   Pins("54"), IOStandard("LVCMOS33")),
+        Subsignal("hold", Pins("50"), IOStandard("LVCMOS33")),
+    ),
+
+    # this one is the FTDI chip
+    ("spiflash", 1,
+        Subsignal("cs_n", Pins("13"), IOStandard("LVCMOS33")),
+        Subsignal("clk",  Pins("16"), IOStandard("LVCMOS33")),
+        Subsignal("miso", Pins("14"), IOStandard("LVCMOS33")),
+        Subsignal("mosi", Pins("15"), IOStandard("LVCMOS33")),
+    ),
+
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = [
+    ("PMOD", "47 41 38 40 - - 36 42 39 37"),
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(GowinPlatform):
+    default_clk_name   = "clk12"
+    default_clk_period = 1e9/12e6
+
+    def __init__(self):
+        GowinPlatform.__init__(self, "GW1NR-LV9QN88C6/I5", _io, toolchain="gowin", devicename='GW1NR-9')
+
+    def create_programmer(self):
+        return OpenFPGALoader("littlebee")
+

--- a/litex_boards/targets/tec0117.py
+++ b/litex_boards/targets/tec0117.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2014-2019 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2013-2014 Sebastien Bourdeauducq <sb@m-labs.hk>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import argparse
+import importlib
+
+from migen import *
+
+from litex.build.io import CRG
+
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+
+from litex_boards.platforms import tec0117
+
+from spiflash.serialflash import SerialFlashManager
+
+kB = 1024
+mB = 1024*kB
+
+class BaseSoC(SoCCore):
+
+    mem_map = {**SoCCore.mem_map, **{"spiflash": 0x80000000}}
+
+    def __init__(self, bios_flash_offset, **kwargs):
+        platform     = tec0117.Platform()
+        sys_clk_freq = int(1e9/platform.default_clk_period)
+
+        # SoC can have littel a bram, as a treat
+        kwargs["integrated_sram_size"] = 2048*2
+        kwargs["integrated_rom_size"]  = 0
+
+        # Set CPU variant / reset address
+        kwargs["cpu_reset_address"] = self.mem_map["spiflash"] + bios_flash_offset
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            ident          = "LiteX SoC on TEC0117",
+            ident_version  = True,
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = CRG(
+                platform.request(platform.default_clk_name),
+                ~platform.request('rst'),
+        )
+
+        # SPI Flash --------------------------------------------------------------------------------
+        self.add_spi_flash(mode="1x", dummy_cycles=8)
+
+        # Add ROM linker region --------------------------------------------------------------------
+        self.bus.add_region("rom", SoCRegion(
+            origin = self.mem_map["spiflash"] + bios_flash_offset,
+            size   = 8*mB,
+            linker = True)
+        )
+
+        # Leds -------------------------------------------------------------------------------------
+        self.submodules.leds = LedChaser(
+            pads         = platform.request_all("user_led"),
+            sys_clk_freq = sys_clk_freq)
+        self.add_csr("leds")
+
+        self.add_constant("UART_POLLING")
+
+# Flash --------------------------------------------------------------------------------------------
+
+def flash(offset, path):
+    platform = tec0117.Platform()
+    flash = platform.request("spiflash", 0)
+    bus = platform.request("spiflash", 1)
+
+    module = Module()
+    module.comb += [
+        flash.clk.eq(bus.clk),
+        flash.cs_n.eq(bus.cs_n),
+        flash.mosi.eq(bus.mosi),
+        bus.miso.eq(flash.miso),
+    ]
+
+    platform.build(module)
+    prog = platform.create_programmer()
+    prog.load_bitstream('build/impl/pnr/project.fs')
+
+    dev = SerialFlashManager.get_flash_device("ftdi://ftdi:2232/2")
+    dev.TIMINGS['chip'] = (4, 60) # chip is too slow
+    print("Erasing flash...")
+    dev.erase(0, -1, True)
+
+    with open(path, 'rb') as f:
+        bios = f.read()
+
+    print("Programming flash...")
+    dev.write(offset, bios)
+
+
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on iCEBreaker")
+    parser.add_argument("--build",             action="store_true", help="Build bitstream")
+    parser.add_argument("--load",              action="store_true", help="Load bitstream")
+    parser.add_argument("--bios-flash-offset", default=0,     help="BIOS offset in SPI Flash")
+    parser.add_argument("--flash",             action="store_true", help="Flash bios")
+    builder_args(parser)
+    soc_core_args(parser)
+    args = parser.parse_args()
+
+    soc     = BaseSoC(args.bios_flash_offset, **soc_core_argdict(args))
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build(run=args.build)
+
+    if args.flash:
+        flash(
+            args.bios_flash_offset,
+            os.path.join(builder.software_dir, "bios", "bios.bin"))
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(
+            os.path.join(builder.gateware_dir, "impl", "pnr", "project.fs"),
+            args.flash)
+
+
+if __name__ == "__main__":
+    main()

--- a/litex_boards/targets/tec0117.py
+++ b/litex_boards/targets/tec0117.py
@@ -70,8 +70,6 @@ class BaseSoC(SoCCore):
             sys_clk_freq = sys_clk_freq)
         self.add_csr("leds")
 
-        self.add_constant("UART_POLLING")
-
 # Flash --------------------------------------------------------------------------------------------
 
 def flash(offset, path):
@@ -94,7 +92,7 @@ def flash(offset, path):
     dev = SerialFlashManager.get_flash_device("ftdi://ftdi:2232/2")
     dev.TIMINGS['chip'] = (4, 60) # chip is too slow
     print("Erasing flash...")
-    dev.erase(0, -1, True)
+    dev.erase(0, -1)
 
     with open(path, 'rb') as f:
         bios = f.read()


### PR DESCRIPTION
This PR complements https://github.com/enjoy-digital/litex/pull/654 and adds support for the TEC0117 board.

Like the Icebreaker target, it puts the BIOS in flash, but since this board has internal bitstream flash and external user flash that is not accessible through JTAG, some hacky stuff is required to program the flash.

It currently uses 2kB sram, the minimal the bios was happy with. That's 2 bram primitives out of 26.