### PR TITLE
netv2: add device variant to allow 100T as well

### DIFF
--- a/litex_boards/platforms/netv2.py
+++ b/litex_boards/platforms/netv2.py
@@ -191,9 +191,12 @@ class Platform(XilinxPlatform):
     default_clk_name   = "clk50"
     default_clk_period = 1e9/50e6
 
-    def __init__(self, device="xc7a35t"):
-        assert device in ["xc7a35t", "xc7a100t"]
-        XilinxPlatform.__init__(self, device + "-fgg484-2", _io, toolchain="vivado")
+    def __init__(self, variant="a7-35"):
+        device = {
+            "a7-35":  "xc7a35t-fgg484-2",
+            "a7-100": "xc7a100t-fgg484-2"
+        }[variant]
+        XilinxPlatform.__init__(self, device, _io, toolchain="vivado")
 
     def create_programmer(self):
         bscan_spi = "bscan_spi_xc7a100t.bit" if "xc7a100t" in self.device else "bscan_spi_xc7a35t.bit"

--- a/litex_boards/targets/netv2.py
+++ b/litex_boards/targets/netv2.py
@@ -62,8 +62,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), with_pcie=False, with_ethernet=False, **kwargs):
-        platform = netv2.Platform()
+    def __init__(self, variant="a7-35", sys_clk_freq=int(100e6), with_pcie=False, with_ethernet=False, **kwargs):
+        platform = netv2.Platform(variant=variant)
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq,
@@ -119,6 +119,7 @@ def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on NeTV2")
     parser.add_argument("--build",           action="store_true", help="Build bitstream")
     parser.add_argument("--load",            action="store_true", help="Load bitstream")
+    parser.add_argument("--variant",         default="a7-35",     help="Board variant: a7-35 (default) or a7-100")
     parser.add_argument("--sys-clk-freq",    default=100e6,       help="System clock frequency (default: 100MHz)")
     parser.add_argument("--with-ethernet",   action="store_true", help="Enable Ethernet support")
     parser.add_argument("--with-pcie",       action="store_true", help="Enable PCIe support")
@@ -131,6 +132,7 @@ def main():
     args = parser.parse_args()
 
     soc = BaseSoC(
+        variant       = args.variant,
         sys_clk_freq  = int(float(args.sys_clk_freq)),
         with_ethernet = args.with_ethernet,
         with_pcie     = args.with_pcie,


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR enables to choose the FPGA device of the netv2 board when executing the netv2 target script (similarly to the arty board target).