### PR TITLE
ULX3S: Make spiflash optionally accessible from the SoC, and bootable

### DIFF
--- a/litex_boards/platforms/ulx3s.py
+++ b/litex_boards/platforms/ulx3s.py
@@ -81,6 +81,21 @@ _io_common = [
         IOStandard("LVCMOS33")
     ),
 
+    # SPIFlash
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("R2")),
+        Subsignal("miso", Pins("V2")),
+        Subsignal("mosi", Pins("W2")),
+        Subsignal("wp", Pins("Y2")),
+        Subsignal("hold", Pins("W1")),
+        IOStandard("LVCMOS33")
+    ),
+    ("spiflash4x", 0,
+        Subsignal("cs_n", Pins("R2")),
+        Subsignal("dq", Pins("W2", "V2", "Y2", "W1")),
+        IOStandard("LVCMOS33")
+    ),
+
     # OLED
     ("oled_spi", 0,
         Subsignal("clk",  Pins("P4")),


### PR DESCRIPTION
A follow on from: https://github.com/litex-hub/litex-boards/issues/148. I wanted to be able to use the onboard flash of the ULX3S as a boot target. This PR adds a new `--with-spiflash` flag that will add the SPI master to the SoC, and lift it into the memory map.

The easiest way to define the `FLASH_BOOT_ADDRESS` [pre-processor definition](https://github.com/enjoy-digital/litex/blob/master/litex/soc/software/bios/boot.c#L468) in the bios was to just do an `soc.add_constant` call. I couldn't find any other board examples defining `FLASH_BOOT_ADDRESS`, so if there's a better way to do this (or a cleaner pattern), please let me know!

Because [this commit](https://github.com/enjoy-digital/litex/commit/41964f945cee71337e8e0998d597086b2ef94f77) removed SPI flashing functionality from the bios, I built and tested a combined bitstream by using a modified version of @gregdavill's [combine script from the OrangeCrab ](https://github.com/gregdavill/OrangeCrab-examples/blob/main/litex/combine.py) to build a combined ECP5 bitstream and firmware image (thanks Greg!), which I was able to verify on my board.

Thanks!