### PR TITLE
targets/colorlight_i5: use .bit stream instead of .svf when loading.

### DIFF
--- a/litex_boards/targets/colorlight_i5.py
+++ b/litex_boards/targets/colorlight_i5.py
@@ -228,7 +228,7 @@ def main():
 
     if args.load:
         prog = soc.platform.create_programmer()
-        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".svf"))
+        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".bit"))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Hi,

I've mistakenly thought ecpdap can load a .svf stream file, though it ends up with
```
Error: ECP5 status register in incorrect state.
```
after the file transfer is done. This PR fixes it.

Regards,
    kaz
