### PR TITLE
fix vc707 default_clk_period

### DIFF
--- a/litex_boards/platforms/vc707.py
+++ b/litex_boards/platforms/vc707.py
@@ -629,7 +629,7 @@ _connectors = [
 
 class Platform(XilinxPlatform):
     default_clk_name   = "clk156"
-    default_clk_period = 1e9/156.5e6
+    default_clk_period = 1e9/156.25e6
 
     def __init__(self):
         XilinxPlatform.__init__(self, "xc7vx485tffg1761-2", _io, _connectors, toolchain="vivado")


### PR DESCRIPTION
according to:
https://www.xilinx.com/support/documentation/boards_and_kits/vc707/ug885_VC707_Eval_Bd.pdf

and confirmed on hardware.