### PR TITLE
nexys4ddr: add support for litexvideo VGA Terminal

### DIFF
--- a/litex_boards/platforms/nexys4ddr.py
+++ b/litex_boards/platforms/nexys4ddr.py
@@ -129,6 +129,16 @@ _io = [
         Subsignal("int_n",   Pins("D8")),
         IOStandard("LVCMOS33")
      ),
+
+    # VGA
+     ("vga", 0,
+        Subsignal("red", Pins("A4 C5 B4 A3")),
+        Subsignal("green", Pins("A6 B6 A5 C6")),
+        Subsignal("blue", Pins("D7 C7 B7")), # D8 is shared with eth int_n
+        Subsignal("hsync", Pins("B11")),
+        Subsignal("vsync",  Pins("B12")),
+        IOStandard("LVCMOS33")
+    ),
 ]
 
 # Platform -----------------------------------------------------------------------------------------


### PR DESCRIPTION
This commit adds VGA support for the Nexys A7/ Nexys 4 DDR.

The VGA is however limited to RGB443 instead of the full 12bit RGB444.
This is because IO D8 which is MSB for Blue, is also used for ETH int_n.
This makes the final output have a yellow tint.