### PR TITLE
genesys2: LiteSDCard support

### DIFF
--- a/litex_boards/platforms/genesys2.py
+++ b/litex_boards/platforms/genesys2.py
@@ -68,17 +68,20 @@ _io = [
 
     # SDCard
     ("spisdcard", 0,
+        Subsignal("rst",  Pins("AE24")),
         Subsignal("clk",  Pins("R28")),
-        Subsignal("cs_n", Pins("T30")),
-        Subsignal("mosi", Pins("R29"), Misc("PULLUP")),
-        Subsignal("miso", Pins("R26"), Misc("PULLUP")),
+        Subsignal("cs_n", Pins("T30"), Misc("PULLUP True")),
+        Subsignal("mosi", Pins("R29"), Misc("PULLUP True")),
+        Subsignal("miso", Pins("R26"), Misc("PULLUP True")),
         Misc("SLEW=FAST"),
         IOStandard("LVCMOS33")
     ),
     ("sdcard", 0,
-        Subsignal("clk", Pins("R28")),
-        Subsignal("cmd", Pins("R29"), Misc("PULLUP True")),
+        Subsignal("rst",  Pins("AE24"),            Misc("PULLUP True")),
         Subsignal("data", Pins("R26 R30 P29 T30"), Misc("PULLUP True")),
+        Subsignal("cmd",  Pins("R29"),             Misc("PULLUP True")),
+        Subsignal("clk",  Pins("R28")),
+        Subsignal("cd",   Pins("P28")),
         Misc("SLEW=FAST"),
         IOStandard("LVCMOS33")
     ),

--- a/litex_boards/targets/genesys2.py
+++ b/litex_boards/targets/genesys2.py
@@ -102,6 +102,8 @@ def main():
     parser.add_argument("--sys-clk-freq",   default=100e6,       help="System clock frequency (default: 100MHz)")
     parser.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
     parser.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
+    parser.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
+    parser.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
     builder_args(parser)
     soc_sdram_args(parser)
     args = parser.parse_args()
@@ -113,6 +115,11 @@ def main():
         with_etherbone = args.with_etherbone,
         **soc_sdram_argdict(args)
     )
+    assert not (args.with_spi_sdcard and args.with_sdcard)
+    if args.with_spi_sdcard:
+        soc.add_spi_sdcard()
+    if args.with_sdcard:
+        soc.add_sdcard()
     builder = Builder(soc, **builder_argdict(args))
     builder.build(run=args.build)
 


### PR DESCRIPTION
Platform patch based on [this entry from the genesys2 board manual](https://reference.digilentinc.com/reference/programmable-logic/genesys-2/reference-manual#microsd_slot). Additionally, some minor cleanup modelled after the equivalent entries in the `nexys4ddr` platform file.

***EDIT***: added commit to support `--with-[spi-]sdcard` on the target build command line