### PR TITLE
sockit: Fix cable name, default to jtag_atlantic

### DIFF
--- a/litex_boards/platforms/arrow_sockit.py
+++ b/litex_boards/platforms/arrow_sockit.py
@@ -164,7 +164,7 @@ class Platform(AlteraPlatform):
         AlteraPlatform.__init__(self, _device_map[revision], _io, connectors=_connectors_hsmc_gpio_daughterboard)
 
     def create_programmer(self):
-        return USBBlaster()
+        return USBBlaster(cable_name="CV SoCKit")
 
     def do_finalize(self, fragment):
         AlteraPlatform.do_finalize(self, fragment)

--- a/litex_boards/targets/arrow_sockit.py
+++ b/litex_boards/targets/arrow_sockit.py
@@ -4,6 +4,15 @@
 #
 # Copyright (c) 2020 Hans Baier <hansfbaier@gmail.com>
 # SPDX-License-Identifier: BSD-2-Clause
+"""
+    This class provides basic support for the Arrow SoCKit.
+    Since the SoCKit has its USB2UART attached to the HPS
+    system, it is not available to the FPGA and thus the only
+    way to communicate is via JTAG serial which is configured
+    by default.
+    To access it, you can use the nios2_terminal application
+    included in the Intel/Altera quartus distribution.
+"""
 
 import os
 import argparse
@@ -44,9 +53,9 @@ class BaseSoC(SoCCore):
     def __init__(self, sys_clk_freq=int(50e6), revision="revd", **kwargs):
         platform = arrow_sockit.Platform(revision)
 
-        # Defaults to Crossover UART because serial is attached to the HPS and cannot be used.
+        # Defaults to UART over JTAG because serial is attached to the HPS and cannot be used.
         if kwargs["uart_name"] == "serial":
-            kwargs["uart_name"] = "crossover"
+            kwargs["uart_name"] = "jtag_atlantic"
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq,


### PR DESCRIPTION
Hi Florent,
I got a request from a user desperate for a serial connection
and I found this solution (include fix to programmer cable name).
Does lxterm work over jtag_atlantic?
(This I have not found out yet).
If not, what would I need to do to make it work?
Best regards,
Hans