### PR TITLE
arrow_sockit: add support for MiSTer XS SDRAM modules

### DIFF
--- a/litex_boards/platforms/arrow_sockit.py
+++ b/litex_boards/platforms/arrow_sockit.py
@@ -33,6 +33,29 @@ _io = [
     ("user_sw", 2, Pins("AC28"), IOStandard("3.3-V LVTTL")),
     ("user_sw", 3, Pins("AC29"), IOStandard("3.3-V LVTTL")),
 
+    # MiSTer SDRAM via GPIO expansion board J2
+    ("sdram_clock", 0, Pins("D10"), IOStandard("3.3-V LVTTL")),
+    ("sdram", 0,
+        Subsignal("a",     Pins(
+            "B1 C2 B2 D2 D9 C7 E12 B7",
+            "D12 A11 B6 D11 A10")),
+        Subsignal("ba",    Pins("B5 A4")),
+        Subsignal("cs_n",  Pins("A3")),
+        # CKE not connected on XS 2.2/2.4
+        Subsignal("cke",   Pins("B3")),
+        Subsignal("ras_n", Pins("E9")),
+        Subsignal("cas_n", Pins("A6")),
+        Subsignal("we_n",  Pins("A5")),
+        Subsignal("dq", Pins(
+            "F14 G15 F15 H15 G13 A13 H14 B13",
+            "C13 C8 B12 B8 F13 C12 B11 E13"),
+        ),
+        # DQML/DQMH not connected on XS 2.2/2.4
+        Subsignal("dm", Pins("AB27 AA26")),
+        IOStandard("3.3-V LVTTL"),
+        Misc("CURRENT_STRENGTH_NEW \"MAXIMUM CURRENT\""),
+    ),
+
     # DDR3 SDRAM
     ("ddram", 0,
         Subsignal("a", Pins(

--- a/litex_boards/targets/arrow_sockit.py
+++ b/litex_boards/targets/arrow_sockit.py
@@ -18,7 +18,7 @@ import os
 import argparse
 
 from migen.fhdl.module      import Module
-from migen.fhdl.structure   import Signal, ClockDomain
+from migen.fhdl.structure   import Signal, ClockDomain, ClockSignal
 from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.soc.cores.clock           import CycloneVPLL
@@ -27,15 +27,64 @@ from litex.soc.integration.soc_core  import SoCCore
 from litex.soc.integration.soc_sdram import soc_sdram_argdict, soc_sdram_args
 from litex.soc.cores.led             import LedChaser
 
+from litex.build.io import DDROutput
+
 from litex_boards.platforms import arrow_sockit
+
+from litedram.modules import _TechnologyTimings, _SpeedgradeTimings, SDRModule, AS4C32M16
+from litedram.phy     import HalfRateGENSDRPHY, GENSDRPHY
+
+# DRAM Module for XS board v2.2 ----------------------------------------------------------------------
+class W9825G6KH6(SDRModule):
+    """
+    Winbond W9825G6KH-6 chip on Mister SDRAM XS board v2.2
+    This is the smallest and cheapest module.
+    running it at 100MHz (1:2 if system clock is 50MHz)
+    works well on my SoCKit and all 32MB test error free
+    I get a number of data errors if I run it at 50MHz,
+    so this defaults to 1:2. If you want to use a higher
+    system clock (eg 100MHz), you might want to consider
+    using 1:1 clocking, because the -6 speedgrade 
+    can be clocked up to 166MHz (CL3) or 133MHz (CL2)
+    """
+    # geometry
+    nbanks = 4
+    nrows  = 8192
+    ncols  = 512
+
+    @staticmethod
+    def clock_cycles_to_ns(cycles, clk_freq, sdram_rate) -> float:
+        d = {
+            "1:1" : 1,
+            "1:2" : 2,
+            "1:4" : 4
+        }
+        return cycles / (d[sdram_rate] * clk_freq) / 1e-9
+
+    def __init__(self, clk_freq, sdram_rate):
+        # The datasheet specifies tWr in clock cycles, not in
+        # ns but to me it looks like litedram expects
+        # ns for these two parameters, so I have to convert them
+        # to ns first.
+        tWr  = self.clock_cycles_to_ns(2, clk_freq, sdram_rate)
+        tRRD = self.clock_cycles_to_ns(2, clk_freq, sdram_rate)
+        self.technology_timings = _TechnologyTimings(tREFI=64e6/8000, tWTR=(2, None), tCCD=(1, None), tRRD=(None, tRRD))
+        self.speedgrade_timings = {"default": _SpeedgradeTimings(tRP=15, tRCD=15, tWR=tWr, tRFC=(None, 60), tFAW=None, tRAS=42)}
+        super().__init__(clk_freq, sdram_rate)
 
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(Module):
-    def __init__(self, platform, sys_clk_freq):
+    def __init__(self, platform, sys_clk_freq, with_sdram=False, sdram_rate="1:2"):
+        self.sdram_rate = sdram_rate
         self.rst = Signal()
         self.clock_domains.cd_sys    = ClockDomain()
-        self.clock_domains.cd_sys_ps = ClockDomain(reset_less=True)
+        if with_sdram:
+            if sdram_rate == "1:2":
+                self.clock_domains.cd_sys2x    = ClockDomain()
+                self.clock_domains.cd_sys2x_ps = ClockDomain(reset_less=True)
+            else:
+                self.clock_domains.cd_sys_ps = ClockDomain(reset_less=True)
 
         # Clk / Rst
         clk50 = platform.request("clk50")
@@ -45,12 +94,22 @@ class _CRG(Module):
         self.comb += pll.reset.eq(self.rst)
         pll.register_clkin(clk50, 50e6)
         pll.create_clkout(self.cd_sys,    sys_clk_freq)
-        pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
+        if with_sdram:
+            if sdram_rate == "1:2":
+                pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
+                pll.create_clkout(self.cd_sys2x_ps, 2*sys_clk_freq, phase=180)  # Idealy 90° but needs to be increased.
+            else:
+                pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
+
+        # SDRAM clock
+        if with_sdram:
+            sdram_clk = ClockSignal("sys2x_ps" if sdram_rate == "1:2" else "sys_ps")
+            self.specials += DDROutput(1, 0, platform.request("sdram_clock"), sdram_clk)
 
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), revision="revd", **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), revision="revd", sdram_rate="1:2", mister_sdram=None, **kwargs):
         platform = arrow_sockit.Platform(revision)
 
         # Defaults to UART over JTAG because serial is attached to the HPS and cannot be used.
@@ -64,7 +123,7 @@ class BaseSoC(SoCCore):
             **kwargs)
 
         # CRG --------------------------------------------------------------------------------------
-        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        self.submodules.crg = _CRG(platform, sys_clk_freq, with_sdram=mister_sdram != None, sdram_rate=sdram_rate)
 
         # Leds -------------------------------------------------------------------------------------
         self.submodules.leds = LedChaser(
@@ -72,22 +131,52 @@ class BaseSoC(SoCCore):
             sys_clk_freq = sys_clk_freq)
         self.add_csr("leds")
 
+        if mister_sdram == "xs_v22":
+            sdrphy_cls = HalfRateGENSDRPHY if sdram_rate == "1:2" else GENSDRPHY
+            self.submodules.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
+            self.add_sdram("sdram",
+                phy                     = self.sdrphy,
+                module                  = W9825G6KH6(sys_clk_freq, sdram_rate),
+                origin                  = self.mem_map["main_ram"],
+                size                    = kwargs.get("max_sdram_size", 0x40000000),
+                l2_cache_size           = kwargs.get("l2_size", 8192),
+                l2_cache_min_data_width = kwargs.get("min_l2_data_width", 128),
+                l2_cache_reverse        = True
+            )
+
+        if mister_sdram == "xs_v24":
+            sdrphy_cls = HalfRateGENSDRPHY if sdram_rate == "1:2" else GENSDRPHY
+            self.submodules.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
+            self.add_sdram("sdram",
+                phy                     = self.sdrphy,
+                module                  = AS4C32M16(sys_clk_freq, sdram_rate),
+                origin                  = self.mem_map["main_ram"],
+                size                    = kwargs.get("max_sdram_size", 0x40000000),
+                l2_cache_size           = kwargs.get("l2_size", 8192),
+                l2_cache_min_data_width = kwargs.get("min_l2_data_width", 128),
+                l2_cache_reverse        = True
+            )
 
 # Build --------------------------------------------------------------------------------------------
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on SoCKit")
-    parser.add_argument("--build",        action="store_true", help="Build bitstream")
-    parser.add_argument("--load",         action="store_true", help="Load bitstream")
-    parser.add_argument("--revision",     default="revd",      help="Board revision: revb (default), revc or revd")
-    parser.add_argument("--sys-clk-freq", default=50e6,        help="System clock frequency (default: 50MHz)")
+    parser.add_argument("--single-rate-sdram",   action="store_true", help="clock SDRAM with 1x the sytem clock (instead of 2x)")
+    parser.add_argument("--mister-sdram-xs-v22", action="store_true", help="Use optional MiSTer SDRAM module XS v2.2 on J2 on GPIO daughter card")
+    parser.add_argument("--mister-sdram-xs-v24", action="store_true", help="Use optional MiSTer SDRAM module XS v2.4 on J2 on GPIO daughter card")
+    parser.add_argument("--build",               action="store_true", help="Build bitstream")
+    parser.add_argument("--load",                action="store_true", help="Load bitstream")
+    parser.add_argument("--revision",            default="revd",      help="Board revision: revb (default), revc or revd")
+    parser.add_argument("--sys-clk-freq",        default=50e6,       help="System clock frequency (default: 50MHz)")
     builder_args(parser)
     soc_sdram_args(parser)
     args = parser.parse_args()
 
     soc = BaseSoC(
-        sys_clk_freq = int(float(args.sys_clk_freq)),
-        revision     = args.revision,
+        sys_clk_freq        = int(float(args.sys_clk_freq)),
+        revision            = args.revision,
+        sdram_rate          = "1:1" if args.single_rate_sdram else "1:2",
+        mister_sdram        = "xs_v22" if args.mister_sdram_xs_v22 else "xs_v24" if args.mister_sdram_xs_v24 else None,
         **soc_sdram_argdict(args)
     )
     builder = Builder(soc, **builder_argdict(args))


### PR DESCRIPTION
Hi Florent,
I got the SDRAM module I have (the Winbond) now stable working error free:
litex> mem_test 0x40000000 0x2000000
Memtest at 0x40000000 (32MiB)...
  Write: 0x40000000-0x42000000 32MiB    
   Read: 0x40000000-0x42000000 32MiB    
Memtest OK

Interestingly the additional pin options made the memory errors worse,
so I left most of them out.
I am also now quite confident that I got the timing right.
In this version I won't need any additions to litedram,
because I create the timings in this module dynamically,
depending on the clock frequency, since the datasheet
specifies two timing values in clock cycles where litedram would expect it in nanoseconds.


