### PR TITLE
Support for the RHS Research LiteFury

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The Colorlight5A is a very nice board to start with, cheap, powerful, easy to us
 | KC705        | Xilinx Kintex7      | XC7K325T      | 125MHz  | FTDI | 64-bit   1GB DDR3  | Gen2 X8** |   1Gbps GMII   |  32MB QSPI* |   Yes  |
 | KCU105       | Xilinx KintexU      | XCKU40        | 125MHz  | FTDI | 64-bit   1GB DDR4  | Gen3 X8** | 1Gbps-BASE-X   |  64MB QSPI* |   Yes  |
 | KX2          | Xilinx Kintex7      | XC7K160T      | 125MHz  | FTDI | 64-bit   1GB DDR3  |     No    |       No       |  64MB QSPI* |   No   |
+| LiteFury     | Xilinx Artix7       | XC7A100T      | 100MHz  | PCIe | 16-bit 512MB DDR3  |  Gen2 X4  |       No       |  32MB QSPI* |   No   |
 | MachXO3      | Lattice MachXO3     | LCMXO3L-6900C | 125MHz  |  ?   |         ?          |     No    |       No       |      ?      |   No   |
 | Mercury XU5  | Xilinx ZynqU+       | XCZU2EG       | 125MHz  | FTDI | 16-bit 512MB DDR4  |     No    |       No       |  64MB QSPI* |   No   |
 | Mimas A7     | Xilinx Artix7       | XC7A50T       | 100MHz  | FTDI | 16-bit 256MB DDR3  |     No    | 1Gbps RGMII    |  16MB QSPI  |   No   |

--- a/litex_boards/platforms/litefury.py
+++ b/litex_boards/platforms/litefury.py
@@ -1,0 +1,158 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2020 <linux.robotdude@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import XilinxPlatform
+from litex.build.openocd import OpenOCD
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("clk200", 0,
+        Subsignal("p", Pins("J19"), IOStandard("LVDS_25")),
+        Subsignal("n", Pins("H19"), IOStandard("LVDS_25"))
+    ),
+
+    # Leds
+    ("user_led", 0, Pins("G3"), IOStandard("LVCMOS33"), Misc("PULLUP"), Misc("DRIVE=8")),
+    ("user_led", 1, Pins("H3"), IOStandard("LVCMOS33"), Misc("PULLUP"), Misc("DRIVE=8")),
+    ("user_led", 2, Pins("G4"),  IOStandard("LVCMOS33"), Misc("PULLUP"), Misc("DRIVE=8")),
+    ("user_led", 3, Pins("H4"),  IOStandard("LVCMOS33"), Misc("PULLUP"), Misc("DRIVE=8")),
+
+    # M.2 Led signal
+    ("m2_led", 0, Pins("M1"), IOStandard("LVCMOS33"), Misc("DRIVE=8")),
+
+    # SMBus (M.2 spec has pullups on host)
+    ("smbus", 0,
+        Subsignal("clk", Pins("Y11"), IOStandard("LVCMOS33")),
+        Subsignal("data", Pins("Y12"), IOStandard("LVCMOS33")),
+        Subsignal("alert_n", Pins("Y13"), IOStandard("LVCMOS33"))
+    ),
+
+    # SPIFlash
+    ("flash", 0,
+        Subsignal("cs_n",  Pins("T19")),
+        Subsignal("mosi",  Pins("P22")),
+        Subsignal("miso",  Pins("R22")),
+        Subsignal("hold",  Pins("R21")),
+        IOStandard("LVCMOS33")
+    ),
+    ("flash4x", 0,  # clock needs to be accessed through STARTUPE2 (pad L12) (90 MHz EMC clock is available)
+        Subsignal("cs_n", Pins("T19")),
+        Subsignal("dq",   Pins("P22", "R22", "P21", "R21")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # PCIe clock request
+    ("pcie_clkreq_l", 0, Pins("G1"), IOStandard("LVCMOS33")),
+
+    # PCIe
+    ("pcie_x1", 0,
+        Subsignal("rst_n", Pins("J1"), IOStandard("LVCMOS33")),
+        Subsignal("clk_p", Pins("F6")),
+        Subsignal("clk_n", Pins("E6")),
+        Subsignal("rx_p",  Pins("B10")),
+        Subsignal("rx_n",  Pins("A10")),
+        Subsignal("tx_p",  Pins("B6")),
+        Subsignal("tx_n",  Pins("A6"))
+    ),
+
+    ("pcie_x4", 0,
+        Subsignal("rst_n", Pins("J1"), IOStandard("LVCMOS33")),
+        Subsignal("clk_p", Pins("F6")),
+        Subsignal("clk_n", Pins("E6")),
+        Subsignal("rx_p",  Pins("B10 B8 D11 D9")),
+        Subsignal("rx_n",  Pins("A10 A8 C11 C9")),
+        Subsignal("tx_p",  Pins("B6 B4 D5 D7")),
+        Subsignal("tx_n",  Pins("A6 A4 C5 C7"))
+    ),
+
+    # DDR3 SDRAM
+    ("ddram", 0,
+        Subsignal("a", Pins(
+            "M15 L21 M16 L18 K21 M18 M21 N20",
+            "M20 N19 J21 M22 K22 N18 N22"),
+            IOStandard("SSTL15")),
+        Subsignal("ba",    Pins("L19 J20 L20"), IOStandard("SSTL15")),
+        Subsignal("ras_n", Pins("H20"),  IOStandard("SSTL15")),
+        Subsignal("cas_n", Pins("K18"),  IOStandard("SSTL15")),
+        Subsignal("we_n",  Pins("L16"),  IOStandard("SSTL15")),
+        Subsignal("dm", Pins("A19 G22"), IOStandard("SSTL15")),
+        Subsignal("dq", Pins(
+            "D19 B20 E19 A20 F19 C19 F20 C18",
+            "E22 G21 D20 E21 C22 D21 B22 D22"),
+            IOStandard("SSTL15"),
+            Misc("IN_TERM=UNTUNED_SPLIT_50")),
+        Subsignal("dqs_p", Pins("F18 B21"),  IOStandard("DIFF_SSTL15")),
+        Subsignal("dqs_n", Pins("E18 A21"), IOStandard("DIFF_SSTL15")),
+        Subsignal("clk_p", Pins("K17"), IOStandard("DIFF_SSTL15")),
+        Subsignal("clk_n", Pins("J17"), IOStandard("DIFF_SSTL15")),
+        Subsignal("cke",   Pins("H22"), IOStandard("SSTL15")),
+        Subsignal("odt",   Pins("K19"), IOStandard("SSTL15")),
+        Subsignal("reset_n", Pins("K16"), IOStandard("LVCMOS15")),
+        Misc("SLEW=FAST"),
+    ),
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = [
+    # Digital IO Header
+    ("IO", {
+        # LVDS pins
+        "dio1_p" : "W9",
+        "dio1_n" : "Y9",
+        "dio2_p" : "Y8",
+        "dio2_n" : "Y7",
+        "dio3_p" : "AA8",
+        "dio3_n" : "AB8",
+        "dio4_p" : "V9",
+        "dio4_n" : "V8",
+        # 3.3V DIO pins (or XADC)
+        "aio1_p" : "J5",
+        "aio1_n" : "H5",
+        "aio2_p" : "K2",
+        "aio2_n" : "J2",
+        }
+    ),
+
+    # Analog Header
+    ("XADC", {
+        "aio1_p" : "J5",
+        "aio1_n" : "H5",
+        "aio2_p" : "K2",
+        "aio2_n" : "J2",
+        }
+    ),
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(XilinxPlatform):
+    default_clk_name   = "clk200"
+    default_clk_period = 1e9/200e6
+
+    def __init__(self):
+        XilinxPlatform.__init__(self, "xc7a100t-fgg484-2l", _io, _connectors, toolchain="vivado")
+        # Enable fast startup so FPGA is up before PCIe root-complex initialization on host
+        self.add_platform_command("set_property BITSTREAM.CONFIG.CONFIGFALLBACK ENABLE [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.EXTMASTERCCLK_EN Div-1 [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_FALL_EDGE YES [current_design]")
+        self.add_platform_command("set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]")
+        self.add_platform_command("set_property CFGBVS VCCO [current_design]")
+        self.add_platform_command("set_property CONFIG_MODE SPIx4 [current_design]")
+        self.add_platform_command("set_property CONFIG_VOLTAGE 3.3 [current_design]")
+
+        self.toolchain.additional_commands = \
+            ["write_cfgmem -force -format mcs -interface spix4 -size 16 "
+             "-loadbit \"up 0x680000 {build_name}.bit\" -file {build_name}.mcs"]
+
+    def do_finalize(self, fragment):
+        XilinxPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk200", loose=True), 1e9/200e6)

--- a/litex_boards/targets/litefury.py
+++ b/litex_boards/targets/litefury.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2018-2019 Rohit Singh <rohit@rohitksingh.in>
+# Copyright (c) 2019-2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import argparse
+import sys
+
+from migen import *
+
+from litex_boards.platforms import litefury
+
+from litex.soc.interconnect.csr import *
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.soc_sdram import *
+from litex.soc.integration.builder import *
+
+from litex.soc.cores.clock import *
+from litex.soc.cores.led import LedChaser
+
+from litedram.modules import AS4C256M16D3A
+from litedram.phy import s7ddrphy
+
+from litepcie.phy.s7pciephy import S7PCIEPHY
+from litepcie.software import generate_litepcie_software
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst = Signal()
+        self.clock_domains.cd_sys       = ClockDomain()
+        self.clock_domains.cd_sys4x     = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
+        self.clock_domains.cd_idelay    = ClockDomain()
+
+        # Clk/Rst
+        clk200 = platform.request("clk200")
+
+        # PLL
+        self.submodules.pll = pll = S7PLL()
+        self.comb += pll.reset.eq(self.rst)
+        pll.register_clkin(clk200, 200e6)
+        pll.create_clkout(self.cd_sys,       sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x,     4*sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x_dqs, 4*sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_idelay,    200e6)
+
+        self.submodules.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
+
+# BaseSoC -----------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=int(100e6), with_pcie=False, **kwargs):
+        platform = litefury.Platform()
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            ident          = "LiteX SoC on LiteFury",
+            ident_version  = True,
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = CRG(platform, sys_clk_freq)
+
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.submodules.ddrphy = s7ddrphy.A7DDRPHY(platform.request("ddram"),
+                memtype          = "DDR3",
+                nphases          = 4,
+                sys_clk_freq     = sys_clk_freq,
+                iodelay_clk_freq = 200e6)
+            self.add_csr("ddrphy")
+            self.add_sdram("sdram",
+                phy                     = self.ddrphy,
+                module                  = AS4C256M16D3A(sys_clk_freq, "1:4"),
+                origin                  = self.mem_map["main_ram"],
+                size                    = kwargs.get("max_sdram_size", 0x20000000),
+                l2_cache_size           = kwargs.get("l2_size", 8192),
+                l2_cache_min_data_width = kwargs.get("min_l2_data_width", 128),
+                l2_cache_reverse        = True
+            )
+
+        # PCIe -------------------------------------------------------------------------------------
+        if with_pcie:
+            self.submodules.pcie_phy = S7PCIEPHY(platform, platform.request("pcie_x4"),
+                data_width = 64,
+                bar0_size  = 0x20000)
+            self.add_csr("pcie_phy")
+            self.add_pcie(phy=self.pcie_phy, ndmas=1)
+
+        # Leds -------------------------------------------------------------------------------------
+        self.submodules.leds = LedChaser(
+            pads         = platform.request_all("user_led"),
+            sys_clk_freq = sys_clk_freq)
+        self.add_csr("leds")
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on Aller")
+    parser.add_argument("--build",        action="store_true", help="Build bitstream")
+    parser.add_argument("--sys-clk-freq", default=100e6,       help="System clock frequency (default: 100MHz)")
+    parser.add_argument("--with-pcie",    action="store_true", help="Enable PCIe support")
+    parser.add_argument("--driver",       action="store_true", help="Generate LitePCIe driver")
+    builder_args(parser)
+    soc_sdram_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq = int(float(args.sys_clk_freq)),
+        with_pcie    = args.with_pcie,
+        **soc_sdram_argdict(args)
+    )
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build(run=args.build)
+
+    if args.driver:
+        generate_litepcie_software(soc, os.path.join(builder.output_dir, "driver"))
+
+if __name__ == "__main__":
+    main()

--- a/test/test_targets.py
+++ b/test/test_targets.py
@@ -51,6 +51,7 @@ class TestTargets(unittest.TestCase):
         platforms.append("tagus")
         platforms.append("acorn_cle_215")
         platforms.append("marblemini")
+        platforms.append("litefury")
 
         # Xilinx Kintex7
         platforms.append("genesys2")


### PR DESCRIPTION
LiteFury is an Artix-7 development board in the M.2 form factor for PCIe accelerator development. It's similar to the Aller but with an xc7a100t rather than an xc7a200t and no TPM module. 

product site: https://rhsresearch.com/collections/rhs-public/products/litefury

As far as testing goes, I've booted into the LiteX bios via a PCIe wishbone bridge with a crossover uart. mem_test passes and the console works.

Caveats: The PCIe data width is set at 64 bits because when set to 128 bits every computer I put the board in either fails to POST (custom i7-5820k system (UEFI)) or hangs when the OS tries to load (Dell Optiplex 980 w/ i7-860 (BIOS)). I don't know where to begin debugging this. I don't have any cables for the IO breakouts on this development board so I can't setup a UART at this time. The LedChaser on the user leds works though.

I also don't have the programming cable set up because I haven't figured out how to flash the FPGA via OpenOCD with the Xilinx Platform Cable USB-II (it only supports JTAG programming until a qspi litex module is available)