### PR TITLE
setup.py: Exclude test package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
     license="BSD",
     python_requires="~=3.6",
     include_package_data=True,
-    packages=find_packages(),
+    packages=find_packages(exclude=['test*']),
 )


### PR DESCRIPTION
Otherwise setuptools finds an additional `test` package.