### PR TITLE
zybo_z7: fix clock pin constraint

### DIFF
--- a/litex_boards/platforms/zybo_z7.py
+++ b/litex_boards/platforms/zybo_z7.py
@@ -11,7 +11,7 @@ from litex.build.xilinx import XilinxPlatform, VivadoProgrammer
 
 _io = [
     # Clk / Rst
-    ("clk125", 0, Pins("L16"), IOStandard("LVCMOS33")),
+    ("clk125", 0, Pins("K17"), IOStandard("LVCMOS33")),
 
     # Leds
     ("user_led", 0, Pins("M14"), IOStandard("LVCMOS33")),


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR fixes an issue with the pin mapping of the Zybo Z7 board.

In fact, the external clock pin is tied to an incorrect pin, which was valid fro the Zybo board, but not for the Z7 version.