### PR TITLE
CYC1000: Add initial support of CYC1000 board

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The Colorlight5A is a very nice board to start with, cheap, powerful, easy to us
 | ArtyS7         | Xilinx Spartan7     | XC7S50        | 100MHz  | FTDI | 16-bit 256MB DDR3  |     No    |       No       |  16MB QSPI  |   No   |
 | Avalanche      | Microsemi PolarFire | MPF300TS      | 100MHz  | IOs  | 16-bit 256MB DDR3  |     No    |   1Gbps RGMII* |   8MB QSPI* |   No   |
 | C10LPRefKit    | Intel Cyclone10     | 10CL055       |  50MHz  | FTDI | 16-bit  32MB SDR   |     No    |  100Mbps MII   |  16MB QSPI  |   No   |
+| CYC1000        | Intel Cyclone10     | 10CL025       |  50MHz  | FTDI | 16-bit  64MB SDR   |     No    |       No       |  16MB QSPI* |   No   |
 | De0Nano        | Intel Cyclone4      | EP4CE22F      |  50MHz  | FTDI | 16-bit  32MB SDR   |     No    |       No       |      No     |   No   |
 | De10Lite       | Intel MAX10         | 10M50DA       |  50MHz  | IOs  | 16-bit  64MB SDR   |     No    |       No       |      No     |   No   |
 | DECA           | Intel MAX10         | 10M50DA       |  50MHz  | JTAG | 16-bit 512MB DDR3* |     No    |       Yes      |      No     |   Yes  |

--- a/litex_boards/platforms/trenz_cyc1000.py
+++ b/litex_boards/platforms/trenz_cyc1000.py
@@ -1,0 +1,82 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2021 Jakub Cabal <jakubcabal@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.altera import AlteraPlatform
+from litex.build.altera.programmer import USBBlaster
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("clk12", 0, Pins("M2"),  IOStandard("3.3-V LVTTL")),
+
+    # Leds
+    ("user_led", 0, Pins("M6"), IOStandard("3.3-V LVTTL")),
+    ("user_led", 1, Pins("T4"), IOStandard("3.3-V LVTTL")),
+    ("user_led", 2, Pins("T3"), IOStandard("3.3-V LVTTL")),
+    ("user_led", 3, Pins("R3"), IOStandard("3.3-V LVTTL")),
+    ("user_led", 4, Pins("T2"), IOStandard("3.3-V LVTTL")),
+    ("user_led", 5, Pins("R4"), IOStandard("3.3-V LVTTL")),
+    ("user_led", 6, Pins("N5"), IOStandard("3.3-V LVTTL")),
+    ("user_led", 7, Pins("N3"), IOStandard("3.3-V LVTTL")),
+
+    # Button
+    ("key", 0, Pins("N6"), IOStandard("3.3-V LVTTL")),
+
+    # Serial
+    ("serial", 0,
+        Subsignal("tx", Pins("T7"), IOStandard("3.3-V LVTTL")),
+        Subsignal("rx", Pins("R7"), IOStandard("3.3-V LVTTL")),
+    ),
+     # SDR SDRAM
+    ("sdram_clock", 0, Pins("B14"), IOStandard("3.3-V LVTTL")),
+    ("sdram", 0,
+        Subsignal("a", Pins(
+            "A3 B5 B4 B3 C3 D3 E6 E7",
+            "D6 D8 A5 E8 A2 C6")),
+        Subsignal("ba",    Pins("A4 B6")),
+        Subsignal("cs_n",  Pins("A6")),
+        Subsignal("cke",   Pins("F8")),
+        Subsignal("ras_n", Pins("B7")),
+        Subsignal("cas_n", Pins("C8")),
+        Subsignal("we_n",  Pins("A7")),
+        Subsignal("dq", Pins(
+            "B10 A10 B11 A11 A12 D9 B12 C9",
+            "D11 E11 A15 E9 D14 F9 C14 A14")),
+        Subsignal("dm", Pins("B13 D12")),
+        IOStandard("3.3-V LVTTL")
+    ),
+
+    # ECPQ
+    ("epcq", 0,
+        Subsignal("data0", Pins("H2")),
+        Subsignal("dclk",  Pins("H1")),
+        Subsignal("ncs0",  Pins("D2")),
+        Subsignal("asd0",  Pins("C1")),
+        IOStandard("3.3-V LVTTL")
+    ),
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(AlteraPlatform):
+    default_clk_name   = "clk12"
+    default_clk_period = 1e9/12e6
+
+    def __init__(self):
+        AlteraPlatform.__init__(self, "10CL025YU256C8G", _io)
+
+    def create_programmer(self):
+        return USBBlaster(cable_name="Arrow-USB-Blaster")
+
+    def do_finalize(self, fragment):
+        AlteraPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk12", loose=True), 1e9/12e6)
+        # Generate PLL clock in STA
+        self.toolchain.additional_sdc_commands.append("derive_pll_clocks")
+        # Calculates clock uncertainties
+        self.toolchain.additional_sdc_commands.append("derive_clock_uncertainty")

--- a/litex_boards/targets/trenz_cyc1000.py
+++ b/litex_boards/targets/trenz_cyc1000.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2021 Jakub Cabal <jakubcabal@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import argparse
+
+from migen import *
+
+from litex_boards.platforms import cyc1000
+
+from litex.soc.cores.clock import Cyclone10LPPLL
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+
+from litedram.modules import M12L64322A
+from litedram.phy import GENSDRPHY
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst = Signal()
+        self.clock_domains.cd_sys    = ClockDomain()
+        self.clock_domains.cd_sys_ps = ClockDomain(reset_less=True)
+
+        # # #
+
+        # Clk / Rst
+        clk12 = platform.request("clk12")
+
+        # PLL
+        self.submodules.pll = pll = Cyclone10LPPLL(speedgrade="-C8")
+        self.comb += pll.reset.eq(self.rst)
+        pll.register_clkin(clk12, 12e6)
+        pll.create_clkout(self.cd_sys,    sys_clk_freq)
+        pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
+
+        # SDRAM clock
+        self.comb += platform.request("sdram_clock").eq(self.cd_sys_ps.clk)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=int(50e6), **kwargs):
+        platform = cyc1000.Platform()
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            ident          = "LiteX SoC on CYC1000",
+            ident_version  = True,
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+
+        # SDR SDRAM --------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.submodules.sdrphy = GENSDRPHY(platform.request("sdram"), sys_clk_freq)
+            self.add_sdram("sdram",
+                phy           = self.sdrphy,
+                module        = M12L64322A(sys_clk_freq, "1:1"), # Winbond W9864G6JT
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
+
+        # Leds -------------------------------------------------------------------------------------
+        self.submodules.leds = LedChaser(
+            pads         = platform.request_all("user_led"),
+            sys_clk_freq = sys_clk_freq)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on CYC1000")
+    parser.add_argument("--build",         action="store_true", help="Build bitstream")
+    parser.add_argument("--load",          action="store_true", help="Load bitstream")
+    parser.add_argument("--sys-clk-freq",  default=50e6,        help="System clock frequency (default: 50MHz)")
+    builder_args(parser)
+    soc_core_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq  = int(float(args.sys_clk_freq)),
+        **soc_core_argdict(args)
+    )
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build(run=args.build)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".sof"))
+
+if __name__ == "__main__":
+    main()

--- a/test/test_targets.py
+++ b/test/test_targets.py
@@ -91,6 +91,7 @@ class TestTargets(unittest.TestCase):
 
         # Intel Cyclone10
         platforms.append("c10lprefkit")
+        platforms.append("cyc1000")
 
         # Intel Max10
         platforms.append("de10lite")


### PR DESCRIPTION
I prepared the initial support for the CYC1000 board by Trenz Electronic. Tested on HW, the generated design boots fine.