### PR TITLE
arrow_sockit: get video terminal working on VGA

### DIFF
--- a/litex_boards/platforms/arrow_sockit.py
+++ b/litex_boards/platforms/arrow_sockit.py
@@ -110,10 +110,11 @@ _io = [
 
     # VGA
     ("vga", 0,
-        Subsignal("hsync_n", Pins("AD12")),
-        Subsignal("vsync_n", Pins("AC12")),
         Subsignal("sync_n",  Pins("AG2")),
         Subsignal("blank_n", Pins("AH3")),
+        Subsignal("clk",     Pins("W20")),
+        Subsignal("hsync_n", Pins("AD12")),
+        Subsignal("vsync_n", Pins("AC12")),
         Subsignal("r", Pins("AG5  AA12 AB12 AF6  AG6  AJ2  AH5  AJ1")),
         Subsignal("g", Pins("Y21  AA25 AB26 AB22 AB23 AA24 AB25 AE27")),
         Subsignal("b", Pins("AE28 Y23  Y24  AG28 AF28 V23  W24  AF29")),

--- a/litex_boards/targets/arrow_sockit.py
+++ b/litex_boards/targets/arrow_sockit.py
@@ -19,16 +19,15 @@ import argparse
 
 from migen.fhdl.module      import Module
 from migen.fhdl.structure   import Signal, ClockDomain, ClockSignal
-from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.soc.cores.clock           import CycloneVPLL
 from litex.soc.integration.builder   import Builder, builder_args, builder_argdict
 from litex.soc.integration.soc_core  import SoCCore
 from litex.soc.integration.soc_sdram import soc_sdram_argdict, soc_sdram_args
 from litex.soc.cores.led             import LedChaser
+from litex.soc.cores.video           import VideoVGAPHY
 
-from litex.build.io import DDROutput
-from litex.build.generic_platform  import Pins, IOStandard, Subsignal
+from litex.build.io                  import DDROutput
 
 from litex_boards.platforms import arrow_sockit
 
@@ -80,6 +79,7 @@ class _CRG(Module):
         self.sdram_rate = sdram_rate
         self.rst = Signal()
         self.clock_domains.cd_sys    = ClockDomain()
+        self.clock_domains.cd_vga    = ClockDomain(reset_less=True)
         if with_sdram:
             if sdram_rate == "1:2":
                 self.clock_domains.cd_sys2x    = ClockDomain()
@@ -94,7 +94,8 @@ class _CRG(Module):
         self.submodules.pll = pll = CycloneVPLL(speedgrade="-C6")
         self.comb += pll.reset.eq(self.rst)
         pll.register_clkin(clk50, 50e6)
-        pll.create_clkout(self.cd_sys,    sys_clk_freq)
+        pll.create_clkout(self.cd_sys, sys_clk_freq)
+        pll.create_clkout(self.cd_vga, 65e6)
         if with_sdram:
             if sdram_rate == "1:2":
                 pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
@@ -110,7 +111,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), revision="revd", sdram_rate="1:2", mister_sdram=None, **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), revision="revd", sdram_rate="1:2", mister_sdram=None, with_video_terminal=False, **kwargs):
         platform = arrow_sockit.Platform(revision)
 
         # Defaults to UART over JTAG because serial is attached to the HPS and cannot be used.
@@ -157,6 +158,14 @@ class BaseSoC(SoCCore):
                 l2_cache_min_data_width = kwargs.get("min_l2_data_width", 128),
                 l2_cache_reverse        = True
             )
+        
+        # Video Terminal ---------------------------------------------------------------------------
+        if with_video_terminal:
+            vga_pads = platform.request("vga")
+            self.comb += [ vga_pads.sync_n.eq(0), vga_pads.blank_n.eq(1) ]
+            self.specials += DDROutput(i1=1, i2=0, o=vga_pads.clk, clk=ClockSignal("vga"))
+            self.submodules.videophy = VideoVGAPHY(vga_pads, clock_domain="vga")
+            self.add_video_terminal(phy=self.videophy, timings="1024x768@60Hz", clock_domain="vga")
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -169,6 +178,7 @@ def main():
     parser.add_argument("--load",                action="store_true", help="Load bitstream")
     parser.add_argument("--revision",            default="revd",      help="Board revision: revb (default), revc or revd")
     parser.add_argument("--sys-clk-freq",        default=50e6,        help="System clock frequency (default: 50MHz)")
+    parser.add_argument("--with-video-terminal", action="store_true", help="Enable Video Terminal (VGA)")
     builder_args(parser)
     soc_sdram_args(parser)
     args = parser.parse_args()
@@ -178,6 +188,7 @@ def main():
         revision            = args.revision,
         sdram_rate          = "1:1" if args.single_rate_sdram else "1:2",
         mister_sdram        = "xs_v22" if args.mister_sdram_xs_v22 else "xs_v24" if args.mister_sdram_xs_v24 else None,
+        with_video_terminal = args.with_video_terminal,
         **soc_sdram_argdict(args)
     )
     builder = Builder(soc, **builder_argdict(args))


### PR DESCRIPTION
![litex-sockit](https://user-images.githubusercontent.com/148607/111258881-6c745100-8650-11eb-84bc-c739292b3a13.jpg)
It's not perfect yet (the color timing of individual components seems to be off by one pixel,
but it is definitely useable.