### PR TITLE
add Qmtech EP4CE15 coreboard support

### DIFF
--- a/litex_boards/platforms/qmtech_EP4CE15.py
+++ b/litex_boards/platforms/qmtech_EP4CE15.py
@@ -1,0 +1,89 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2014-2019 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.altera import AlteraPlatform
+from litex.build.altera.programmer import USBBlaster
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk
+    ("clk50", 0, Pins("T2"), IOStandard("3.3-V LVTTL")),
+
+    # Leds
+    ("user_led", 0, Pins("E4"), IOStandard("3.3-V LVTTL")),
+
+    # Button
+    ("key", 0, Pins("Y13"), IOStandard("3.3-V LVTTL")),
+    ("key", 1, Pins("W13"),  IOStandard("3.3-V LVTTL")),
+
+    # Serial
+    ("serial", 0,
+        # Compatible with cheap FT232 based cables (ex: Gaoominy 6Pin Ftdi Ft232Rl Ft232)
+        Subsignal("tx", Pins("AA13"), IOStandard("3.3-V LVTTL")), # GPIO_07 (JP1 Pin 10)
+        Subsignal("rx", Pins("AA14"), IOStandard("3.3-V LVTTL"))  # GPIO_05 (JP1 Pin 8)
+    ),
+
+    # SDR SDRAM
+    ("sdram_clock", 0, Pins("Y6"), IOStandard("3.3-V LVTTL")),
+    ("sdram", 0,
+        Subsignal("a",     Pins(
+            "V2 V1 U2 U1 V3 V4 Y2 AA1",
+            "Y3 V5 W1 Y4 V6")),
+        Subsignal("ba",    Pins("Y1 W2")),
+        Subsignal("cs_n",  Pins("AA3")),
+        Subsignal("cke",   Pins("W6")),
+        Subsignal("ras_n", Pins("AB3")),
+        Subsignal("cas_n", Pins("AA4")),
+        Subsignal("we_n",  Pins("AB4")),
+        Subsignal("dq", Pins(
+            "AA10 AB9 AA9 AB8 AA8 AB7 AA7 AB5",
+            "Y7 W8 Y8 V9 V10 Y10 W10 V11")),
+        Subsignal("dm", Pins("AA5 W7")),
+        IOStandard("3.3-V LVTTL")
+    ),
+
+    # GPIOs
+    #ignore for now
+    #("gpio_0", 0, Pins(
+    #    "D3 C3  A2  A3  B3  B4  A4  B5",
+    #    "A5 D5  B6  A6  B7  D6  A7  C6",
+    #    "C8 E6  E7  D8  E8  F8  F9  E9",
+    #    "C9 D9 E11 E10 C11 B11 A12 D11",
+    #    "D12 B12"),
+    #    IOStandard("3.3-V LVTTL")
+    #),
+    #("gpio_1", 0, Pins(
+    #    "F13 T15 T14 T13 R13 T12 R12 T11",
+    #    "T10 R11 P11 R10 N12  P9  N9 N11",
+    #    "L16 K16 R16 L15 P15 P16 R14 N16",
+    #    "N15 P14 L14 N14 M10 L13 J16 K15",
+    #    "J13 J14"),
+    #    IOStandard("3.3-V LVTTL")
+    #),
+    #("gpio_2", 0, Pins(
+    #    "A14 B16 C14 C16 C15 D16 D15 D14",
+    #    "F15 F16 F14 G16 G15"),
+    #    IOStandard("3.3-V LVTTL")
+    #),
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(AlteraPlatform):
+    default_clk_name   = "clk50"
+    default_clk_period = 1e9/50e6
+
+    def __init__(self):
+        AlteraPlatform.__init__(self, "EP4CE15F23C8", _io)
+
+    def create_programmer(self):
+        return USBBlaster()
+
+    def do_finalize(self, fragment):
+        AlteraPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)

--- a/litex_boards/platforms/qmtech_EP4CE15.py
+++ b/litex_boards/platforms/qmtech_EP4CE15.py
@@ -1,7 +1,7 @@
 #
 # This file is part of LiteX-Boards.
 #
-# Copyright (c) 2014-2019 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2020 Basel Sayeh <Basel.Sayeh@hotmail.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.build.generic_platform import *

--- a/litex_boards/targets/qmtech_EP4CE15.py
+++ b/litex_boards/targets/qmtech_EP4CE15.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2015-2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import argparse
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.build.io import DDROutput
+
+from litex_boards.platforms import qmtech_EP4CE15
+
+from litex.soc.cores.clock import CycloneIVPLL
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.soc_sdram import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+
+from litedram.modules import IS42S16160
+from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq, sdram_rate="1:1"):
+        self.rst = Signal()
+        self.clock_domains.cd_sys    = ClockDomain()
+        if sdram_rate == "1:2":
+            self.clock_domains.cd_sys2x    = ClockDomain()
+            self.clock_domains.cd_sys2x_ps = ClockDomain(reset_less=True)
+        else:
+            self.clock_domains.cd_sys_ps = ClockDomain(reset_less=True)
+
+        # # #
+
+        # Clk / Rst
+        clk50 = platform.request("clk50")
+
+        # PLL
+        self.submodules.pll = pll = CycloneIVPLL(speedgrade="-6")
+        self.comb += pll.reset.eq(self.rst)
+        pll.register_clkin(clk50, 50e6)
+        pll.create_clkout(self.cd_sys,    sys_clk_freq)
+        if sdram_rate == "1:2":
+            pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
+            pll.create_clkout(self.cd_sys2x_ps, 2*sys_clk_freq, phase=180)  # Idealy 90° but needs to be increased.
+        else:
+            pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
+
+        # SDRAM clock
+        sdram_clk = ClockSignal("sys2x_ps" if sdram_rate == "1:2" else "sys_ps")
+        self.specials += DDROutput(1, 0, platform.request("sdram_clock"), sdram_clk)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=int(50e6), sdram_rate="1:1", **kwargs):
+        platform = qmtech_EP4CE15.Platform()
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            ident          = "LiteX SoC on qmtech_EP4CE15",
+            ident_version  = True,
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq, sdram_rate=sdram_rate)
+
+        # SDR SDRAM --------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            sdrphy_cls = HalfRateGENSDRPHY if sdram_rate == "1:2" else GENSDRPHY
+            self.submodules.sdrphy = sdrphy_cls(platform.request("sdram"))
+            self.add_sdram("sdram",
+                phy                     = self.sdrphy,
+                module                  = IS42S16160(sys_clk_freq, sdram_rate),
+                origin                  = self.mem_map["main_ram"],
+                size                    = kwargs.get("max_sdram_size", 0x40000000),
+                l2_cache_size           = kwargs.get("l2_size", 8192),
+                l2_cache_min_data_width = kwargs.get("min_l2_data_width", 128),
+                l2_cache_reverse        = True
+            )
+
+        # Leds -------------------------------------------------------------------------------------
+        self.submodules.leds = LedChaser(
+            pads         = platform.request_all("user_led"),
+            sys_clk_freq = sys_clk_freq)
+        self.add_csr("leds")
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on qmtech_EP4CE15")
+    parser.add_argument("--build", action="store_true", help="Build bitstream")
+    parser.add_argument("--load",  action="store_true", help="Load bitstream")
+    parser.add_argument("--sdram-rate",  default="1:1", help="SDRAM Rate 1:1 Full Rate (default), 1:2 Half Rate")
+    builder_args(parser)
+    soc_sdram_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(sdram_rate=args.sdram_rate, **soc_sdram_argdict(args))
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build(run=args.build)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".sof"))
+
+if __name__ == "__main__":
+    main()

--- a/litex_boards/targets/qmtech_EP4CE15.py
+++ b/litex_boards/targets/qmtech_EP4CE15.py
@@ -3,7 +3,7 @@
 #
 # This file is part of LiteX-Boards.
 #
-# Copyright (c) 2015-2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2020 Basel Sayeh <Basel.Sayeh@hotmail.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os


### PR DESCRIPTION
Works perfectly
```
[LXTERM] Starting....
�
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2020 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Nov 12 2020 11:54:25
 BIOS CRC passed (4972a288)

 Migen git sha1: a5cc037
 LiteX git sha1: 9c0f6879

--=============== SoC ==================--
CPU:		VexRiscv_Linux @ 50MHz
BUS:		WISHBONE 32-bit @ 4GiB
CSR:		8-bit data
ROM:		32KiB
SRAM:		2KiB
L2:		2KiB
SDRAM:		32768KiB 16-bit @ 50MT/s (CL-2 CWL-2)

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2MiB)...
  Write: 0x40000000-0x40200000 2MiB     
   Read: 0x40000000-0x40200000 2MiB     
Memtest OK
Memspeed at 0x40000000 (2MiB)...
  Write speed: 12MiB/s
   Read speed: 10MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
[LXTERM] Received firmware download request from the device.
[LXTERM] Uploading buildroot/Image to 0x40000000 (4545524 bytes)...
[LXTERM] Upload complete (80.0KB/s).
[LXTERM] Uploading buildroot/rootfs.cpio to 0x40800000 (8029184 bytes)...
[LXTERM] Upload complete (79.7KB/s).
[LXTERM] Uploading buildroot/rv32.dtb to 0x41000000 (1891 bytes)...
[LXTERM] Upload complete (80.3KB/s).
[LXTERM] Uploading emulator/emulator.bin to 0x41100000 (9724 bytes)...
[LXTERM] Upload complete (79.9KB/s).
[LXTERM] Booting the device.
[LXTERM] Done.
KExecuting booted program at 0x41100000

--============= Liftoff! ===============--
VexRiscv Machine Mode software built Nov 12 2020 11:58:59
--========== Booting Linux =============--
[    0.000000] No DTB passed to the kernel
[    0.000000] Linux version 5.0.13 (florent@lab) (gcc version 8.3.0 (Buildroot 2019.08-rc2-00011-gad9efda578)) #1 Thu Sep 12 14:20:26 CEST 2019
[    0.000000] earlycon: sbi0 at I/O port 0x0 (options '')
[    0.000000] printk: bootconsole [sbi0] enabled
[    0.000000] Initial ramdisk at: 0x(ptrval) (8388608 bytes)
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000040000000-0x0000000041ffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000041ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x0000000041ffffff]
[    0.000000] elf_hwcap is 0x1101
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 8128
[    0.000000] Kernel command line: mem=32M@0x40000000 rootwait console=liteuart earlycon=sbi root=/dev/ram0 init=/sbin/init swiotlb=32
[    0.000000] Dentry cache hash table entries: 4096 (order: 2, 16384 bytes)
[    0.000000] Inode-cache hash table entries: 2048 (order: 1, 8192 bytes)
[    0.000000] Sorting __ex_table...
[    0.000000] Memory: 19796K/32768K available (3415K kernel code, 148K rwdata, 509K rodata, 140K init, 216K bss, 12972K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] NR_IRQS: 0, nr_irqs: 0, preallocated irqs: 0
[    0.000000] clocksource: riscv_clocksource: mask: 0xffffffffffffffff max_cycles: 0xb8812736b, max_idle_ns: 440795202655 ns
[    0.000540] sched_clock: 64 bits at 50MHz, resolution 20ns, wraps every 4398046511100ns
[    0.005726] Console: colour dummy device 80x25
[    0.008833] Calibrating delay loop (skipped), value calculated using timer frequency.. 100.00 BogoMIPS (lpj=200000)
[    0.011109] pid_max: default: 32768 minimum: 301
[    0.030169] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes)
[    0.032945] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes)
[    0.141581] devtmpfs: initialized
[    0.222261] random: get_random_bytes called from setup_net+0x4c/0x188 with crng_init=0
[    0.235382] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.237607] futex hash table entries: 256 (order: -1, 3072 bytes)
[    0.259021] NET: Registered protocol family 16
[    0.682393] clocksource: Switched to clocksource riscv_clocksource
[    1.313904] NET: Registered protocol family 2
[    1.347619] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes)
[    1.350160] TCP established hash table entries: 1024 (order: 0, 4096 bytes)
[    1.353203] TCP bind hash table entries: 1024 (order: 0, 4096 bytes)
[    1.355867] TCP: Hash tables configured (established 1024 bind 1024)
[    1.363617] UDP hash table entries: 256 (order: 0, 4096 bytes)
[    1.365702] UDP-Lite hash table entries: 256 (order: 0, 4096 bytes)
[    1.401596] Unpacking initramfs...
[    6.103894] Initramfs unpacking failed: junk in compressed archive
[    6.151371] workingset: timestamp_bits=30 max_order=13 bucket_order=0
[    7.328716] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 253)
[    7.331142] io scheduler mq-deadline registered
[    7.332399] io scheduler kyber registered
[   11.257781] f0001000.serial: ttyLXU0 at MMIO 0xf0001000 (irq = 0, base_baud = 0) is a liteuart
[   11.261006] printk: console [liteuart0] enabled
[   11.261006] printk: console [liteuart0] enabled
[   11.263552] printk: bootconsole [sbi0] disabled
[   11.263552] printk: bootconsole [sbi0] disabled
[   11.328686] libphy: Fixed MDIO Bus: probed
[   11.343175] i2c /dev entries driver
[   11.488928] NET: Registered protocol family 10
[   11.537155] Segment Routing with IPv6
[   11.543202] sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
[   11.657158] Freeing unused kernel memory: 140K
[   11.659017] This architecture does not have kernel memory protection.
[   11.660254] Run /init as init process
mount: mounting tmpfs on /dev/shm failed: Invalid argument
mount: mounting tmpfs on /tmp failed: Invalid argument
mount: mounting tmpfs on /run failed: Invalid argument
Starting syslogd: OK
Starting klogd: OK
Running sysctl: OK
Initializing random number generator... [   18.969930] random: dd: uninitialized urandom read (512 bytes read)
done.
Starting network: OK
Starting dropbear sshd: [   22.640028] random: dropbear: uninitialized urandom read (32 bytes read)
OK

Welcome to Buildroot
buildroot login: 


```