### PR TITLE
add etherbone ip address option for all boards with etherbone

### DIFF
--- a/litex_boards/targets/arty.py
+++ b/litex_boards/targets/arty.py
@@ -56,7 +56,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, variant="a7-35", toolchain="vivado", sys_clk_freq=int(100e6), with_ethernet=False, with_etherbone=False, ident_version=True, **kwargs):
+    def __init__(self, variant="a7-35", toolchain="vivado", sys_clk_freq=int(100e6), with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", ident_version=True, **kwargs):
         platform = arty.Platform(variant=variant, toolchain=toolchain)
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -94,7 +94,7 @@ class BaseSoC(SoCCore):
             if with_ethernet:
                 self.add_ethernet(phy=self.ethphy)
             if with_etherbone:
-                self.add_etherbone(phy=self.ethphy)
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
 
         # Leds -------------------------------------------------------------------------------------
         self.submodules.leds = LedChaser(
@@ -106,16 +106,17 @@ class BaseSoC(SoCCore):
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on Arty A7")
-    parser.add_argument("--toolchain",        default="vivado",     help="Toolchain use to build (default: vivado)")
-    parser.add_argument("--build",            action="store_true",  help="Build bitstream")
-    parser.add_argument("--load",             action="store_true",  help="Load bitstream")
-    parser.add_argument("--variant",          default="a7-35",      help="Board variant: a7-35 (default) or a7-100")
-    parser.add_argument("--sys-clk-freq",     default=100e6,        help="System clock frequency (default: 100MHz)")
-    parser.add_argument("--with-ethernet",    action="store_true",  help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone",   action="store_true",  help="Enable Etherbone support")
-    parser.add_argument("--with-spi-sdcard",  action="store_true",  help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",      action="store_true",  help="Enable SDCard support")
-    parser.add_argument("--no-ident-version", action="store_false", help="Disable build time output")
+    parser.add_argument("--toolchain",        default="vivado",                 help="Toolchain use to build (default: vivado)")
+    parser.add_argument("--build",            action="store_true",              help="Build bitstream")
+    parser.add_argument("--load",             action="store_true",              help="Load bitstream")
+    parser.add_argument("--variant",          default="a7-35",                  help="Board variant: a7-35 (default) or a7-100")
+    parser.add_argument("--sys-clk-freq",     default=100e6,                    help="System clock frequency (default: 100MHz)")
+    parser.add_argument("--with-ethernet",    action="store_true",              help="Enable Ethernet support")
+    parser.add_argument("--with-etherbone",   action="store_true",              help="Enable Etherbone support")
+    parser.add_argument("--eth-ip",           default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
+    parser.add_argument("--with-spi-sdcard",  action="store_true",              help="Enable SPI-mode SDCard support")
+    parser.add_argument("--with-sdcard",      action="store_true",              help="Enable SDCard support")
+    parser.add_argument("--no-ident-version", action="store_false",             help="Disable build time output")
     builder_args(parser)
     soc_sdram_args(parser)
     vivado_build_args(parser)
@@ -128,6 +129,7 @@ def main():
         sys_clk_freq   = int(float(args.sys_clk_freq)),
         with_ethernet  = args.with_ethernet,
         with_etherbone = args.with_etherbone,
+        eth_ip         = args.eth_ip,
         ident_version  = args.no_ident_version,
         **soc_sdram_argdict(args)
     )

--- a/litex_boards/targets/genesys2.py
+++ b/litex_boards/targets/genesys2.py
@@ -103,8 +103,6 @@ def main():
     parser.add_argument("--sys-clk-freq",   default=100e6,       help="System clock frequency (default: 100MHz)")
     parser.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
     parser.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
-    parser.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
     builder_args(parser)
     soc_sdram_args(parser)
     args = parser.parse_args()
@@ -116,11 +114,6 @@ def main():
         with_etherbone = args.with_etherbone,
         **soc_sdram_argdict(args)
     )
-    assert not (args.with_spi_sdcard and args.with_sdcard)
-    if args.with_spi_sdcard:
-        soc.add_spi_sdcard()
-    if args.with_sdcard:
-        soc.add_sdcard()
     builder = Builder(soc, **builder_argdict(args))
     builder.build(run=args.build)
 

--- a/litex_boards/targets/kcu105.py
+++ b/litex_boards/targets/kcu105.py
@@ -63,7 +63,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(125e6), with_ethernet=False, with_etherbone=False, with_pcie=False, with_sata=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", with_pcie=False, with_sata=False, **kwargs):
         platform = kcu105.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -103,7 +103,7 @@ class BaseSoC(SoCCore):
             if with_ethernet:
                 self.add_ethernet(phy=self.ethphy)
             if with_etherbone:
-                self.add_etherbone(phy=self.ethphy)
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
 
         # PCIe -------------------------------------------------------------------------------------
         if with_pcie:
@@ -158,14 +158,15 @@ class BaseSoC(SoCCore):
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on KCU105")
-    parser.add_argument("--build",          action="store_true", help="Build bitstream")
-    parser.add_argument("--load",           action="store_true", help="Load bitstream")
-    parser.add_argument("--sys-clk-freq",   default=125e6,       help="System clock frequency (default: 125MHz)")
-    parser.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
-    parser.add_argument("--with-pcie",      action="store_true", help="Enable PCIe support")
-    parser.add_argument("--driver",         action="store_true", help="Generate PCIe driver")
-    parser.add_argument("--with-sata",      action="store_true", help="Enable SATA support (over SFP2SATA)")
+    parser.add_argument("--build",          action="store_true",              help="Build bitstream")
+    parser.add_argument("--load",           action="store_true",              help="Load bitstream")
+    parser.add_argument("--sys-clk-freq",   default=125e6,                    help="System clock frequency (default: 125MHz)")
+    parser.add_argument("--with-ethernet",  action="store_true",              help="Enable Ethernet support")
+    parser.add_argument("--with-etherbone", action="store_true",              help="Enable Etherbone support")
+    parser.add_argument("--eth-ip",         default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
+    parser.add_argument("--with-pcie",      action="store_true",              help="Enable PCIe support")
+    parser.add_argument("--driver",         action="store_true",              help="Generate PCIe driver")
+    parser.add_argument("--with-sata",      action="store_true",              help="Enable SATA support (over SFP2SATA)")
     builder_args(parser)
     soc_sdram_args(parser)
     args = parser.parse_args()
@@ -175,6 +176,7 @@ def main():
         sys_clk_freq   = int(float(args.sys_clk_freq)),
         with_ethernet  = args.with_ethernet,
         with_etherbone = args.with_etherbone,
+        eth_ip         = args.eth_ip,
         with_pcie      = args.with_pcie,
         with_sata      = args.with_sata,
         **soc_sdram_argdict(args)

--- a/litex_boards/targets/pano_logic_g2.py
+++ b/litex_boards/targets/pano_logic_g2.py
@@ -44,7 +44,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, revision, sys_clk_freq=int(50e6), with_ethernet=False, with_etherbone=False, **kwargs):
+    def __init__(self, revision, sys_clk_freq=int(50e6), with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", **kwargs):
         platform = pano_logic_g2.Platform(revision=revision)
         if with_etherbone:
             sys_clk_freq = int(125e6)
@@ -69,7 +69,7 @@ class BaseSoC(SoCCore):
             if with_ethernet:
                 self.add_ethernet(phy=self.ethphy)
             if with_etherbone:
-                self.add_etherbone(phy=self.ethphy)
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
 
         # Leds -------------------------------------------------------------------------------------
         self.submodules.leds = LedChaser(
@@ -81,12 +81,13 @@ class BaseSoC(SoCCore):
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on Pano Logic G2")
-    parser.add_argument("--build",          action="store_true", help="Build bitstream")
-    parser.add_argument("--load",           action="store_true", help="Load bitstream")
-    parser.add_argument("--revision",       default="c",         help="Board revision c (default) or b")
-    parser.add_argument("--sys-clk-freq",   default=50e6,        help="System clock frequency (default: 50MHz)")
-    parser.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
+    parser.add_argument("--build",          action="store_true",              help="Build bitstream")
+    parser.add_argument("--load",           action="store_true",              help="Load bitstream")
+    parser.add_argument("--revision",       default="c",                      help="Board revision c (default) or b")
+    parser.add_argument("--sys-clk-freq",   default=50e6,                     help="System clock frequency (default: 50MHz)")
+    parser.add_argument("--with-ethernet",  action="store_true",              help="Enable Ethernet support")
+    parser.add_argument("--with-etherbone", action="store_true",              help="Enable Etherbone support")
+    parser.add_argument("--eth-ip",         default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
     builder_args(parser)
     soc_core_args(parser)
     args = parser.parse_args()
@@ -97,6 +98,7 @@ def main():
         sys_clk_freq   = int(float(args.sys_clk_freq)),
         with_ethernet  = args.with_ethernet,
         with_etherbone = args.with_etherbone,
+        eth_ip         = args.eth_ip,
         **soc_core_argdict(args)
     )
     builder = Builder(soc, **builder_argdict(args))

--- a/litex_boards/targets/qmtech_wukong.py
+++ b/litex_boards/targets/qmtech_wukong.py
@@ -54,7 +54,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), with_ethernet=False, with_etherbone=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", **kwargs):
         platform = qmtech_wukong.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -92,7 +92,7 @@ class BaseSoC(SoCCore):
             if with_ethernet:
                 self.add_ethernet(phy=self.ethphy)
             if with_etherbone:
-                self.add_etherbone(phy=self.ethphy)
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
 
         # Leds -------------------------------------------------------------------------------------
         self.submodules.leds = LedChaser(
@@ -104,13 +104,14 @@ class BaseSoC(SoCCore):
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on QMTECH Wukong Board")
-    parser.add_argument("--build",           action="store_true", help="Build bitstream")
-    parser.add_argument("--load",            action="store_true", help="Load bitstream")
-    parser.add_argument("--sys-clk-freq",    default=100e6,       help="System clock frequency (default: 100MHz)")
-    parser.add_argument("--with-ethernet",   action="store_true", help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone",  action="store_true", help="Enable Etherbone support")
-    parser.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
+    parser.add_argument("--build",           action="store_true",              help="Build bitstream")
+    parser.add_argument("--load",            action="store_true",              help="Load bitstream")
+    parser.add_argument("--sys-clk-freq",    default=100e6,                    help="System clock frequency (default: 100MHz)")
+    parser.add_argument("--with-ethernet",   action="store_true",              help="Enable Ethernet support")
+    parser.add_argument("--with-etherbone",  action="store_true",              help="Enable Etherbone support")
+    parser.add_argument("--eth-ip",          default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
+    parser.add_argument("--with-spi-sdcard", action="store_true",              help="Enable SPI-mode SDCard support")
+    parser.add_argument("--with-sdcard",     action="store_true",              help="Enable SDCard support")
     builder_args(parser)
     soc_sdram_args(parser)
     vivado_build_args(parser)
@@ -121,6 +122,7 @@ def main():
         sys_clk_freq   = int(float(args.sys_clk_freq)),
         with_ethernet  = args.with_ethernet,
         with_etherbone = args.with_etherbone,
+        eth_ip         = args.eth_ip,
         **soc_sdram_argdict(args)
     )
     assert not (args.with_spi_sdcard and args.with_sdcard)

--- a/litex_boards/targets/sds1104xe.py
+++ b/litex_boards/targets/sds1104xe.py
@@ -61,7 +61,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), with_etherbone=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), with_etherbone=False, eth_ip="192.168.1.50", **kwargs):
         platform = sds1104xe.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -96,16 +96,17 @@ class BaseSoC(SoCCore):
                 clock_pads = self.platform.request("eth_clocks"),
                 pads       = self.platform.request("eth"))
             self.add_csr("ethphy")
-            self.add_etherbone(phy=self.ethphy)
+            self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
 
 # Build --------------------------------------------------------------------------------------------
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on SDS1104X-E")
-    parser.add_argument("--build",          action="store_true", help="Build bitstream")
-    parser.add_argument("--load",           action="store_true", help="Load bitstream")
-    parser.add_argument("--sys-clk-freq",   default=100e6,       help="System clock frequency (default: 100MHz)")
-    parser.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
+    parser.add_argument("--build",          action="store_true",              help="Build bitstream")
+    parser.add_argument("--load",           action="store_true",              help="Load bitstream")
+    parser.add_argument("--sys-clk-freq",   default=100e6,                    help="System clock frequency (default: 100MHz)")
+    parser.add_argument("--with-etherbone", action="store_true",              help="Enable Etherbone support")
+    parser.add_argument("--eth-ip",         default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
     builder_args(parser)
     soc_sdram_args(parser)
     vivado_build_args(parser)
@@ -114,8 +115,10 @@ def main():
     soc = BaseSoC(
         sys_clk_freq   = int(float(args.sys_clk_freq)),
         with_etherbone = args.with_etherbone,
+        eth_ip         = args.eth_ip,
         **soc_sdram_argdict(args)
     )
+
     builder = Builder(soc, **builder_argdict(args))
     builder.build(**vivado_build_argdict(args), run=args.build)
 

--- a/litex_boards/targets/sds1104xe.py
+++ b/litex_boards/targets/sds1104xe.py
@@ -63,6 +63,8 @@ class _CRG(Module):
 class BaseSoC(SoCCore):
     def __init__(self, sys_clk_freq=int(100e6), with_etherbone=False, eth_ip="192.168.1.50", **kwargs):
         platform = sds1104xe.Platform()
+        # platform has no uart pins, so disable uart
+        kwargs['with_uart'] = False
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq,

--- a/litex_boards/targets/versa_ecp5.py
+++ b/litex_boards/targets/versa_ecp5.py
@@ -79,7 +79,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(75e6), device="LFE5UM5G", with_ethernet=False, with_etherbone=False, eth_phy=0, toolchain="trellis", **kwargs):
+    def __init__(self, sys_clk_freq=int(75e6), device="LFE5UM5G", with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", eth_phy=0, toolchain="trellis", **kwargs):
         platform = versa_ecp5.Platform(toolchain=toolchain, device=device)
 
         # FIXME: adapt integrated rom size for Microwatt
@@ -122,7 +122,7 @@ class BaseSoC(SoCCore):
             if with_ethernet:
                 self.add_ethernet(phy=self.ethphy)
             if with_etherbone:
-                self.add_etherbone(phy=self.ethphy)
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
 
         # Leds -------------------------------------------------------------------------------------
         self.submodules.leds = LedChaser(
@@ -134,14 +134,15 @@ class BaseSoC(SoCCore):
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on Versa ECP5")
-    parser.add_argument("--build",          action="store_true", help="Build bitstream")
-    parser.add_argument("--load",           action="store_true", help="Load bitstream")
-    parser.add_argument("--toolchain",      default="trellis",   help="FPGA toolchain: trellis (default) or diamond")
-    parser.add_argument("--sys-clk-freq",   default=75e6,        help="System clock frequency (default: 75MHz)")
-    parser.add_argument("--device",         default="LFE5UM5G",  help="FPGA device (LFE5UM5G (default) or LFE5UM)")
-    parser.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
-    parser.add_argument("--eth-phy",        default=0, type=int, help="Ethernet PHY: 0 (default) or 1")
+    parser.add_argument("--build",          action="store_true",              help="Build bitstream")
+    parser.add_argument("--load",           action="store_true",              help="Load bitstream")
+    parser.add_argument("--toolchain",      default="trellis",                help="FPGA toolchain: trellis (default) or diamond")
+    parser.add_argument("--sys-clk-freq",   default=75e6,                     help="System clock frequency (default: 75MHz)")
+    parser.add_argument("--device",         default="LFE5UM5G",               help="FPGA device (LFE5UM5G (default) or LFE5UM)")
+    parser.add_argument("--with-ethernet",  action="store_true",              help="Enable Ethernet support")
+    parser.add_argument("--with-etherbone", action="store_true",              help="Enable Etherbone support")
+    parser.add_argument("--eth-ip",         default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
+    parser.add_argument("--eth-phy",        default=0, type=int,              help="Ethernet PHY: 0 (default) or 1")
     builder_args(parser)
     soc_sdram_args(parser)
     trellis_args(parser)
@@ -153,6 +154,7 @@ def main():
         device         = args.device,
         with_ethernet  = args.with_ethernet,
         with_etherbone = args.with_etherbone,
+        eth_ip         = args.eth_ip,
         eth_phy        = args.eth_phy,
         toolchain      = args.toolchain,
         **soc_sdram_argdict(args)


### PR DESCRIPTION
Hi,
I added the eth-ip option to all boards with etherbone.
I also tested with a debugger that the option value arrives in LiteXSoC.
During those tests I noticed that on the sds1104xe board
I get an exception, because with_uart is active while the platform defines
no uart pins, so I disabled it in the commit below.
I am not perfectly happy with this solution, because when I tried to
add `with_uart` options to the constuctor calls of the SoC, I
got double keyword exceptions. So something I could not
find out in reasonable time automatically set this option.
