### PR TITLE
Be friendlier about incompatible options.

### DIFF
--- a/litex_boards/targets/acorn_cle_215.py
+++ b/litex_boards/targets/acorn_cle_215.py
@@ -160,15 +160,15 @@ def main():
     parser.add_argument("--load",            action="store_true", help="Load bitstream")
     parser.add_argument("--flash",           action="store_true", help="Flash bitstream")
     parser.add_argument("--sys-clk-freq",    default=100e6,       help="System clock frequency (default: 100MHz)")
-    parser.add_argument("--with-pcie",       action="store_true", help="Enable PCIe support")
+    pcieopts = parser.add_mutually_exclusive_group()
+    pcieopts.add_argument("--with-pcie",     action="store_true", help="Enable PCIe support")
     parser.add_argument("--driver",          action="store_true", help="Generate PCIe driver")
     parser.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support (requires SDCard adapter on P2)")
-    parser.add_argument("--with-sata",       action="store_true", help="Enable SATA support (over PCIe2SATA)")
+    pcieopts.add_argument("--with-sata",     action="store_true", help="Enable SATA support (over PCIe2SATA)")
     builder_args(parser)
     soc_sdram_args(parser)
     args = parser.parse_args()
 
-    assert not (args.with_pcie and args.with_sata)
     soc = BaseSoC(
         sys_clk_freq = int(float(args.sys_clk_freq)),
         with_pcie    = args.with_pcie,

--- a/litex_boards/targets/arty.py
+++ b/litex_boards/targets/arty.py
@@ -111,18 +111,19 @@ def main():
     parser.add_argument("--load",             action="store_true",              help="Load bitstream")
     parser.add_argument("--variant",          default="a7-35",                  help="Board variant: a7-35 (default) or a7-100")
     parser.add_argument("--sys-clk-freq",     default=100e6,                    help="System clock frequency (default: 100MHz)")
-    parser.add_argument("--with-ethernet",    action="store_true",              help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone",   action="store_true",              help="Enable Etherbone support")
+    ethopts = parser.add_mutually_exclusive_group()
+    ethopts.add_argument("--with-ethernet",   action="store_true",              help="Enable Ethernet support")
+    ethopts.add_argument("--with-etherbone",  action="store_true",              help="Enable Etherbone support")
     parser.add_argument("--eth-ip",           default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
-    parser.add_argument("--with-spi-sdcard",  action="store_true",              help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",      action="store_true",              help="Enable SDCard support")
+    sdopts = parser.add_mutually_exclusive_group()
+    sdopts.add_argument("--with-spi-sdcard",  action="store_true",              help="Enable SPI-mode SDCard support")
+    sdopts.add_argument("--with-sdcard",      action="store_true",              help="Enable SDCard support")
     parser.add_argument("--no-ident-version", action="store_false",             help="Disable build time output")
     builder_args(parser)
     soc_sdram_args(parser)
     vivado_build_args(parser)
     args = parser.parse_args()
 
-    assert not (args.with_ethernet and args.with_etherbone)
     soc = BaseSoC(
         variant        = args.variant,
         toolchain      = args.toolchain,
@@ -133,7 +134,6 @@ def main():
         ident_version  = args.no_ident_version,
         **soc_sdram_argdict(args)
     )
-    assert not (args.with_spi_sdcard and args.with_sdcard)
     soc.platform.add_extension(arty._sdcard_pmod_io)
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()

--- a/litex_boards/targets/colorlight_5a_75x.py
+++ b/litex_boards/targets/colorlight_5a_75x.py
@@ -189,8 +189,9 @@ def main():
     parser.add_argument("--board",             default="5a-75b",                 help="Board type: 5a-75b (default) or 5a-75e")
     parser.add_argument("--revision",          default="7.0", type=str,          help="Board revision: 7.0 (default), 6.0 or 6.1")
     parser.add_argument("--sys-clk-freq",      default=60e6,                     help="System clock frequency (default: 60MHz)")
-    parser.add_argument("--with-ethernet",     action="store_true",              help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone",    action="store_true",              help="Enable Etherbone support")
+    ethopts = parser.add_mutually_exclusive_group()
+    ethopts.add_argument("--with-ethernet",    action="store_true",              help="Enable Ethernet support")
+    ethopts.add_argument("--with-etherbone",   action="store_true",              help="Enable Etherbone support")
     parser.add_argument("--eth-ip",            default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
     parser.add_argument("--eth-phy",           default=0, type=int,              help="Ethernet PHY: 0 (default) or 1")
     parser.add_argument("--use-internal-osc",  action="store_true",              help="Use internal oscillator")
@@ -200,7 +201,6 @@ def main():
     trellis_args(parser)
     args = parser.parse_args()
 
-    assert not (args.with_ethernet and args.with_etherbone)
     soc = BaseSoC(board=args.board, revision=args.revision,
         sys_clk_freq     = int(float(args.sys_clk_freq)),
         with_ethernet    = args.with_ethernet,

--- a/litex_boards/targets/colorlight_i5.py
+++ b/litex_boards/targets/colorlight_i5.py
@@ -185,12 +185,14 @@ def main():
     parser.add_argument("--board",            default="i5",         help="Board type: i5 (default)")
     parser.add_argument("--revision",         default="7.0", type=str,  help="Board revision: 7.0 (default)")
     parser.add_argument("--sys-clk-freq",     default=60e6,             help="System clock frequency (default: 60MHz)")
-    parser.add_argument("--with-ethernet",    action="store_true",      help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone",   action="store_true",      help="Enable Etherbone support")
+    ethopts = parser.add_mutually_exclusive_group()
+    ethopts.add_argument("--with-ethernet",   action="store_true",      help="Enable Ethernet support")
+    ethopts.add_argument("--with-etherbone",  action="store_true",      help="Enable Etherbone support")
     parser.add_argument("--remote-ip",        default="192.168.1.100",  help="Remote IP address of TFTP server")
     parser.add_argument("--local-ip",         default="192.168.1.50",   help="Local IP address")
-    parser.add_argument("--with-spi-sdcard",  action="store_true",	help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",      action="store_true",	help="Enable SDCard support")
+    sdopts = parser.add_mutually_exclusive_group()
+    sdopts.add_argument("--with-spi-sdcard",  action="store_true",	help="Enable SPI-mode SDCard support")
+    sdopts.add_argument("--with-sdcard",      action="store_true",	help="Enable SDCard support")
     parser.add_argument("--eth-phy",          default=0, type=int,      help="Ethernet PHY: 0 (default) or 1")
     parser.add_argument("--use-internal-osc", action="store_true",      help="Use internal oscillator")
     parser.add_argument("--sdram-rate",       default="1:1",            help="SDRAM Rate: 1:1 Full Rate (default), 1:2 Half Rate")
@@ -201,7 +203,6 @@ def main():
     trellis_args(parser)
     args = parser.parse_args()
 
-    assert not (args.with_ethernet and args.with_etherbone)
     soc = BaseSoC(board=args.board, revision=args.revision,
         sys_clk_freq     = int(float(args.sys_clk_freq)),
         with_ethernet    = args.with_ethernet,
@@ -215,7 +216,6 @@ def main():
         with_prbs        = args.with_prbs,
         **soc_core_argdict(args)
     )
-    assert not (args.with_spi_sdcard and args.with_sdcard)
     soc.platform.add_extension(colorlight_i5._sdcard_pmod_io)
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()

--- a/litex_boards/targets/fpc_iii.py
+++ b/litex_boards/targets/fpc_iii.py
@@ -143,22 +143,22 @@ def main():
     parser.add_argument("--load",            action="store_true", help="Load bitstream")
     parser.add_argument("--toolchain",       default="trellis",   help="Gateware toolchain to use, trellis (default) or diamond")
     parser.add_argument("--sys-clk-freq",    default=80e6,        help="System clock frequency (default=80MHz)")
-    parser.add_argument("--with-ethernet",   action="store_true", help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone",  action="store_true", help="Enable Ethernet wishbone support")
-    parser.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
+    ethopts = parser.add_mutually_exclusive_group()
+    ethopts.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
+    ethopts.add_argument("--with-etherbone", action="store_true", help="Enable Ethernet wishbone support")
+    sdopts = parser.add_mutually_exclusive_group()
+    sdopts.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
+    sdopts.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
     builder_args(parser)
     soc_sdram_args(parser)
     trellis_args(parser)
     args = parser.parse_args()
 
-    assert not (args.with_ethernet and args.with_etherbone)
     soc = BaseSoC(
         sys_clk_freq = int(float(args.sys_clk_freq)),
         with_ethernet = args.with_ethernet,
         with_etherbone = args.with_etherbone,
         **soc_sdram_argdict(args))
-    assert not (args.with_spi_sdcard and args.with_sdcard)
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()
     if args.with_sdcard:

--- a/litex_boards/targets/genesys2.py
+++ b/litex_boards/targets/genesys2.py
@@ -98,25 +98,25 @@ class BaseSoC(SoCCore):
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on Genesys2")
-    parser.add_argument("--build",          action="store_true", help="Build bitstream")
-    parser.add_argument("--load",           action="store_true", help="Load bitstream")
-    parser.add_argument("--sys-clk-freq",   default=100e6,       help="System clock frequency (default: 100MHz)")
-    parser.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
-    parser.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
+    parser.add_argument("--build",           action="store_true", help="Build bitstream")
+    parser.add_argument("--load",            action="store_true", help="Load bitstream")
+    parser.add_argument("--sys-clk-freq",    default=100e6,       help="System clock frequency (default: 100MHz)")
+    ethopts = parser.add_mutually_exclusive_group()
+    ethopts.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
+    ethopts.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
+    sdopts = parser.add_mutually_exclusive_group()
+    sdopts.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
+    sdopts.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
     builder_args(parser)
     soc_sdram_args(parser)
     args = parser.parse_args()
 
-    assert not (args.with_ethernet and args.with_etherbone)
     soc = BaseSoC(
         sys_clk_freq   = int(float(args.sys_clk_freq)),
         with_ethernet  = args.with_ethernet,
         with_etherbone = args.with_etherbone,
         **soc_sdram_argdict(args)
     )
-    assert not (args.with_spi_sdcard and args.with_sdcard)
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()
     if args.with_sdcard:

--- a/litex_boards/targets/kcu105.py
+++ b/litex_boards/targets/kcu105.py
@@ -158,20 +158,20 @@ class BaseSoC(SoCCore):
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on KCU105")
-    parser.add_argument("--build",          action="store_true",              help="Build bitstream")
-    parser.add_argument("--load",           action="store_true",              help="Load bitstream")
-    parser.add_argument("--sys-clk-freq",   default=125e6,                    help="System clock frequency (default: 125MHz)")
-    parser.add_argument("--with-ethernet",  action="store_true",              help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone", action="store_true",              help="Enable Etherbone support")
-    parser.add_argument("--eth-ip",         default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
-    parser.add_argument("--with-pcie",      action="store_true",              help="Enable PCIe support")
-    parser.add_argument("--driver",         action="store_true",              help="Generate PCIe driver")
-    parser.add_argument("--with-sata",      action="store_true",              help="Enable SATA support (over SFP2SATA)")
+    parser.add_argument("--build",           action="store_true",              help="Build bitstream")
+    parser.add_argument("--load",            action="store_true",              help="Load bitstream")
+    parser.add_argument("--sys-clk-freq",    default=125e6,                    help="System clock frequency (default: 125MHz)")
+    ethopts = parser.add_mutually_exclusive_group()
+    ethopts.add_argument("--with-ethernet",  action="store_true",              help="Enable Ethernet support")
+    ethopts.add_argument("--with-etherbone", action="store_true",              help="Enable Etherbone support")
+    parser.add_argument("--eth-ip",          default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
+    parser.add_argument("--with-pcie",       action="store_true",              help="Enable PCIe support")
+    parser.add_argument("--driver",          action="store_true",              help="Generate PCIe driver")
+    parser.add_argument("--with-sata",       action="store_true",              help="Enable SATA support (over SFP2SATA)")
     builder_args(parser)
     soc_sdram_args(parser)
     args = parser.parse_args()
 
-    assert not (args.with_ethernet and args.with_etherbone)
     soc = BaseSoC(
         sys_clk_freq   = int(float(args.sys_clk_freq)),
         with_ethernet  = args.with_ethernet,

--- a/litex_boards/targets/netv2.py
+++ b/litex_boards/targets/netv2.py
@@ -124,8 +124,9 @@ def main():
     parser.add_argument("--with-ethernet",   action="store_true", help="Enable Ethernet support")
     parser.add_argument("--with-pcie",       action="store_true", help="Enable PCIe support")
     parser.add_argument("--driver",          action="store_true", help="Generate PCIe driver")
-    parser.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
+    sdopts = parser.add_mutually_exclusive_group()
+    sdopts.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
+    sdopts.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
 
     builder_args(parser)
     soc_sdram_args(parser)
@@ -138,7 +139,6 @@ def main():
         with_pcie     = args.with_pcie,
         **soc_sdram_argdict(args)
     )
-    assert not (args.with_spi_sdcard and args.with_sdcard)
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()
     if args.with_sdcard:

--- a/litex_boards/targets/nexys4ddr.py
+++ b/litex_boards/targets/nexys4ddr.py
@@ -122,23 +122,23 @@ def main():
     parser.add_argument("--build",           action="store_true", help="Build bitstream")
     parser.add_argument("--load",            action="store_true", help="Load bitstream")
     parser.add_argument("--sys-clk-freq",    default=75e6,        help="System clock frequency (default: 75MHz)")
-    parser.add_argument("--with-ethernet",   action="store_true", help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone",  action="store_true", help="Enable Etherbone support")
-    parser.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
+    ethopts = parser.add_mutually_exclusive_group()    
+    ethopts.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
+    ethopts.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
+    sdopts = parser.add_mutually_exclusive_group()    
+    sdopts.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
+    sdopts.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
     parser.add_argument("--with-vga",        action="store_true", help="Enable VGA support")
     builder_args(parser)
     soc_sdram_args(parser)
     args = parser.parse_args()
 
-    assert not (args.with_ethernet and args.with_etherbone)
     soc = BaseSoC(
         sys_clk_freq   = int(float(args.sys_clk_freq)),
         with_ethernet  = args.with_ethernet,
         with_etherbone = args.with_etherbone,
         **soc_sdram_argdict(args)
     )
-    assert not (args.with_spi_sdcard and args.with_sdcard)
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()
     if args.with_sdcard:

--- a/litex_boards/targets/nexys_video.py
+++ b/litex_boards/targets/nexys_video.py
@@ -133,8 +133,9 @@ def main():
     parser.add_argument("--load",            action="store_true", help="Load bitstream")
     parser.add_argument("--sys-clk-freq",    default=100e6,       help="System clock frequency (default: 100MHz)")
     parser.add_argument("--with-ethernet",   action="store_true", help="Enable Ethernet support")
-    parser.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
+    sdopts = parser.add_mutually_exclusive_group()    
+    sdopts.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
+    sdopts.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
     parser.add_argument("--with-sata",       action="store_true", help="Enable SATA support (over FMCRAID)")
     builder_args(parser)
     soc_sdram_args(parser)
@@ -146,7 +147,6 @@ def main():
         with_sata     = args.with_sata,
         **soc_sdram_argdict(args)
     )
-    assert not (args.with_spi_sdcard and args.with_sdcard)
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()
     if args.with_sdcard:

--- a/litex_boards/targets/pano_logic_g2.py
+++ b/litex_boards/targets/pano_logic_g2.py
@@ -81,18 +81,18 @@ class BaseSoC(SoCCore):
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on Pano Logic G2")
-    parser.add_argument("--build",          action="store_true",              help="Build bitstream")
-    parser.add_argument("--load",           action="store_true",              help="Load bitstream")
-    parser.add_argument("--revision",       default="c",                      help="Board revision c (default) or b")
-    parser.add_argument("--sys-clk-freq",   default=50e6,                     help="System clock frequency (default: 50MHz)")
-    parser.add_argument("--with-ethernet",  action="store_true",              help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone", action="store_true",              help="Enable Etherbone support")
-    parser.add_argument("--eth-ip",         default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
+    parser.add_argument("--build",           action="store_true",              help="Build bitstream")
+    parser.add_argument("--load",            action="store_true",              help="Load bitstream")
+    parser.add_argument("--revision",        default="c",                      help="Board revision c (default) or b")
+    parser.add_argument("--sys-clk-freq",    default=50e6,                     help="System clock frequency (default: 50MHz)")
+    ethopts = parser.add_mutually_exclusive_group()    
+    ethopts.add_argument("--with-ethernet",  action="store_true",              help="Enable Ethernet support")
+    ethopts.add_argument("--with-etherbone", action="store_true",              help="Enable Etherbone support")
+    parser.add_argument("--eth-ip",          default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
     builder_args(parser)
     soc_core_args(parser)
     args = parser.parse_args()
 
-    assert not (args.with_ethernet and args.with_etherbone)
     soc = BaseSoC(
         revision       = args.revision,
         sys_clk_freq   = int(float(args.sys_clk_freq)),

--- a/litex_boards/targets/qmtech_wukong.py
+++ b/litex_boards/targets/qmtech_wukong.py
@@ -107,17 +107,18 @@ def main():
     parser.add_argument("--build",           action="store_true",              help="Build bitstream")
     parser.add_argument("--load",            action="store_true",              help="Load bitstream")
     parser.add_argument("--sys-clk-freq",    default=100e6,                    help="System clock frequency (default: 100MHz)")
-    parser.add_argument("--with-ethernet",   action="store_true",              help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone",  action="store_true",              help="Enable Etherbone support")
+    ethopts = parser.add_mutually_exclusive_group()    
+    ethopts.add_argument("--with-ethernet",  action="store_true",              help="Enable Ethernet support")
+    ethopts.add_argument("--with-etherbone", action="store_true",              help="Enable Etherbone support")
     parser.add_argument("--eth-ip",          default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
-    parser.add_argument("--with-spi-sdcard", action="store_true",              help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",     action="store_true",              help="Enable SDCard support")
+    sdopts = parser.add_mutually_exclusive_group()    
+    sdopts.add_argument("--with-spi-sdcard", action="store_true",              help="Enable SPI-mode SDCard support")
+    sdopts.add_argument("--with-sdcard",     action="store_true",              help="Enable SDCard support")
     builder_args(parser)
     soc_sdram_args(parser)
     vivado_build_args(parser)
     args = parser.parse_args()
 
-    assert not (args.with_ethernet and args.with_etherbone)
     soc = BaseSoC(
         sys_clk_freq   = int(float(args.sys_clk_freq)),
         with_ethernet  = args.with_ethernet,
@@ -125,7 +126,6 @@ def main():
         eth_ip         = args.eth_ip,
         **soc_sdram_argdict(args)
     )
-    assert not (args.with_spi_sdcard and args.with_sdcard)
     soc.platform.add_extension(qmtech_wukong._sdcard_pmod_io)
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()

--- a/litex_boards/targets/trellisboard.py
+++ b/litex_boards/targets/trellisboard.py
@@ -166,8 +166,9 @@ def main():
     parser.add_argument("--toolchain",       default="trellis",   help="FPGA toolchain: trellis (default) or diamond")
     parser.add_argument("--sys-clk-freq",    default=75e6,        help="System clock frequency (default: 75MHz)")
     parser.add_argument("--with-ethernet",   action="store_true", help="Enable Ethernet support")
-    parser.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
+    sdopts = parser.add_mutually_exclusive_group()        
+    sdopts.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support")
+    sdopts.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support")
     builder_args(parser)
     soc_sdram_args(parser)
     trellis_args(parser)
@@ -178,7 +179,6 @@ def main():
         with_ethernet = args.with_ethernet,
         **soc_sdram_argdict(args)
     )
-    assert not (args.with_spi_sdcard and args.with_sdcard)
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()
     if args.with_sdcard:

--- a/litex_boards/targets/ulx3s.py
+++ b/litex_boards/targets/ulx3s.py
@@ -139,8 +139,9 @@ def main():
     parser.add_argument("--sdram-module",    default="MT48LC16M16", help="SDRAM module: MT48LC16M16 (default), AS4C32M16 or AS4C16M16")
     parser.add_argument("--with-spiflash",   action="store_true",   help="Make the SPI Flash accessible from the SoC")
     parser.add_argument("--flash-boot-adr",  type=lambda x: int(x,0), default=None, help="Flash boot address")
-    parser.add_argument("--with-spi-sdcard", action="store_true",   help="Enable SPI-mode SDCard support")
-    parser.add_argument("--with-sdcard",     action="store_true",   help="Enable SDCard support")
+    sdopts = parser.add_mutually_exclusive_group()    
+    sdopts.add_argument("--with-spi-sdcard", action="store_true",   help="Enable SPI-mode SDCard support")
+    sdopts.add_argument("--with-sdcard",     action="store_true",   help="Enable SDCard support")
     parser.add_argument("--with-oled",       action="store_true",   help="Enable SDD1331 OLED support")
     parser.add_argument("--sdram-rate",      default="1:1",         help="SDRAM Rate: 1:1 Full Rate (default), 1:2 Half Rate")
     builder_args(parser)
@@ -157,7 +158,6 @@ def main():
         sdram_rate       = args.sdram_rate,
         spiflash         = args.with_spiflash,
         **soc_sdram_argdict(args))
-    assert not (args.with_spi_sdcard and args.with_sdcard)
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()
     if args.with_sdcard:

--- a/litex_boards/targets/versa_ecp5.py
+++ b/litex_boards/targets/versa_ecp5.py
@@ -134,21 +134,21 @@ class BaseSoC(SoCCore):
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on Versa ECP5")
-    parser.add_argument("--build",          action="store_true",              help="Build bitstream")
-    parser.add_argument("--load",           action="store_true",              help="Load bitstream")
-    parser.add_argument("--toolchain",      default="trellis",                help="FPGA toolchain: trellis (default) or diamond")
-    parser.add_argument("--sys-clk-freq",   default=75e6,                     help="System clock frequency (default: 75MHz)")
-    parser.add_argument("--device",         default="LFE5UM5G",               help="FPGA device (LFE5UM5G (default) or LFE5UM)")
-    parser.add_argument("--with-ethernet",  action="store_true",              help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone", action="store_true",              help="Enable Etherbone support")
-    parser.add_argument("--eth-ip",         default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
-    parser.add_argument("--eth-phy",        default=0, type=int,              help="Ethernet PHY: 0 (default) or 1")
+    parser.add_argument("--build",           action="store_true",              help="Build bitstream")
+    parser.add_argument("--load",            action="store_true",              help="Load bitstream")
+    parser.add_argument("--toolchain",       default="trellis",                help="FPGA toolchain: trellis (default) or diamond")
+    parser.add_argument("--sys-clk-freq",    default=75e6,                     help="System clock frequency (default: 75MHz)")
+    parser.add_argument("--device",          default="LFE5UM5G",               help="FPGA device (LFE5UM5G (default) or LFE5UM)")
+    ethopts = parser.add_mutually_exclusive_group()    
+    ethopts.add_argument("--with-ethernet",  action="store_true",              help="Enable Ethernet support")
+    ethopts.add_argument("--with-etherbone", action="store_true",              help="Enable Etherbone support")
+    parser.add_argument("--eth-ip",          default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
+    parser.add_argument("--eth-phy",         default=0, type=int,              help="Ethernet PHY: 0 (default) or 1")
     builder_args(parser)
     soc_sdram_args(parser)
     trellis_args(parser)
     args = parser.parse_args()
 
-    assert not (args.with_ethernet and args.with_etherbone)
     soc = BaseSoC(
         sys_clk_freq   = int(float(args.sys_clk_freq)),
         device         = args.device,


### PR DESCRIPTION
Collect `--with-ethernet`/`--with-etherbone`, `--with-spi-sdcard`/`--with-sdcard`, etc. into `ArgumentParser.add_mutually_exclusive_group()`s.  That way, we get pretty `--help` output, and appropriate error messages if somebody tries to ask for something that doesn't make sense.