### PR TITLE
Minor fixes for AU280 [work in progress]

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ PCIe accelerators boards that you could use to accelerate your applications, Lit
 | ForestKitten33 | Xilinx Ultrascale+  | XCVU33P       | 125MHz   | PCIe | 2 x 1024-bit 4GB HBM2*|  Gen3 X16     |     ?       |
 | BCU1525        | Xilinx Ultrascale+  | XCVU9P        | 125MHz   | PCIe | 4 x 64-bit DDR4 DIMM  |  Gen3 X16     |     ?       |
 | AlveoU250      | Xilinx Ultrascale+  | XCU250        | 125MHz   | PCIe | 4 x 64-bit DDR4 DIMM  |  Gen2 X16     |     ?       |
-| AlveoU280      | Xilinx Ultrascale+  | XCU280        | 125MHz   | PCIe* | 2 x 64-bit DDR4 DIMM* & HBM2*  |  Gen2 X16     |     ?       |
+| AlveoU280      | Xilinx Ultrascale+  | XCU280-ES1    | 150MHz   | PCIe* | 2 x 64-bit DDR4 DIMM <BR> 2 x 1024-bit 4GB HBM2* |  Gen2 X16     |     ?       |
 
 \* Present on the board but not yet supported or validated with LiteX.
 


### PR DESCRIPTION
Following the previous pull request, where some of the changes were merged manually, this pull request corrects a few minor details such as:
- LED component is now on-demand similar to how PCIe is because my board crashes when one of the LEDs is turned on (evaluation silicon issue)
- frequency of 150MHz_1:4_600MHz in target and description file
- pass `cmd_latency      = 1` and `iodelay_clk_freq = 600e6` arguments to PHY
- am not 100% sure about the sdram setting `size          = 0x80000000`

I tested litex boot and several memory tests and identified a failing test that hopefully will help us understand what is wrong about the ddr4 controller.
[au280ddr4tests.txt](https://github.com/litex-hub/litex-boards/files/6401319/au280ddr4tests.txt)
