### PR TITLE
targets/orangecrab: Fix --sdram-device help text

### DIFF
--- a/litex_boards/targets/orangecrab.py
+++ b/litex_boards/targets/orangecrab.py
@@ -215,7 +215,7 @@ def main():
     parser.add_argument("--sys-clk-freq",    default=48e6,         help="System clock frequency (default: 48MHz)")
     parser.add_argument("--revision",        default="0.2",        help="Board Revision: 0.1 or 0.2 (default)")
     parser.add_argument("--device",          default="25F",        help="ECP5 device (default: 25F)")
-    parser.add_argument("--sdram-device",    default="MT41K64M16", help="ECP5 device (default: MT41K64M16)")
+    parser.add_argument("--sdram-device",    default="MT41K64M16", help="SDRAM device (default: MT41K64M16)")
     parser.add_argument("--with-spi-sdcard", action="store_true",  help="Enable SPI-mode SDCard support")
     builder_args(parser)
     soc_sdram_args(parser)


### PR DESCRIPTION
Obviously --sdram-device takes the SDRAM device, not the ECP5 FPGA
device.

Fixes: bf3c9dc9bf97e3aa ("orangecrab: Add sdram selection option")
Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>