### PR TITLE
platforms/ecp5: Fix slewrate configuration

### DIFF
--- a/litex_boards/platforms/logicbone.py
+++ b/litex_boards/platforms/logicbone.py
@@ -92,7 +92,7 @@ _io_rev0 = [
         Subsignal("mosi", Pins("D15"), Misc("PULLMODE=UP")),
         Subsignal("cs_n", Pins("E14"), Misc("PULLMODE=UP")),
         Subsignal("miso", Pins("D13"), Misc("PULLMODE=UP")),
-        Misc("SLEW=FAST"),
+        Misc("SLEWRATE=FAST"),
         IOStandard("LVCMOS33"),
     ),
     ("sdcard", 0,
@@ -100,7 +100,7 @@ _io_rev0 = [
         Subsignal("cmd",  Pins("D15"), Misc("PULLMODE=UP")),
         Subsignal("data", Pins("D13 E13 E15 E14"), Misc("PULLMODE=UP")),
         Subsignal("cd",   Pins("D14"), Misc("PULLMODE=UP")),
-        IOStandard("LVCMOS33"), Misc("SLEW=FAST")
+        IOStandard("LVCMOS33"), Misc("SLEWRATE=FAST")
     ),
 
     # I2C

--- a/litex_boards/platforms/orangecrab.py
+++ b/litex_boards/platforms/orangecrab.py
@@ -83,7 +83,7 @@ _io_r0_1 = [
         Subsignal("mosi", Pins("K2"), Misc("PULLMODE=UP")),
         Subsignal("cs_n", Pins("M1"), Misc("PULLMODE=UP")),
         Subsignal("miso", Pins("J1"), Misc("PULLMODE=UP")),
-        Misc("SLEW=FAST"),
+        Misc("SLEWRATE=FAST"),
         IOStandard("LVCMOS33"),
     ),
 ]
@@ -164,7 +164,7 @@ _io_r0_2 = [
         Subsignal("mosi", Pins("K2"), Misc("PULLMODE=UP")),
         Subsignal("cs_n", Pins("M1"), Misc("PULLMODE=UP")),
         Subsignal("miso", Pins("J1"), Misc("PULLMODE=UP")),
-        Misc("SLEW=FAST"),
+        Misc("SLEWRATE=FAST"),
         IOStandard("LVCMOS33"),
     ),
 
@@ -172,7 +172,7 @@ _io_r0_2 = [
         Subsignal("clk",  Pins("K1")),
         Subsignal("cmd",  Pins("K2"), Misc("PULLMODE=UP")),
         Subsignal("data", Pins("J1 K3 L3 M1"), Misc("PULLMODE=UP")),
-        IOStandard("LVCMOS33"), Misc("SLEW=FAST")
+        IOStandard("LVCMOS33"), Misc("SLEWRATE=FAST")
     ),
 ]
 


### PR DESCRIPTION
When building linux-on-litex-vexriscv for OrangeCrab:

    Warning: IOBUF 'spisdcard_clk' attribute 'SLEW' is not recognised (on line 207)
    Warning: IOBUF 'spisdcard_mosi' attribute 'SLEW' is not recognised (on line 210)
    Warning: IOBUF 'spisdcard_cs_n' attribute 'SLEW' is not recognised (on line 214)
    Warning: IOBUF 'spisdcard_miso' attribute 'SLEW' is not recognised (on line 218)

Platforms using litex.build.lattice.LatticePlatform seem to support only
"SLEWRATE", not "SLEW".  Fix the few offenders in the LogicBone and
OrangeCrab platform definitions.

Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>