### PR TITLE
Fix colorlight 5a 75b v6.1 flash pins

### DIFF
--- a/litex_boards/platforms/colorlight_5a_75b.py
+++ b/litex_boards/platforms/colorlight_5a_75b.py
@@ -34,7 +34,7 @@ _io_v6_1 = [ # Documented by @smunaut
     # SPIFlash (GD25Q16CSIG)
     ("spiflash", 0,
         Subsignal("cs_n", Pins("R2")),
-        Subsignal("clk",  Pins("U3")),
+        #Subsignal("clk",  Pins("")), driven through USRMCLK
         Subsignal("mosi", Pins("W2")),
         Subsignal("miso", Pins("V2")),
         IOStandard("LVCMOS33"),


### PR DESCRIPTION
As with the other versions, the clk pin can't be directly driven and has to be used with the usrmclk primitive. Tested, reading works