### PR TITLE
Alveo U280 board

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ PCIe accelerators boards that you could use to accelerate your applications, Lit
 | ForestKitten33 | Xilinx Ultrascale+  | XCVU33P       | 125MHz   | PCIe | 2 x 1024-bit 4GB HBM2*|  Gen3 X16     |     ?       |
 | BCU1525        | Xilinx Ultrascale+  | XCVU9P        | 125MHz   | PCIe | 4 x 64-bit DDR4 DIMM  |  Gen3 X16     |     ?       |
 | AlveoU250      | Xilinx Ultrascale+  | XCU250        | 125MHz   | PCIe | 4 x 64-bit DDR4 DIMM  |  Gen2 X16     |     ?       |
+| AlveoU280      | Xilinx Ultrascale+  | XCU280        | 125MHz   | PCIe* | 4 x 64-bit DDR4 DIMM*  |  Gen2 X16     |     ?       |
 
 \* Present on the board but not yet supported or validated with LiteX.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ PCIe accelerators boards that you could use to accelerate your applications, Lit
 | ForestKitten33 | Xilinx Ultrascale+  | XCVU33P       | 125MHz   | PCIe | 2 x 1024-bit 4GB HBM2*|  Gen3 X16     |     ?       |
 | BCU1525        | Xilinx Ultrascale+  | XCVU9P        | 125MHz   | PCIe | 4 x 64-bit DDR4 DIMM  |  Gen3 X16     |     ?       |
 | AlveoU250      | Xilinx Ultrascale+  | XCU250        | 125MHz   | PCIe | 4 x 64-bit DDR4 DIMM  |  Gen2 X16     |     ?       |
-| AlveoU280      | Xilinx Ultrascale+  | XCU280        | 125MHz   | PCIe* | 4 x 64-bit DDR4 DIMM*  |  Gen2 X16     |     ?       |
+| AlveoU280      | Xilinx Ultrascale+  | XCU280        | 125MHz   | PCIe* | 2 x 64-bit DDR4 DIMM* & HBM2*  |  Gen2 X16     |     ?       |
 
 \* Present on the board but not yet supported or validated with LiteX.
 

--- a/litex_boards/platforms/alveo_u280.py
+++ b/litex_boards/platforms/alveo_u280.py
@@ -3,13 +3,15 @@
 #
 # Copyright (c) 2020 David Shah <dave@ds0.me>
 # Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
-# Modified for Alveo U280 by Sergiu Mosanu based on XCU1525
 # SPDX-License-Identifier: BSD-2-Clause
+
+# Modified for Alveo U280 by Sergiu Mosanu based on XCU1525 and Alveo U250
+
 
 from litex.build.generic_platform import Pins, Subsignal, IOStandard, Misc
 from litex.build.xilinx import XilinxPlatform, VivadoProgrammer
 
-# IOs ----------------------------------------------------------------------------------------------
+# IOs -----------------------------------------------------------------------------------------------
 
 _io = [
     # Clk / Rst
@@ -21,7 +23,33 @@ _io = [
         Subsignal("n", Pins("BJ6"), IOStandard("LVDS")),
         Subsignal("p", Pins("BH6"), IOStandard("LVDS")),
     ),
+
+
+
+
+
+
+
+
     ("cpu_reset", 0, Pins("L30"), IOStandard("LVCMOS18")),
+
+    # Leds
+    ("gpio_led", 0, Pins("C32"), IOStandard("LVCMOS18")),
+    ("gpio_led", 1, Pins("D32"), IOStandard("LVCMOS18")),
+    ("gpio_led", 2, Pins("D31"), IOStandard("LVCMOS18")),
+
+    # Switches
+    
+    ("gpio_sw", 0, Pins("J30"), IOStandard("LVCMOS18")),
+    ("gpio_sw", 1, Pins("J32"), IOStandard("LVCMOS18")),
+    ("gpio_sw", 2, Pins("K32"), IOStandard("LVCMOS18")),
+    ("gpio_sw", 3, Pins("K31"), IOStandard("LVCMOS18")),
+    
+
+
+
+
+
 
     # Serial
     ("serial", 0,
@@ -29,20 +57,22 @@ _io = [
         Subsignal("tx", Pins("B33"), IOStandard("LVCMOS18")),
     ),
 
+    
+
+
+
     # DDR4 SDRAM
-    #("ddram_reset_gate", 0, Pins("AU21"), IOStandard("LVCMOS12")),
+    #("ddram_reset_gate", 0, Pins(""), IOStandard("LVCMOS12")),???
     ("ddram", 0,
         Subsignal("a", Pins(
             "BF46 BG43 BK45 BF42 BL45 BF43 BG42 BL43",
-            "BK43 BM42 BG45 BD41 BL42 BE44"), #"BE43 BL46 BH44"
+            "BK43 BM42 BG45 BD41 BL42 BE44"),
             IOStandard("SSTL12_DCI")),
         Subsignal("act_n", Pins("BH41"), IOStandard("SSTL12_DCI")),
-        Subsignal("ba",    Pins("BH45 BM47"), IOStandard("SSTL12_DCI")),
-        Subsignal("bg",    Pins("BF41 BE41"), IOStandard("SSTL12_DCI")),
-        Subsignal("ras_n", Pins("BH44"), IOStandard("SSTL12_DCI")), # A16
+        Subsignal("ba", Pins("BH45 BM47"), IOStandard("SSTL12_DCI")),
+        Subsignal("bg", Pins("BF41 BE41"), IOStandard("SSTL12_DCI")),
         Subsignal("cas_n", Pins("BL46"), IOStandard("SSTL12_DCI")), # A15
-        Subsignal("we_n",  Pins("BE43"), IOStandard("SSTL12_DCI")), # A14
-        Subsignal("cke",   Pins("BH42"), IOStandard("SSTL12_DCI")),
+        Subsignal("cke", Pins("BH42"), IOStandard("SSTL12_DCI")),
         Subsignal("clk_n", Pins("BJ46"), IOStandard("DIFF_SSTL12_DCI")),
         Subsignal("clk_p", Pins("BH46"), IOStandard("DIFF_SSTL12_DCI")),
         Subsignal("cs_n",  Pins("BK46"), IOStandard("SSTL12_DCI")),
@@ -56,28 +86,26 @@ _io = [
             "BH50 BJ51 BH51 BH49 BK50 BK51 BJ49 BJ48",
             "BN44 BN45 BM44 BM45 BP43 BP44 BN47 BP47"),
             IOStandard("POD12_DCI"),
-            # Misc("OUTPUT_IMPEDANCE=RDRV_40_40"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_n", Pins(
             "BN30 BM29 BK30 BG30 BM35 BN35 BK35 BJ32",
             "BM50 BP49 BF48 BG49 BJ47 BK49 BP46 BP42"), #"BJ54 BJ53"
             IOStandard("DIFF_POD12"),
-            # Misc("OUTPUT_IMPEDANCE=RDRV_40_40"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_p", Pins(
             "BN29 BM28 BJ29 BG29 BL35 BM34 BK34 BH32",
             "BM49 BP48 BF47 BG48 BH47 BK48 BN46 BN42"), #"BH54 BJ52"
             IOStandard("DIFF_POD12"),
-            # Misc("OUTPUT_IMPEDANCE=RDRV_40_40"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("odt", Pins("BG44"), IOStandard("SSTL12_DCI")),
+        Subsignal("ras_n", Pins("BH44"), IOStandard("SSTL12_DCI")), # A16
         Subsignal("reset_n", Pins("BG33"), IOStandard("LVCMOS12")),
+        Subsignal("we_n",  Pins("BE43"), IOStandard("SSTL12_DCI")), # A14
         Misc("SLEW=FAST")
     ),
-
 ]
 
 # Connectors ---------------------------------------------------------------------------------------
@@ -100,10 +128,29 @@ class Platform(XilinxPlatform):
         XilinxPlatform.do_finalize(self, fragment)
         self.add_period_constraint(self.lookup_request("sysclk", 0, loose=True), 1e9/100e6)
         self.add_period_constraint(self.lookup_request("sysclk", 1, loose=True), 1e9/100e6)
+
+
         # For passively cooled boards, overheating is a significant risk if airflow isn't sufficient
         self.add_platform_command("set_property BITSTREAM.CONFIG.OVERTEMPSHUTDOWN ENABLE [current_design]")
         # Reduce programming time
         self.add_platform_command("set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
         # Other suggested configurations
         self.add_platform_command("set_property CONFIG_VOLTAGE 1.8 [current_design]")
         self.add_platform_command("set_property BITSTREAM.CONFIG.CONFIGFALLBACK Enable [current_design]")

--- a/litex_boards/platforms/alveo_u280.py
+++ b/litex_boards/platforms/alveo_u280.py
@@ -23,64 +23,22 @@ _io = [
     ),
     ("cpu_reset", 0, Pins("L30"), IOStandard("LVCMOS18")),
 
-    # Leds
-    ("user_led", 0, Pins("C32"), IOStandard("LVCMOS18")),
-    ("user_led", 1, Pins("D32"), IOStandard("LVCMOS18")),
-    ("user_led", 2, Pins("D31"), IOStandard("LVCMOS18")),
-
     # Serial
     ("serial", 0,
         Subsignal("rx", Pins("A28"), IOStandard("LVCMOS18")),
         Subsignal("tx", Pins("B33"), IOStandard("LVCMOS18")),
     ),
 
-    # # PCIe
-    # ("pcie_x2", 0,
-    #     Subsignal("rst_n", Pins("BD21"), IOStandard("LVCMOS12")),
-    #     Subsignal("clk_n", Pins("AM10")),
-    #     Subsignal("clk_p", Pins("AM11")),
-    #     Subsignal("rx_n",  Pins("AF1 AG3")),
-    #     Subsignal("rx_p",  Pins("AF2 AG4")),
-    #     Subsignal("tx_n",  Pins("AF6 AG8")),
-    #     Subsignal("tx_p",  Pins("AF7 AG9")),
-    # ),
-    # ("pcie_x4", 0,
-    #     Subsignal("rst_n", Pins("BD21"), IOStandard("LVCMOS12")),
-    #     Subsignal("clk_n", Pins("AM10")),
-    #     Subsignal("clk_p", Pins("AM11")),
-    #     Subsignal("rx_n",  Pins("AF1 AG3 AH1 AJ3")),
-    #     Subsignal("rx_p",  Pins("AF2 AG4 AH2 AJ4")),
-    #     Subsignal("tx_n",  Pins("AF6 AG8 AH6 AJ8")),
-    #     Subsignal("tx_p",  Pins("AF7 AG9 AH7 AJ9")),
-    # ),
-    # ("pcie_x8", 0,
-    #     Subsignal("rst_n", Pins("BD21"), IOStandard("LVCMOS12")),
-    #     Subsignal("clk_n", Pins("AM10")),
-    #     Subsignal("clk_p", Pins("AM11")),
-    #     Subsignal("rx_n",  Pins("AF1 AG3 AH1 AJ3 AK1 AL3 AM1 AN3")),
-    #     Subsignal("rx_p",  Pins("AF2 AG4 AH2 AJ4 AK2 AL4 AM2 AN4")),
-    #     Subsignal("tx_n",  Pins("AF6 AG8 AH6 AJ8 AK6 AL8 AM6 AN8")),
-    #     Subsignal("tx_p",  Pins("AF7 AG9 AH7 AJ9 AK7 AL9 AM7 AN9")),
-    # ),
-    # ("pcie_x16", 0,
-    #     Subsignal("rst_n", Pins("BD21"), IOStandard("LVCMOS12")),
-    #     Subsignal("clk_n", Pins("AM10")),
-    #     Subsignal("clk_p", Pins("AM11")),
-    #     Subsignal("rx_n", Pins("AF1 AG3 AH1 AJ3 AK1 AL3 AM1 AN3 AP1 AR3 AT1 AU3 AV1 AW3 BA1 BC1")),
-    #     Subsignal("rx_p", Pins("AF2 AG4 AH2 AJ4 AK2 AL4 AM2 AN4 AP2 AR4 AT2 AU4 AV2 AW4 BA2 BC2")),
-    #     Subsignal("tx_n", Pins("AF6 AG8 AH6 AJ8 AK6 AL8 AM6 AN8 AP6 AR8 AT6 AU8 AV6 BB4 BD4 BF4")),
-    #     Subsignal("tx_p", Pins("AF7 AG9 AH7 AJ9 AK7 AL9 AM7 AN9 AP7 AR9 AT7 AU9 AV7 BB5 BD5 BF5")),
-    # ),
-
     # DDR4 SDRAM
+    #("ddram_reset_gate", 0, Pins("AU21"), IOStandard("LVCMOS12")),
     ("ddram", 0,
         Subsignal("a", Pins(
             "BF46 BG43 BK45 BF42 BL45 BF43 BG42 BL43",
             "BK43 BM42 BG45 BD41 BL42 BE44"), #"BE43 BL46 BH44"
             IOStandard("SSTL12_DCI")),
         Subsignal("act_n", Pins("BH41"), IOStandard("SSTL12_DCI")),
-        Subsignal("ba", Pins("BH45 BM47"), IOStandard("SSTL12_DCI")),
-        Subsignal("bg", Pins("BF41 BE41"), IOStandard("SSTL12_DCI")),
+        Subsignal("ba",    Pins("BH45 BM47"), IOStandard("SSTL12_DCI")),
+        Subsignal("bg",    Pins("BF41 BE41"), IOStandard("SSTL12_DCI")),
         Subsignal("ras_n", Pins("BH44"), IOStandard("SSTL12_DCI")), # A16
         Subsignal("cas_n", Pins("BL46"), IOStandard("SSTL12_DCI")), # A15
         Subsignal("we_n",  Pins("BE43"), IOStandard("SSTL12_DCI")), # A14
@@ -115,7 +73,7 @@ _io = [
             # Misc("OUTPUT_IMPEDANCE=RDRV_40_40"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
-        Subsignal("odt",     Pins("BG44"), IOStandard("SSTL12_DCI")),
+        Subsignal("odt", Pins("BG44"), IOStandard("SSTL12_DCI")),
         Subsignal("reset_n", Pins("BG33"), IOStandard("LVCMOS12")),
         Misc("SLEW=FAST")
     ),
@@ -156,24 +114,3 @@ class Platform(XilinxPlatform):
         self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_FALL_EDGE YES [current_design]")
         self.add_platform_command("set_property BITSTREAM.CONFIG.UNUSEDPIN Pullup [current_design]")
         self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_32BIT_ADDR Yes [current_design]")
-        # ------------------------------------------------------------------------
-        # # DDR4 memory channel C0 Clock constraint / Internal Vref
-        # self.add_period_constraint(self.lookup_request("clk300", 0, loose=True), 1e9/300e6)
-        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 40]")
-        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 41]")
-        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 42]")
-        # # DDR4 memory channel C1 Clock constraint / Internal Vref
-        # self.add_period_constraint(self.lookup_request("clk300", 1, loose=True), 1e9/300e6)
-        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 65]")
-        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 66]")
-        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 67]")
-        # # DDR4 memory channel C2 Clock constraint / Internal Vref
-        # self.add_period_constraint(self.lookup_request("clk300", 2, loose=True), 1e9/300e6)
-        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 46]")
-        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 47]")
-        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 48]")
-        # # DDR4 memory channel C3 Clock constraint / Internal Vref
-        # self.add_period_constraint(self.lookup_request("clk300", 3, loose=True), 1e9/300e6)
-        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 70]")
-        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 71]")
-        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 72]")

--- a/litex_boards/platforms/alveo_u280.py
+++ b/litex_boards/platforms/alveo_u280.py
@@ -7,7 +7,6 @@
 
 # Modified for Alveo U280 by Sergiu Mosanu based on XCU1525 and Alveo U250
 
-
 from litex.build.generic_platform import Pins, Subsignal, IOStandard, Misc
 from litex.build.xilinx import XilinxPlatform, VivadoProgrammer
 
@@ -24,13 +23,6 @@ _io = [
         Subsignal("p", Pins("BH6"), IOStandard("LVDS")),
     ),
 
-
-
-
-
-
-
-
     ("cpu_reset", 0, Pins("L30"), IOStandard("LVCMOS18")),
 
     # Leds
@@ -45,21 +37,11 @@ _io = [
     ("gpio_sw", 2, Pins("K32"), IOStandard("LVCMOS18")),
     ("gpio_sw", 3, Pins("K31"), IOStandard("LVCMOS18")),
     
-
-
-
-
-
-
     # Serial
     ("serial", 0,
         Subsignal("rx", Pins("A28"), IOStandard("LVCMOS18")),
         Subsignal("tx", Pins("B33"), IOStandard("LVCMOS18")),
     ),
-
-    
-
-
 
     # DDR4 SDRAM
     #("ddram_reset_gate", 0, Pins(""), IOStandard("LVCMOS12")),???
@@ -129,27 +111,14 @@ class Platform(XilinxPlatform):
         self.add_period_constraint(self.lookup_request("sysclk", 0, loose=True), 1e9/100e6)
         self.add_period_constraint(self.lookup_request("sysclk", 1, loose=True), 1e9/100e6)
 
-
         # For passively cooled boards, overheating is a significant risk if airflow isn't sufficient
         self.add_platform_command("set_property BITSTREAM.CONFIG.OVERTEMPSHUTDOWN ENABLE [current_design]")
         # Reduce programming time
         self.add_platform_command("set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]")
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        # DDR4 memory channel C1 Internal Vref
+        self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 64]")
+        self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 65]")
+        self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 66]")
 
         # Other suggested configurations
         self.add_platform_command("set_property CONFIG_VOLTAGE 1.8 [current_design]")

--- a/litex_boards/platforms/alveo_u280.py
+++ b/litex_boards/platforms/alveo_u280.py
@@ -1,0 +1,179 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2020 David Shah <dave@ds0.me>
+# Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# Modified for Alveo U280 by Sergiu Mosanu based on XCU1525
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import Pins, Subsignal, IOStandard, Misc
+from litex.build.xilinx import XilinxPlatform, VivadoProgrammer
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("sysclk", 0,
+        Subsignal("n", Pins("BJ44"), IOStandard("LVDS")),
+        Subsignal("p", Pins("BJ43"), IOStandard("LVDS")),
+    ),
+    ("sysclk", 1,
+        Subsignal("n", Pins("BJ6"), IOStandard("LVDS")),
+        Subsignal("p", Pins("BH6"), IOStandard("LVDS")),
+    ),
+    ("cpu_reset", 0, Pins("L30"), IOStandard("LVCMOS18")),
+
+    # Leds
+    ("user_led", 0, Pins("C32"), IOStandard("LVCMOS18")),
+    ("user_led", 1, Pins("D32"), IOStandard("LVCMOS18")),
+    ("user_led", 2, Pins("D31"), IOStandard("LVCMOS18")),
+
+    # Serial
+    ("serial", 0,
+        Subsignal("rx", Pins("A28"), IOStandard("LVCMOS18")),
+        Subsignal("tx", Pins("B33"), IOStandard("LVCMOS18")),
+    ),
+
+    # # PCIe
+    # ("pcie_x2", 0,
+    #     Subsignal("rst_n", Pins("BD21"), IOStandard("LVCMOS12")),
+    #     Subsignal("clk_n", Pins("AM10")),
+    #     Subsignal("clk_p", Pins("AM11")),
+    #     Subsignal("rx_n",  Pins("AF1 AG3")),
+    #     Subsignal("rx_p",  Pins("AF2 AG4")),
+    #     Subsignal("tx_n",  Pins("AF6 AG8")),
+    #     Subsignal("tx_p",  Pins("AF7 AG9")),
+    # ),
+    # ("pcie_x4", 0,
+    #     Subsignal("rst_n", Pins("BD21"), IOStandard("LVCMOS12")),
+    #     Subsignal("clk_n", Pins("AM10")),
+    #     Subsignal("clk_p", Pins("AM11")),
+    #     Subsignal("rx_n",  Pins("AF1 AG3 AH1 AJ3")),
+    #     Subsignal("rx_p",  Pins("AF2 AG4 AH2 AJ4")),
+    #     Subsignal("tx_n",  Pins("AF6 AG8 AH6 AJ8")),
+    #     Subsignal("tx_p",  Pins("AF7 AG9 AH7 AJ9")),
+    # ),
+    # ("pcie_x8", 0,
+    #     Subsignal("rst_n", Pins("BD21"), IOStandard("LVCMOS12")),
+    #     Subsignal("clk_n", Pins("AM10")),
+    #     Subsignal("clk_p", Pins("AM11")),
+    #     Subsignal("rx_n",  Pins("AF1 AG3 AH1 AJ3 AK1 AL3 AM1 AN3")),
+    #     Subsignal("rx_p",  Pins("AF2 AG4 AH2 AJ4 AK2 AL4 AM2 AN4")),
+    #     Subsignal("tx_n",  Pins("AF6 AG8 AH6 AJ8 AK6 AL8 AM6 AN8")),
+    #     Subsignal("tx_p",  Pins("AF7 AG9 AH7 AJ9 AK7 AL9 AM7 AN9")),
+    # ),
+    # ("pcie_x16", 0,
+    #     Subsignal("rst_n", Pins("BD21"), IOStandard("LVCMOS12")),
+    #     Subsignal("clk_n", Pins("AM10")),
+    #     Subsignal("clk_p", Pins("AM11")),
+    #     Subsignal("rx_n", Pins("AF1 AG3 AH1 AJ3 AK1 AL3 AM1 AN3 AP1 AR3 AT1 AU3 AV1 AW3 BA1 BC1")),
+    #     Subsignal("rx_p", Pins("AF2 AG4 AH2 AJ4 AK2 AL4 AM2 AN4 AP2 AR4 AT2 AU4 AV2 AW4 BA2 BC2")),
+    #     Subsignal("tx_n", Pins("AF6 AG8 AH6 AJ8 AK6 AL8 AM6 AN8 AP6 AR8 AT6 AU8 AV6 BB4 BD4 BF4")),
+    #     Subsignal("tx_p", Pins("AF7 AG9 AH7 AJ9 AK7 AL9 AM7 AN9 AP7 AR9 AT7 AU9 AV7 BB5 BD5 BF5")),
+    # ),
+
+    # DDR4 SDRAM
+    ("ddram", 0,
+        Subsignal("a", Pins(
+            "BF46 BG43 BK45 BF42 BL45 BF43 BG42 BL43",
+            "BK43 BM42 BG45 BD41 BL42 BE44"), #"BE43 BL46 BH44"
+            IOStandard("SSTL12_DCI")),
+        Subsignal("act_n", Pins("BH41"), IOStandard("SSTL12_DCI")),
+        Subsignal("ba", Pins("BH45 BM47"), IOStandard("SSTL12_DCI")),
+        Subsignal("bg", Pins("BF41 BE41"), IOStandard("SSTL12_DCI")),
+        Subsignal("ras_n", Pins("BH44"), IOStandard("SSTL12_DCI")), # A16
+        Subsignal("cas_n", Pins("BL46"), IOStandard("SSTL12_DCI")), # A15
+        Subsignal("we_n",  Pins("BE43"), IOStandard("SSTL12_DCI")), # A14
+        Subsignal("cke",   Pins("BH42"), IOStandard("SSTL12_DCI")),
+        Subsignal("clk_n", Pins("BJ46"), IOStandard("DIFF_SSTL12_DCI")),
+        Subsignal("clk_p", Pins("BH46"), IOStandard("DIFF_SSTL12_DCI")),
+        Subsignal("cs_n",  Pins("BK46"), IOStandard("SSTL12_DCI")),
+        Subsignal("dq", Pins(
+            "BN32 BP32 BL30 BM30 BP29 BP28 BP31 BN31",
+            "BJ31 BH31 BF32 BF33 BH29 BH30 BF31 BG32",
+            "BK31 BL31 BK33 BL33 BL32 BM33 BN34 BP34",
+            "BH34 BH35 BF35 BF36 BJ33 BJ34 BG34 BG35",
+            "BM52 BL53 BL52 BL51 BN50 BN51 BN49 BM48",
+            "BE50 BE49 BE51 BD51 BF52 BF51 BG50 BF50",
+            "BH50 BJ51 BH51 BH49 BK50 BK51 BJ49 BJ48",
+            "BN44 BN45 BM44 BM45 BP43 BP44 BN47 BP47"),
+            IOStandard("POD12_DCI"),
+            # Misc("OUTPUT_IMPEDANCE=RDRV_40_40"),
+            Misc("PRE_EMPHASIS=RDRV_240"),
+            Misc("EQUALIZATION=EQ_LEVEL2")),
+        Subsignal("dqs_n", Pins(
+            "BN30 BM29 BK30 BG30 BM35 BN35 BK35 BJ32",
+            "BM50 BP49 BF48 BG49 BJ47 BK49 BP46 BP42"), #"BJ54 BJ53"
+            IOStandard("DIFF_POD12"),
+            # Misc("OUTPUT_IMPEDANCE=RDRV_40_40"),
+            Misc("PRE_EMPHASIS=RDRV_240"),
+            Misc("EQUALIZATION=EQ_LEVEL2")),
+        Subsignal("dqs_p", Pins(
+            "BN29 BM28 BJ29 BG29 BL35 BM34 BK34 BH32",
+            "BM49 BP48 BF47 BG48 BH47 BK48 BN46 BN42"), #"BH54 BJ52"
+            IOStandard("DIFF_POD12"),
+            # Misc("OUTPUT_IMPEDANCE=RDRV_40_40"),
+            Misc("PRE_EMPHASIS=RDRV_240"),
+            Misc("EQUALIZATION=EQ_LEVEL2")),
+        Subsignal("odt",     Pins("BG44"), IOStandard("SSTL12_DCI")),
+        Subsignal("reset_n", Pins("BG33"), IOStandard("LVCMOS12")),
+        Misc("SLEW=FAST")
+    ),
+
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = []
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(XilinxPlatform):
+    default_clk_name   = "sysclk"
+    default_clk_period = 1e9/100e6
+
+    def __init__(self):
+        XilinxPlatform.__init__(self, "xcu280-fsvh2892-2L-e-es1", _io, _connectors, toolchain="vivado")
+
+    def create_programmer(self):
+        return VivadoProgrammer()
+
+    def do_finalize(self, fragment):
+        XilinxPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("sysclk", 0, loose=True), 1e9/100e6)
+        self.add_period_constraint(self.lookup_request("sysclk", 1, loose=True), 1e9/100e6)
+        # For passively cooled boards, overheating is a significant risk if airflow isn't sufficient
+        self.add_platform_command("set_property BITSTREAM.CONFIG.OVERTEMPSHUTDOWN ENABLE [current_design]")
+        # Reduce programming time
+        self.add_platform_command("set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]")
+        # Other suggested configurations
+        self.add_platform_command("set_property CONFIG_VOLTAGE 1.8 [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.CONFIGFALLBACK Enable [current_design]")
+        self.add_platform_command("set_property CONFIG_MODE SPIx4 [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.CONFIGRATE 85.0 [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.EXTMASTERCCLK_EN disable [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_FALL_EDGE YES [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.UNUSEDPIN Pullup [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_32BIT_ADDR Yes [current_design]")
+        # ------------------------------------------------------------------------
+        # # DDR4 memory channel C0 Clock constraint / Internal Vref
+        # self.add_period_constraint(self.lookup_request("clk300", 0, loose=True), 1e9/300e6)
+        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 40]")
+        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 41]")
+        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 42]")
+        # # DDR4 memory channel C1 Clock constraint / Internal Vref
+        # self.add_period_constraint(self.lookup_request("clk300", 1, loose=True), 1e9/300e6)
+        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 65]")
+        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 66]")
+        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 67]")
+        # # DDR4 memory channel C2 Clock constraint / Internal Vref
+        # self.add_period_constraint(self.lookup_request("clk300", 2, loose=True), 1e9/300e6)
+        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 46]")
+        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 47]")
+        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 48]")
+        # # DDR4 memory channel C3 Clock constraint / Internal Vref
+        # self.add_period_constraint(self.lookup_request("clk300", 3, loose=True), 1e9/300e6)
+        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 70]")
+        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 71]")
+        # self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 72]")

--- a/litex_boards/platforms/alveo_u280.py
+++ b/litex_boards/platforms/alveo_u280.py
@@ -88,6 +88,49 @@ _io = [
         Subsignal("we_n",  Pins("BE43"), IOStandard("SSTL12_DCI")), # A14
         Misc("SLEW=FAST")
     ),
+        ("ddram", 1,
+        Subsignal("a", Pins(
+            "BF7 BK1 BF6 BF5 BE3 BE6 BE5 BG7",
+            "BJ1 BG2 BJ8 BE4 BL2 BK5"), # BK8 BJ4 BF8
+            IOStandard("SSTL12_DCI")),
+        Subsignal("act_n", Pins("BG3"), IOStandard("SSTL12_DCI")),
+        Subsignal("ba", Pins("BG8 BK4"), IOStandard("SSTL12_DCI")),
+        Subsignal("bg", Pins("BF3 BF2"), IOStandard("SSTL12_DCI")),
+        Subsignal("cas_n", Pins("BJ4"), IOStandard("SSTL12_DCI")), # A15
+        Subsignal("cke", Pins("BE1"), IOStandard("SSTL12_DCI")),
+        Subsignal("clk_n", Pins("BJ2"), IOStandard("DIFF_SSTL12_DCI")),
+        Subsignal("clk_p", Pins("BJ3"), IOStandard("DIFF_SSTL12_DCI")),
+        Subsignal("cs_n",  Pins("BL3"), IOStandard("SSTL12_DCI")),
+        Subsignal("dq", Pins(
+            "A11 A10 A9 A8 B12 B10 C12 B11",
+            "E11 D11 E12 F11 F10 E9 F9 G11",
+            "H12 G13 H13 H14 J11 J12 J15 J14",
+            "A14 C15 A15 B15 F15 E14 F14 F13",
+            "BM3 BM4 BM5 BL6 BN4 BN5 BN6 BN7",
+            "BJ9 BK9 BK10 BL10 BM9 BN9 BN10 BM10",
+            "BM15 BM14 BL15 BM13 BN12 BM12 BP13 BP14",
+            "BJ13 BJ12 BH15 BH14 BK14 BK15 BL12 BL13"),
+            IOStandard("POD12_DCI"),
+            Misc("PRE_EMPHASIS=RDRV_240"),
+            Misc("EQUALIZATION=EQ_LEVEL2")),
+        Subsignal("dqs_n", Pins(
+            "A13 D9 G15 D14 BM7 BM8 BN14 BK13",
+            "BF11 C9 G10 K13 D12 BP6 BP8 BP11"), # "BK11 BH9"
+            IOStandard("DIFF_POD12"),
+            Misc("PRE_EMPHASIS=RDRV_240"),
+            Misc("EQUALIZATION=EQ_LEVEL2")),
+        Subsignal("dqs_p", Pins(
+            "B13 C10 D10 H10 H15 K14 D15 E13",
+            "BL7 BP7 BL8 BP9 BN15 BP12 BJ14 BJ11"), #"BH54 BJ52"
+            IOStandard("DIFF_POD12"),
+            Misc("PRE_EMPHASIS=RDRV_240"),
+            Misc("EQUALIZATION=EQ_LEVEL2")),
+        Subsignal("odt", Pins("BH2"), IOStandard("SSTL12_DCI")),
+        Subsignal("ras_n", Pins("BF8"), IOStandard("SSTL12_DCI")), # A16
+        Subsignal("reset_n", Pins("BH12"), IOStandard("LVCMOS12")),
+        Subsignal("we_n",  Pins("BK8"), IOStandard("SSTL12_DCI")), # A14
+        Misc("SLEW=FAST")
+    ),
 ]
 
 # Connectors ---------------------------------------------------------------------------------------
@@ -115,10 +158,14 @@ class Platform(XilinxPlatform):
         self.add_platform_command("set_property BITSTREAM.CONFIG.OVERTEMPSHUTDOWN ENABLE [current_design]")
         # Reduce programming time
         self.add_platform_command("set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]")
-        # DDR4 memory channel C1 Internal Vref
+        # DDR4 memory channel C0 Internal Vref
         self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 64]")
         self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 65]")
         self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 66]")
+        # DDR4 memory channel C1 Internal Vref
+        self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 68]")
+        self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 69]")
+        self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 70]")
 
         # Other suggested configurations
         self.add_platform_command("set_property CONFIG_VOLTAGE 1.8 [current_design]")

--- a/litex_boards/targets/alveo_u280.py
+++ b/litex_boards/targets/alveo_u280.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# Modified for Alveo U280 by Sergiu Mosanu based on XCU1525
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import argparse
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex_boards.platforms import alveo_u280
+
+from litex.soc.cores.clock import *
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.soc_sdram import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+
+from litedram.modules import MTA18ASF2G72PZ
+from litedram.phy import usddrphy
+
+from litepcie.phy.usppciephy import USPPCIEPHY
+from litepcie.software import generate_litepcie_software
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq, ddram_channel):
+        self.rst = Signal()
+        self.clock_domains.cd_sys    = ClockDomain()
+        self.clock_domains.cd_sys4x  = ClockDomain(reset_less=True)
+        self.clock_domains.cd_pll4x  = ClockDomain(reset_less=True)
+        self.clock_domains.cd_idelay = ClockDomain()
+
+        # # #
+
+        self.submodules.pll = pll = USMMCM(speedgrade=-2)
+        self.comb += pll.reset.eq(self.rst)
+        #pll.register_clkin(platform.request("clk300", ddram_channel), 300e6)
+        pll.register_clkin(platform.request("sysclk", ddram_channel), 100e6)
+        pll.create_clkout(self.cd_pll4x, sys_clk_freq*4, buf=None, with_reset=False)
+        pll.create_clkout(self.cd_idelay, 500e6, with_reset=False)
+        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
+
+        self.specials += [
+            Instance("BUFGCE_DIV", name="main_bufgce_div",
+                p_BUFGCE_DIVIDE=4,
+                i_CE=1, i_I=self.cd_pll4x.clk, o_O=self.cd_sys.clk),
+            Instance("BUFGCE", name="main_bufgce",
+                i_CE=1, i_I=self.cd_pll4x.clk, o_O=self.cd_sys4x.clk),
+            AsyncResetSynchronizer(self.cd_idelay, ~pll.locked),
+        ]
+
+        self.submodules.idelayctrl = USIDELAYCTRL(cd_ref=self.cd_idelay, cd_sys=self.cd_sys)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=int(125e6), ddram_channel=0, with_pcie=False, **kwargs):
+        platform = alveo_u280.Platform()
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            ident          = "LiteX SoC on AlveoU280",
+            ident_version  = True,
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq, ddram_channel)
+
+        # DDR4 SDRAM -------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.submodules.ddrphy = usddrphy.USPDDRPHY(
+                pads             = platform.request("ddram", ddram_channel),
+                memtype          = "DDR4",
+                sys_clk_freq     = sys_clk_freq,
+                iodelay_clk_freq = 500e6,
+                is_rdimm         = True)
+            self.add_csr("ddrphy")
+            self.add_sdram("sdram",
+                phy                     = self.ddrphy,
+                module                  = MTA18ASF2G72PZ(sys_clk_freq, "1:4"),
+                origin                  = self.mem_map["main_ram"],
+                size                    = kwargs.get("max_sdram_size", 0x40000000),
+                l2_cache_size           = kwargs.get("l2_size", 8192),
+                l2_cache_min_data_width = kwargs.get("min_l2_data_width", 128),
+                l2_cache_reverse        = True
+            )
+            # Workadound for Vivado 2018.2 DRC, can be ignored and probably fixed on newer Vivado versions.
+            platform.add_platform_command("set_property SEVERITY {{Warning}} [get_drc_checks PDCN-2736]")
+
+        # Firmware RAM (To ease initial LiteDRAM calibration support) ------------------------------
+        self.add_ram("firmware_ram", 0x20000000, 0x8000)
+
+        # PCIe -------------------------------------------------------------------------------------
+        if with_pcie:
+            self.submodules.pcie_phy = USPPCIEPHY(platform, platform.request("pcie_x4"),
+                data_width = 128,
+                bar0_size  = 0x20000)
+            self.add_csr("pcie_phy")
+            self.add_pcie(phy=self.pcie_phy, ndmas=1)
+
+        # Leds -------------------------------------------------------------------------------------
+        self.submodules.leds = LedChaser(
+            pads         = platform.request_all("user_led"),
+            sys_clk_freq = sys_clk_freq)
+        self.add_csr("leds")
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on AlveoU280")
+    parser.add_argument("--build",         action="store_true", help="Build bitstream")
+    parser.add_argument("--load",          action="store_true", help="Load bitstream")
+    parser.add_argument("--sys-clk-freq",  default=125e6,       help="System clock frequency (default: 125MHz)")
+    parser.add_argument("--ddram-channel", default="0",         help="DDRAM channel (default: 0)")
+    parser.add_argument("--with-pcie",     action="store_true", help="Enable PCIe support")
+    parser.add_argument("--driver",        action="store_true", help="Generate PCIe driver")
+    builder_args(parser)
+    soc_sdram_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq  = int(float(args.sys_clk_freq)),
+        ddram_channel = int(args.ddram_channel, 0),
+        with_pcie     = args.with_pcie,
+        **soc_sdram_argdict(args)
+	)
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build(run=args.build)
+
+    if args.driver:
+        generate_litepcie_software(soc, os.path.join(builder.output_dir, "driver"))
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".bit"))
+
+if __name__ == "__main__":
+    main()

--- a/litex_boards/targets/alveo_u280.py
+++ b/litex_boards/targets/alveo_u280.py
@@ -19,7 +19,6 @@ from litex.soc.cores.clock import *
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
-from litex.soc.cores.led import LedChaser
 
 from litedram.modules import MTA18ASF2G72PZ
 from litedram.phy import usddrphy
@@ -66,7 +65,7 @@ class BaseSoC(SoCCore):
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq,
-            ident          = "LiteX SoC on AlveoU280",
+            ident          = "LiteX SoC on Alveo U280",
             ident_version  = True,
             **kwargs)
 
@@ -91,8 +90,6 @@ class BaseSoC(SoCCore):
                 l2_cache_min_data_width = kwargs.get("min_l2_data_width", 128),
                 l2_cache_reverse        = True
             )
-            # Workadound for Vivado 2018.2 DRC, can be ignored and probably fixed on newer Vivado versions.
-            platform.add_platform_command("set_property SEVERITY {{Warning}} [get_drc_checks PDCN-2736]")
 
         # Firmware RAM (To ease initial LiteDRAM calibration support) ------------------------------
         self.add_ram("firmware_ram", 0x20000000, 0x8000)
@@ -105,16 +102,10 @@ class BaseSoC(SoCCore):
             self.add_csr("pcie_phy")
             self.add_pcie(phy=self.pcie_phy, ndmas=1)
 
-        # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
-        self.add_csr("leds")
-
 # Build --------------------------------------------------------------------------------------------
 
 def main():
-    parser = argparse.ArgumentParser(description="LiteX SoC on AlveoU280")
+    parser = argparse.ArgumentParser(description="LiteX SoC on Alveo U280")
     parser.add_argument("--build",         action="store_true", help="Build bitstream")
     parser.add_argument("--load",          action="store_true", help="Load bitstream")
     parser.add_argument("--sys-clk-freq",  default=125e6,       help="System clock frequency (default: 125MHz)")

--- a/litex_boards/targets/alveo_u280.py
+++ b/litex_boards/targets/alveo_u280.py
@@ -41,7 +41,7 @@ class _CRG(Module):
 
         self.submodules.pll = pll = USMMCM(speedgrade=-2)
         self.comb += pll.reset.eq(self.rst)
-        pll.register_clkin(platform.request("sysclk", 0), 100e6)
+        pll.register_clkin(platform.request("sysclk", 1), 100e6)
         pll.create_clkout(self.cd_pll4x, sys_clk_freq*4, buf=None, with_reset=False)
         pll.create_clkout(self.cd_idelay, 500e6, with_reset=False)
         platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
@@ -75,7 +75,7 @@ class BaseSoC(SoCCore):
 
         # DDR4 SDRAM -------------------------------------------------------------------------------
         if not self.integrated_main_ram_size:
-            self.submodules.ddrphy = usddrphy.USPDDRPHY(platform.request("ddram"),
+            self.submodules.ddrphy = usddrphy.USPDDRPHY(platform.request("ddram", 1),
                 memtype          = "DDR4",
                 sys_clk_freq     = sys_clk_freq,
                 iodelay_clk_freq = 500e6,


### PR DESCRIPTION
This PR is related to #156 with _target_ and _platform_ files for the Xilinx Alveo U280 accelerator card. Only the sysclk0/1, cpu_reset, LEDs, switches, serial port and DDR4 C0/C1 constraints are defined at this time. 