### PR TITLE
Add support for proFPGA XCVU19P board

### DIFF
--- a/litex_boards/platforms/profpga_xcvu19p.py
+++ b/litex_boards/platforms/profpga_xcvu19p.py
@@ -1,0 +1,74 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2020 David Shah <dave@ds0.me>
+# Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2020 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import Pins, Subsignal, IOStandard, Misc
+from litex.build.xilinx import XilinxPlatform, VivadoProgrammer
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # CLK1
+    ("clk300", 0,
+        Subsignal("n", Pins("CA40"), IOStandard("LVDS")),
+        Subsignal("p", Pins("CA39"), IOStandard("LVDS")),
+    ),
+    # Serial
+    ("serial", 0,
+        Subsignal("rx", Pins("BE29"), IOStandard("LVCMOS18")),
+        Subsignal("tx", Pins("BE30"), IOStandard("LVCMOS18")),
+    ),
+    # EB-PDS-PCIe-Cable-R3 on TA1
+    ("pcie_x4", 0,
+        Subsignal("rst_n", Pins("E40"), IOStandard("LVCMOS12")),
+        Subsignal("clk_n", Pins("AU10")),
+        Subsignal("clk_p", Pins("AU11")),
+        Subsignal("rx_n",  Pins("AJ1 AK3 AL1 AM3")),
+        Subsignal("rx_p",  Pins("AJ2 AK4 AL2 AM4")),
+        Subsignal("tx_n",  Pins("AL6 AM8 AN6 AP8")),
+        Subsignal("tx_p",  Pins("AL7 AM9 AN7 AP9")),
+    ),
+    ("pcie_x8", 0,
+        Subsignal("rst_n", Pins("E40"), IOStandard("LVCMOS12")),
+        Subsignal("clk_n", Pins("AU10")),
+        Subsignal("clk_p", Pins("AU11")),
+        Subsignal("rx_n",  Pins("AJ1 AK3 AL1 AM3 AN1 AP3 AR1 AT3")),
+        Subsignal("rx_p",  Pins("AJ2 AK4 AL2 AM4 AN2 AP4 AR2 AT4")),
+        Subsignal("tx_n",  Pins("AL6 AM8 AN6 AP8 AR6 AT8 AU6 AV8")),
+        Subsignal("tx_p",  Pins("AL7 AM9 AN7 AP9 AR7 AT9 AU7 AV9")),
+    ),
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = []
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(XilinxPlatform):
+    default_clk_name   = "clk300"
+    default_clk_period = 1e9/300e6
+
+    def __init__(self):
+        XilinxPlatform.__init__(self, "xcvu19p-fsva3824-2-e", _io, _connectors, toolchain="vivado")
+
+    def create_programmer(self):
+        return VivadoProgrammer()
+
+    def do_finalize(self, fragment):
+        XilinxPlatform.do_finalize(self, fragment)
+        # For passively cooled boards, overheating is a significant risk if airflow isn't sufficient
+        self.add_platform_command("set_property BITSTREAM.CONFIG.OVERTEMPSHUTDOWN ENABLE [current_design]")
+        # Reduce programming time
+        self.add_platform_command("set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]")
+
+        # TA1 pins Internal Vref
+        self.add_platform_command("set_property INTERNAL_VREF 0.90 [get_iobanks 69]")
+        self.add_platform_command("set_property INTERNAL_VREF 0.90 [get_iobanks 70]")
+        self.add_platform_command("set_property INTERNAL_VREF 0.90 [get_iobanks 71]")
+
+        self.add_period_constraint(self.lookup_request("clk300", 0, loose=True), 1e9/300e6)

--- a/litex_boards/targets/profpga_xcvu19p.py
+++ b/litex_boards/targets/profpga_xcvu19p.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2020 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import argparse
+
+from migen import *
+
+from litex_boards.platforms import profpga_xcvu19p
+
+from litex.soc.cores.clock import *
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+
+from litepcie.phy.usppciephy import USP19PPCIEPHY
+from litepcie.core import LitePCIeEndpoint, LitePCIeMSI
+from litepcie.frontend.dma import LitePCIeDMA
+from litepcie.frontend.wishbone import LitePCIeWishboneBridge
+from litepcie.software import generate_litepcie_software
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.clock_domains.cd_sys    = ClockDomain()
+
+        # # #
+
+        self.submodules.pll = pll = USPPLL(speedgrade=-2)
+        pll.register_clkin(platform.request("clk300"), 300e6)
+        pll.create_clkout(self.cd_sys, sys_clk_freq)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=int(125e6), with_pcie=False, **kwargs):
+        platform = profpga_xcvu19p.Platform()
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            ident          = "LiteX SoC on proFPGA XCVU19P",
+            ident_version  = True,
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+
+        # PCIe -------------------------------------------------------------------------------------
+        if with_pcie:
+            # PHY
+            self.submodules.pcie_phy = USP19PPCIEPHY(platform, platform.request("pcie_x4"),
+                speed      = "gen3",
+                data_width = 128,
+                bar0_size  = 0x20000)
+            platform.add_false_path_constraints(self.crg.cd_sys.clk, self.pcie_phy.cd_pcie.clk)
+            self.add_csr("pcie_phy")
+
+            # Endpoint
+            self.submodules.pcie_endpoint = LitePCIeEndpoint(self.pcie_phy, max_pending_requests=8)
+
+            # Wishbone bridge
+            self.submodules.pcie_bridge = LitePCIeWishboneBridge(self.pcie_endpoint,
+                base_address = self.mem_map["csr"])
+            self.add_wb_master(self.pcie_bridge.wishbone)
+
+            # DMA0
+            self.submodules.pcie_dma0 = LitePCIeDMA(self.pcie_phy, self.pcie_endpoint,
+                with_buffering = True, buffering_depth=1024,
+                with_loopback  = True)
+            self.add_csr("pcie_dma0")
+
+            self.add_constant("DMA_CHANNELS", 1)
+
+            # MSI
+            self.submodules.pcie_msi = LitePCIeMSI()
+            self.add_csr("pcie_msi")
+            self.comb += self.pcie_msi.source.connect(self.pcie_phy.msi)
+            self.interrupts = {
+                "PCIE_DMA0_WRITER":    self.pcie_dma0.writer.irq,
+                "PCIE_DMA0_READER":    self.pcie_dma0.reader.irq,
+            }
+            for i, (k, v) in enumerate(sorted(self.interrupts.items())):
+                self.comb += self.pcie_msi.irqs[i].eq(v)
+                self.add_constant(k + "_INTERRUPT", i)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on proFPGA XCVU19P")
+    parser.add_argument("--build",         action="store_true", help="Build bitstream")
+    parser.add_argument("--with-pcie",     action="store_true", help="Enable PCIe support")
+    parser.add_argument("--driver",        action="store_true", help="Generate PCIe driver")
+    parser.add_argument("--load",          action="store_true", help="Load bitstream")
+    builder_args(parser)
+    soc_core_args(parser)
+    args = parser.parse_args()
+
+    # Enforce arguments
+    args.csr_data_width = 32
+
+    soc =  BaseSoC(
+        with_pcie     = args.with_pcie,
+        **soc_core_argdict(args))
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build(run=args.build)
+
+    if args.driver:
+        generate_litepcie_software(soc, os.path.join(builder.output_dir, "driver"))
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".bit"))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR aims to add support for proFPGA XCVU19P board (https://www.profpga.com/profpga-xcvu19p).
Before merging serial port configuration needs to be adjusted since current pins are connected to onboard LEDs (and it looks like this board has no onboard USB-UART converter).
@enjoy-digital what would be the best way to handle UART in this case?
Is is possible to disable it entirely or maybe configure it to be accessible via PCIe-Wishbone bridge?

Also this platform represents only one configuration of this board (FPGA board with PCIe adapter attached to port TA1) but in theory many more modules can be attached to different expansion ports so I'm wondering if there is a better way to represent such configurations in Litex?