### PR TITLE
de0nano-target: expose platform to inheriting classes for easier customization

### DIFF
--- a/litex_boards/targets/terasic_de0nano.py
+++ b/litex_boards/targets/terasic_de0nano.py
@@ -60,7 +60,7 @@ class _CRG(Module):
 
 class BaseSoC(SoCCore):
     def __init__(self, sys_clk_freq=int(50e6), sdram_rate="1:1", **kwargs):
-        platform = de0nano.Platform()
+        self.platform = platform = de0nano.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq,


### PR DESCRIPTION
This is necessary for inheriting targets to access the platform (eg to add extensions).