### PR TITLE
vc707.py: clk156 add missing constraint

### DIFF
--- a/litex_boards/platforms/vc707.py
+++ b/litex_boards/platforms/vc707.py
@@ -642,4 +642,5 @@ class Platform(XilinxPlatform):
     def do_finalize(self, fragment):
         XilinxPlatform.do_finalize(self, fragment)
         self.add_period_constraint(self.lookup_request("clk200",      loose=True), 1e9/200e6)
+        self.add_period_constraint(self.lookup_request("clk156",      loose=True), 1e9/156e6)
         self.add_period_constraint(self.lookup_request("sgmii_clock", loose=True), 1e9/125e6)


### PR DESCRIPTION
The `create_clock -name sys_clk` entry was missing in the generated .xdc file, which leads to critical warnings in synthesis.

Adding this period constraint fixes it.