### PR TITLE
ECPIX-5: ddram: Add missing address pin.

### DIFF
--- a/litex_boards/platforms/ecpix5.py
+++ b/litex_boards/platforms/ecpix5.py
@@ -51,7 +51,7 @@ _io = [
     ("ddram", 0,
         Subsignal("a", Pins(
             "T5 M3 L3 V6 K2 W6 K3 L1",
-            "H2 L2 N1 J1 M1 K1"),
+            "H2 L2 N1 J1 M1 K1 H1"),
             IOStandard("SSTL15_I")),
         Subsignal("ba",    Pins("U6 N3 N4"), IOStandard("SSTL15_I")),
         Subsignal("ras_n", Pins("T3"), IOStandard("SSTL15_I")),


### PR DESCRIPTION
Fixes #161