### PR TITLE
fix #848: allow ram initialization in bitstream to enable block ram 

### DIFF
--- a/litex_boards/platforms/deca.py
+++ b/litex_boards/platforms/deca.py
@@ -287,6 +287,7 @@ class Platform(AlteraPlatform):
         self.add_platform_command("set_global_assignment -name AUTO_RESTART_CONFIGURATION ON")
         self.add_platform_command("set_global_assignment -name ENABLE_CONFIGURATION_PINS OFF")
         self.add_platform_command("set_global_assignment -name ENABLE_BOOT_SEL_PIN OFF")
+        self.add_platform_command("set_global_assignment -name INTERNAL_FLASH_UPDATE_MODE \"SINGLE IMAGE WITH ERAM\"")
 
     def create_programmer(self):
         return USBBlaster()


### PR DESCRIPTION
This is a fix for #848 [https://github.com/enjoy-digital/litex/issues/848](https://github.com/enjoy-digital/litex/issues/848)