### PR TITLE
acorn_cle_215: Fix hard-lockup on PCIe bringup.

### DIFF
--- a/litex_boards/targets/acorn_cle_215.py
+++ b/litex_boards/targets/acorn_cle_215.py
@@ -105,7 +105,7 @@ class BaseSoC(SoCCore):
         # PCIe -------------------------------------------------------------------------------------
         if with_pcie:
             self.submodules.pcie_phy = S7PCIEPHY(platform, platform.request("pcie_x4"),
-                data_width = 128,
+                data_width = 128, pcie_data_width=64,
                 bar0_size  = 0x20000)
             self.add_csr("pcie_phy")
             self.add_pcie(phy=self.pcie_phy, ndmas=1)


### PR DESCRIPTION
When building the SQRL CLE 215/nitefury target, the host crashes after programming.

Repro steps: 
1) clone current litex
2) python upstream/litex-boards/litex_boards/targets/acorn_cle_215.py --uart-name=crossover --with-pcie --build --driver
3) flash with vivado hw manager (I'm using the platform cable, so I flash with the vendor tools)
4) execute `lspci`, or otherwise rescan the bus
5) system locks up: display freeze, ssh sessions die, does not respond to ping or power button, etc. 

No logs in dmesg make it to disk, and I havn't got a UART cable to see if there's any kernel logging that gets displayed. I've reproduced on a Intel (Intel Xeon CPU E3-1240) and AMD (AM1) platform, both Ubuntu 20.04.

I believe this is due to the PCIe bus width being set to 128b. Running git bisect narrows down the issue to a commit in litepcie - with eveything else up to date with HEAD:

```
# first bad commit: [899a0e9d68ddb58d7b231f25332216692c8dd601] phy/s7pciephy/uspciephy: set default pcie_data_width to None and set it to data_width if None.
```

manually specifing the old default bus width (64b) allows the device to be enumerated correctly and the driver info & DMA tests work fine. Is this a reasonable fix & if so, 1) why does 128b break and should this be replicated for other PCIe targets?