### PR TITLE
Add with_led_chaser argument to constructor of boards using LedChaser submodule.

### DIFF
--- a/litex_boards/targets/1bitsquared_icebreaker.py
+++ b/litex_boards/targets/1bitsquared_icebreaker.py
@@ -70,7 +70,8 @@ class _CRG(Module):
 
 class BaseSoC(SoCCore):
     mem_map = {**SoCCore.mem_map, **{"spiflash": 0x80000000}}
-    def __init__(self, bios_flash_offset, sys_clk_freq=int(24e6), with_video_terminal=False, **kwargs):
+    def __init__(self, bios_flash_offset, sys_clk_freq=int(24e6), with_led_chaser=True,
+                 with_video_terminal=False, **kwargs):
         platform = icebreaker.Platform()
         platform.add_extension(icebreaker.break_off_pmod)
 
@@ -111,9 +112,10 @@ class BaseSoC(SoCCore):
             self.add_video_terminal(phy=self.videophy, timings="640x480@75Hz", clock_domain="sys")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Flash --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/antmicro_lpddr4_test_board.py
+++ b/litex_boards/targets/antmicro_lpddr4_test_board.py
@@ -55,7 +55,7 @@ class BaseSoC(SoCCore):
     def __init__(self, *, sys_clk_freq=int(50e6), iodelay_clk_freq=200e6,
             with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", eth_dynamic_ip=False,
             with_hyperram=False, with_sdcard=False, with_jtagbone=True, with_uartbone=False,
-            ident_version=True, **kwargs):
+            with_led_chaser=True, ident_version=True, **kwargs):
         platform = lpddr4_test_board.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -113,9 +113,10 @@ class BaseSoC(SoCCore):
             self.add_uartbone("serial", baudrate=1e6)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/camlink_4k.py
+++ b/litex_boards/targets/camlink_4k.py
@@ -72,7 +72,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, toolchain="trellis", **kwargs):
+    def __init__(self, toolchain="trellis", with_led_chaser=True, **kwargs):
         platform     = camlink_4k.Platform(toolchain=toolchain)
         sys_clk_freq = int(81e6)
 
@@ -98,7 +98,8 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        if platform.lookup_request("serial", loose=True) is None: # Disable leds when serial is used.
+        # Disable leds when serial is used.
+        if platform.lookup_request("serial", loose=True) is None and with_led_chaser:
             self.submodules.leds = LedChaser(
                 pads         = platform.request_all("user_led"),
                 sys_clk_freq = sys_clk_freq)

--- a/litex_boards/targets/colorlight_5a_75x.py
+++ b/litex_boards/targets/colorlight_5a_75x.py
@@ -119,7 +119,9 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, board, revision, sys_clk_freq=60e6, with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", eth_phy=0, use_internal_osc=False, sdram_rate="1:1", **kwargs):
+    def __init__(self, board, revision, sys_clk_freq=60e6, with_ethernet=False,
+                 with_etherbone=False, eth_ip="192.168.1.50", eth_phy=0, with_led_chaser=True,
+                 use_internal_osc=False, sdram_rate="1:1", **kwargs):
         board = board.lower()
         assert board in ["5a-75b", "5a-75e"]
         if board == "5a-75b":
@@ -167,7 +169,8 @@ class BaseSoC(SoCCore):
                 self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
 
         # Leds -------------------------------------------------------------------------------------
-        if platform.lookup_request("serial", loose=True) is None: # Disable leds when serial is used.
+        # Disable leds when serial is used.
+        if platform.lookup_request("serial", loose=True) is None and with_led_chaser:
             self.submodules.leds = LedChaser(
                 pads         = platform.request_all("user_led_n"),
                 sys_clk_freq = sys_clk_freq)

--- a/litex_boards/targets/colorlight_i5.py
+++ b/litex_boards/targets/colorlight_i5.py
@@ -99,7 +99,10 @@ class _CRG(Module):
 
 class BaseSoC(SoCCore):
     mem_map = {**SoCCore.mem_map, **{"spiflash": 0xd0000000}}
-    def __init__(self, board="i5", revision="7.0", sys_clk_freq=60e6, with_ethernet=False, with_etherbone=False, local_ip="", remote_ip="", eth_phy=0, use_internal_osc=False, sdram_rate="1:1", with_video_terminal=False, with_video_framebuffer=False, **kwargs):
+    def __init__(self, board="i5", revision="7.0", sys_clk_freq=60e6, with_ethernet=False,
+                 with_etherbone=False, local_ip="", remote_ip="", eth_phy=0, with_led_chaser=True, 
+                 use_internal_osc=False, sdram_rate="1:1", with_video_terminal=False,
+                 with_video_framebuffer=False, **kwargs):
         board = board.lower()
         assert board in ["i5"]
         if board == "i5":
@@ -117,8 +120,9 @@ class BaseSoC(SoCCore):
         self.submodules.crg = _CRG(platform, sys_clk_freq, use_internal_osc=use_internal_osc, with_usb_pll=with_usb_pll, with_video_pll=with_video_pll, sdram_rate=sdram_rate)
 
         # Leds -------------------------------------------------------------------------------------
-        ledn = platform.request_all("user_led_n")
-        self.submodules.leds = LedChaser(pads=ledn, sys_clk_freq=sys_clk_freq)
+        if with_led_chaser:
+            ledn = platform.request_all("user_led_n")
+            self.submodules.leds = LedChaser(pads=ledn, sys_clk_freq=sys_clk_freq)
 
         # SPI Flash --------------------------------------------------------------------------------
         self.add_spi_flash(mode="1x", dummy_cycles=8)

--- a/litex_boards/targets/digilent_arty.py
+++ b/litex_boards/targets/digilent_arty.py
@@ -61,7 +61,10 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, variant="a7-35", toolchain="vivado", sys_clk_freq=int(100e6), with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", eth_dynamic_ip=False, ident_version=True, with_jtagbone=True, with_mapped_flash=False, **kwargs):
+    def __init__(self, variant="a7-35", toolchain="vivado", sys_clk_freq=int(100e6),
+                 with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50",
+                 eth_dynamic_ip=False, ident_version=True, with_led_chaser=True, with_jtagbone=True,
+                 with_mapped_flash=False, **kwargs):
         platform = arty.Platform(variant=variant, toolchain=toolchain)
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -107,9 +110,10 @@ class BaseSoC(SoCCore):
             self.bus.add_slave(name="spiflash", slave=self.spiflash_mmap.bus, region=spiflash_region)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/digilent_arty_s7.py
+++ b/litex_boards/targets/digilent_arty_s7.py
@@ -51,7 +51,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, variant="s7-50", sys_clk_freq=int(100e6), **kwargs):
+    def __init__(self, variant="s7-50", sys_clk_freq=int(100e6), with_led_chaser=True, **kwargs):
         platform = arty_s7.Platform(variant=variant)
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -76,9 +76,10 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/digilent_basys3.py
+++ b/litex_boards/targets/digilent_basys3.py
@@ -40,7 +40,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(75e6), with_video_terminal=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(75e6), with_led_chaser=True, with_video_terminal=False, **kwargs):
         platform = basys3.Platform()
 
         # SoCCore ----------------------------------_-----------------------------------------------
@@ -59,9 +59,10 @@ class BaseSoC(SoCCore):
                 self.add_video_terminal(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------  
 def main():

--- a/litex_boards/targets/digilent_genesys2.py
+++ b/litex_boards/targets/digilent_genesys2.py
@@ -47,7 +47,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), with_ethernet=False, with_etherbone=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), with_ethernet=False, with_etherbone=False,
+                 with_led_chaser=True, **kwargs):
         platform = genesys2.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -82,9 +83,10 @@ class BaseSoC(SoCCore):
                 self.add_etherbone(phy=self.ethphy)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/digilent_nexys4ddr.py
+++ b/litex_boards/targets/digilent_nexys4ddr.py
@@ -54,7 +54,9 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(75e6), with_ethernet=False, with_etherbone=False, with_video_terminal=False, with_video_framebuffer=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(75e6), with_ethernet=False, with_etherbone=False,
+                 with_led_chaser=True, with_video_terminal=False, with_video_framebuffer=False,
+                 **kwargs):
         platform = nexys4ddr.Platform()
 
         # SoCCore ----------------------------------_-----------------------------------------------
@@ -97,9 +99,10 @@ class BaseSoC(SoCCore):
                 self.add_video_framebuffer(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/digilent_nexys_video.py
+++ b/litex_boards/targets/digilent_nexys_video.py
@@ -71,7 +71,9 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, toolchain="vivado", sys_clk_freq=int(100e6), with_ethernet=False, with_sata=False, vadj="1.2V", with_video_terminal=False, with_video_framebuffer=False, **kwargs):
+    def __init__(self, toolchain="vivado", sys_clk_freq=int(100e6), with_ethernet=False,
+                 with_led_chaser=True, with_sata=False, vadj="1.2V", with_video_terminal=False,
+                 with_video_framebuffer=False, **kwargs):
         platform = nexys_video.Platform(toolchain=toolchain)
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -141,9 +143,10 @@ class BaseSoC(SoCCore):
                 self.add_video_framebuffer(phy=self.videophy, timings="800x600@60Hz", clock_domain="hdmi")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
         # VADJ -------------------------------------------------------------------------------------
         vadj_map = {"1.2V": 0b00, "1.8V": 0b01, "2.5V": 0b10, "3.3V": 0b11}

--- a/litex_boards/targets/ego1.py
+++ b/litex_boards/targets/ego1.py
@@ -39,7 +39,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), with_vga=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), with_led_chaser=True, with_vga=False, **kwargs):
         platform = ego1.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -65,10 +65,11 @@ class BaseSoC(SoCCore):
             ]
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
-        self.add_csr("leds")
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+            self.add_csr("leds")
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/enclustra_mercury_kx2.py
+++ b/litex_boards/targets/enclustra_mercury_kx2.py
@@ -46,7 +46,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(125e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), with_led_chaser=True, **kwargs):
         platform = mercury_kx2.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -71,9 +71,10 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/enclustra_mercury_xu5.py
+++ b/litex_boards/targets/enclustra_mercury_xu5.py
@@ -54,7 +54,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(125e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), with_led_chaser=True, **kwargs):
         platform = mercury_xu5.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -79,9 +79,10 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/fpc_iii.py
+++ b/litex_boards/targets/fpc_iii.py
@@ -80,7 +80,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(80e6), toolchain="trellis", with_ethernet=False, with_etherbone=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(80e6), toolchain="trellis", with_ethernet=False,
+                 with_etherbone=False, with_led_chaser=True, **kwargs):
         platform = fpc_iii.Platform(toolchain=toolchain)
 
         # Serial -----------------------------------------------------------------------------------
@@ -123,9 +124,10 @@ class BaseSoC(SoCCore):
                 self.add_etherbone(phy=self.ethphy)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/gsd_orangecrab.py
+++ b/litex_boards/targets/gsd_orangecrab.py
@@ -147,7 +147,7 @@ class _CRGSDRAM(Module):
 
 class BaseSoC(SoCCore):
     def __init__(self, revision="0.2", device="25F", sdram_device="MT41K64M16",
-                 sys_clk_freq=int(48e6), toolchain="trellis", **kwargs):
+                 sys_clk_freq=int(48e6), toolchain="trellis", with_led_chaser=True, **kwargs):
         platform = orangecrab.Platform(revision=revision, device=device ,toolchain=toolchain)
 
         # Serial -----------------------------------------------------------------------------------
@@ -197,9 +197,10 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/kosagi_fomu.py
+++ b/litex_boards/targets/kosagi_fomu.py
@@ -70,7 +70,7 @@ class _CRG(Module):
 
 class BaseSoC(SoCCore):
     mem_map = {**SoCCore.mem_map, **{"spiflash": 0x80000000}}
-    def __init__(self, bios_flash_offset, sys_clk_freq=int(12e6), **kwargs):
+    def __init__(self, bios_flash_offset, sys_clk_freq=int(12e6), with_led_chaser=True, **kwargs):
         kwargs["uart_name"] = "usb_acm" # Enforce UART to USB-ACM
         platform = fomu_pvt.Platform()
 
@@ -110,9 +110,10 @@ class BaseSoC(SoCCore):
         )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led_n"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led_n"),
+                sys_clk_freq = sys_clk_freq)
 
 # Flash --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/kosagi_netv2.py
+++ b/litex_boards/targets/kosagi_netv2.py
@@ -61,7 +61,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, variant="a7-35", sys_clk_freq=int(100e6), with_pcie=False, with_ethernet=False, **kwargs):
+    def __init__(self, variant="a7-35", sys_clk_freq=int(100e6), with_pcie=False,
+                 with_ethernet=False, with_led_chaser=True, **kwargs):
         platform = netv2.Platform(variant=variant)
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -100,9 +101,10 @@ class BaseSoC(SoCCore):
             self.add_pcie(phy=self.pcie_phy, ndmas=1)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/lambdaconcept_ecpix5.py
+++ b/litex_boards/targets/lambdaconcept_ecpix5.py
@@ -78,7 +78,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, device="85F", sys_clk_freq=int(75e6), with_ethernet=False, with_etherbone=False, **kwargs):
+    def __init__(self, device="85F", sys_clk_freq=int(75e6), with_ethernet=False,
+                 with_etherbone=False, with_led_chaser=True, **kwargs):
         platform = ecpix5.Platform(device=device, toolchain="trellis")
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -115,14 +116,15 @@ class BaseSoC(SoCCore):
                 self.add_etherbone(phy=self.ethphy)
 
         # Leds -------------------------------------------------------------------------------------
-        leds_pads = []
-        for i in range(4):
-            rgb_led_pads = platform.request("rgb_led", i)
-            self.comb += [getattr(rgb_led_pads, n).eq(1) for n in "gb"] # Disable Green/Blue Leds.
-            leds_pads += [getattr(rgb_led_pads, n) for n in "r"]
-        self.submodules.leds = LedChaser(
-            pads         = Cat(leds_pads),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            leds_pads = []
+            for i in range(4):
+                rgb_led_pads = platform.request("rgb_led", i)
+                self.comb += [getattr(rgb_led_pads, n).eq(1) for n in "gb"] # Disable Green/Blue Leds.
+                leds_pads += [getattr(rgb_led_pads, n) for n in "r"]
+            self.submodules.leds = LedChaser(
+                pads         = Cat(leds_pads),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/lattice_crosslink_nx_evn.py
+++ b/litex_boards/targets/lattice_crosslink_nx_evn.py
@@ -68,7 +68,7 @@ class BaseSoC(SoCCore):
         "sram" : 0x40000000,
         "csr"  : 0xf0000000,
     }
-    def __init__(self, sys_clk_freq=int(75e6), toolchain="radiant", **kwargs):
+    def __init__(self, sys_clk_freq=int(75e6), toolchain="radiant", with_led_chaser=True, **kwargs):
         platform = crosslink_nx_evn.Platform(toolchain=toolchain)
         platform.add_platform_command("ldc_set_sysconfig {{MASTER_SPI_PORT=SERIAL}}")
 
@@ -93,9 +93,10 @@ class BaseSoC(SoCCore):
         self.register_mem("sram", self.mem_map["sram"], self.spram.bus, size)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = Cat(*[platform.request("user_led", i) for i in range(14)]),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = Cat(*[platform.request("user_led", i) for i in range(14)]),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/lattice_crosslink_nx_vip.py
+++ b/litex_boards/targets/lattice_crosslink_nx_vip.py
@@ -69,7 +69,8 @@ class BaseSoC(SoCCore):
         "sram": 0x40000000,
         "csr":  0xf0000000,
     }
-    def __init__(self, sys_clk_freq=int(75e6), hyperram="none", toolchain="radiant", **kwargs):
+    def __init__(self, sys_clk_freq=int(75e6), hyperram="none", toolchain="radiant",
+                 with_led_chaser=True, **kwargs):
         platform = crosslink_nx_vip.Platform(toolchain=toolchain)
         platform.add_platform_command("ldc_set_sysconfig {{MASTER_SPI_PORT=SERIAL}}")
 
@@ -98,9 +99,10 @@ class BaseSoC(SoCCore):
             self.register_mem("sram", self.mem_map["sram"], self.hyperram.bus, size)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = Cat(*[platform.request("user_led", i) for i in range(4)]),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = Cat(*[platform.request("user_led", i) for i in range(4)]),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/lattice_ecp5_evn.py
+++ b/litex_boards/targets/lattice_ecp5_evn.py
@@ -45,7 +45,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), x5_clk_freq=None, toolchain="trellis", **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), x5_clk_freq=None, toolchain="trellis",
+                 with_led_chaser=True, **kwargs):
         platform = ecp5_evn.Platform(toolchain=toolchain)
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -59,9 +60,10 @@ class BaseSoC(SoCCore):
         self.submodules.crg = crg
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/lattice_ice40up5k_evn.py
+++ b/litex_boards/targets/lattice_ice40up5k_evn.py
@@ -63,7 +63,7 @@ class _CRG(Module):
 
 class BaseSoC(SoCCore):
     mem_map = {**SoCCore.mem_map, **{"spiflash": 0x80000000}}
-    def __init__(self, bios_flash_offset, sys_clk_freq=int(12e6), **kwargs):
+    def __init__(self, bios_flash_offset, sys_clk_freq=int(12e6), with_led_chaser=True, **kwargs):
         platform = lattice_ice40up5k_evn.Platform()
 
         # Disable Integrated ROM/SRAM since too large for iCE40 and UP5K has specific SPRAM.
@@ -98,9 +98,10 @@ class BaseSoC(SoCCore):
         )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led_n"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led_n"),
+                sys_clk_freq = sys_clk_freq)
 
         # Add a UART-Wishbone bridge -----------------------------------------
         debug_uart=False

--- a/litex_boards/targets/lattice_versa_ecp5.py
+++ b/litex_boards/targets/lattice_versa_ecp5.py
@@ -78,7 +78,9 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(75e6), device="LFE5UM5G", with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", eth_phy=0, toolchain="trellis", **kwargs):
+    def __init__(self, sys_clk_freq=int(75e6), device="LFE5UM5G", with_ethernet=False,
+                 with_etherbone=False, with_led_chaser=True, eth_ip="192.168.1.50", eth_phy=0,
+                 toolchain="trellis", **kwargs):
         platform = versa_ecp5.Platform(toolchain=toolchain, device=device)
 
         # FIXME: adapt integrated rom size for Microwatt
@@ -120,9 +122,10 @@ class BaseSoC(SoCCore):
                 self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/linsn_rv901t.py
+++ b/litex_boards/targets/linsn_rv901t.py
@@ -50,7 +50,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(75e6), with_ethernet=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(75e6), with_ethernet=False, with_led_chaser=True, **kwargs):
         platform     = linsn_rv901t.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -79,9 +79,10 @@ class BaseSoC(SoCCore):
             self.add_ethernet(phy=self.ethphy)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/logicbone.py
+++ b/litex_boards/targets/logicbone.py
@@ -92,9 +92,10 @@ class _CRG(Module):
 
 class BaseSoC(SoCCore):
     def __init__(self, revision="rev0", device="45F", sdram_device="MT41K512M16",
-                 sys_clk_freq  = int(75e6),
-                 with_ethernet = False,
-                 toolchain     = "trellis",
+                 sys_clk_freq    = int(75e6),
+                 with_ethernet   = False,
+                 with_led_chaser = True,
+                 toolchain       = "trellis",
                  **kwargs):
         platform = logicbone.Platform(revision=revision, device=device ,toolchain=toolchain)
 
@@ -142,9 +143,10 @@ class BaseSoC(SoCCore):
 
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/mist.py
+++ b/litex_boards/targets/mist.py
@@ -54,7 +54,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), with_video_terminal=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), with_led_chaser=True, with_video_terminal=False,
+                 **kwargs):
         platform = mist.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -81,9 +82,10 @@ class BaseSoC(SoCCore):
             self.add_video_terminal(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/muselab_icesugar.py
+++ b/litex_boards/targets/muselab_icesugar.py
@@ -58,7 +58,8 @@ class _CRG(Module):
 
 class BaseSoC(SoCCore):
     mem_map = {**SoCCore.mem_map, **{"spiflash": 0x80000000}}
-    def __init__(self, bios_flash_offset, sys_clk_freq=int(24e6), with_video_terminal=False, **kwargs):
+    def __init__(self, bios_flash_offset, sys_clk_freq=int(24e6), with_led_chaser=True,
+                 with_video_terminal=False, **kwargs):
         platform = muselab_icesugar.Platform()
 
         # Disable Integrated ROM/SRAM since too large for iCE40 and UP5K has specific SPRAM.
@@ -93,10 +94,11 @@ class BaseSoC(SoCCore):
         )
 
         # Leds -------------------------------------------------------------------------------------
-        led_pads = platform.request_all("user_led_n")
-        self.submodules.leds = LedChaser(
-            pads         = led_pads,
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            led_pads = platform.request_all("user_led_n")
+            self.submodules.leds = LedChaser(
+                pads         = led_pads,
+                sys_clk_freq = sys_clk_freq)
 
 # Flash --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/numato_aller.py
+++ b/litex_boards/targets/numato_aller.py
@@ -56,7 +56,7 @@ class CRG(Module):
 # BaseSoC -----------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), with_pcie=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), with_led_chaser=True, with_pcie=False, **kwargs):
         platform = aller.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -91,9 +91,10 @@ class BaseSoC(SoCCore):
             self.add_pcie(phy=self.pcie_phy, ndmas=1)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/numato_mimas_a7.py
+++ b/litex_boards/targets/numato_mimas_a7.py
@@ -51,7 +51,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), with_ethernet=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), with_led_chaser=True, with_ethernet=False,
+                 **kwargs):
         platform = mimas_a7.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -83,9 +84,10 @@ class BaseSoC(SoCCore):
             self.add_ethernet(phy=self.ethphy)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/numato_tagus.py
+++ b/litex_boards/targets/numato_tagus.py
@@ -57,7 +57,7 @@ class CRG(Module):
 # BaseSoC -----------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), with_pcie=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), with_led_chaser=True, with_pcie=False, **kwargs):
         platform = tagus.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -91,9 +91,10 @@ class BaseSoC(SoCCore):
             self.add_pcie(phy=self.pcie_phy, ndmas=1)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/pano_logic_g2.py
+++ b/litex_boards/targets/pano_logic_g2.py
@@ -44,7 +44,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, revision, sys_clk_freq=int(50e6), with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", **kwargs):
+    def __init__(self, revision, sys_clk_freq=int(50e6), with_ethernet=False, with_etherbone=False,
+                 eth_ip="192.168.1.50", with_led_chaser=True, **kwargs):
         platform = pano_logic_g2.Platform(revision=revision)
         if with_etherbone:
             sys_clk_freq = int(125e6)
@@ -71,9 +72,10 @@ class BaseSoC(SoCCore):
                 self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/qmtech_ep4ce15.py
+++ b/litex_boards/targets/qmtech_ep4ce15.py
@@ -75,7 +75,7 @@ class _CRG(Module):
 class BaseSoC(SoCCore):
     def __init__(self, sys_clk_freq=int(50e6), with_daughterboard=False,
                  with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", eth_dynamic_ip=False,
-                 with_video_terminal=False, with_video_framebuffer=False,
+                 with_led_chaser=True, with_video_terminal=False, with_video_framebuffer=False,
                  ident_version=True, sdram_rate="1:1", **kwargs):
         platform = qmtech_ep4ce15.Platform(with_daughterboard=with_daughterboard)
 
@@ -120,9 +120,10 @@ class BaseSoC(SoCCore):
                 self.add_video_framebuffer(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/qmtech_wukong.py
+++ b/litex_boards/targets/qmtech_wukong.py
@@ -74,7 +74,9 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", with_video_terminal=False, with_video_framebuffer=False, video_timing="640x480@60Hz", **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), with_ethernet=False, with_etherbone=False,
+                 eth_ip="192.168.1.50", with_led_chaser=True, with_video_terminal=False,
+                 with_video_framebuffer=False, video_timing="640x480@60Hz", **kwargs):
         platform = qmtech_wukong.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -111,9 +113,10 @@ class BaseSoC(SoCCore):
                 self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
         # Video ------------------------------------------------------------------------------------
         if with_video_terminal or with_video_framebuffer:

--- a/litex_boards/targets/qmtech_xc7a35t.py
+++ b/litex_boards/targets/qmtech_xc7a35t.py
@@ -76,7 +76,7 @@ class _CRG(Module):
 class BaseSoC(SoCCore):
     def __init__(self, toolchain="vivado", sys_clk_freq=int(100e6), with_daughterboard=False,
                  with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", eth_dynamic_ip=False,
-                 with_video_terminal=False, with_video_framebuffer=False,
+                 with_led_chaser=True, with_video_terminal=False, with_video_framebuffer=False,
                  ident_version=True, with_jtagbone=True, with_mapped_flash=False, **kwargs):
         platform = qmtech_xc7a35t.Platform(toolchain=toolchain, with_daughterboard=with_daughterboard)
 
@@ -133,9 +133,10 @@ class BaseSoC(SoCCore):
                 self.add_video_framebuffer(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
         if not with_daughterboard and kwargs["uart_name"] == "serial":
             kwargs["uart_name"] = "jtag_serial"

--- a/litex_boards/targets/radiona_ulx3s.py
+++ b/litex_boards/targets/radiona_ulx3s.py
@@ -92,7 +92,8 @@ class _CRG(Module):
 class BaseSoC(SoCCore):
     def __init__(self, device="LFE5U-45F", revision="2.0", toolchain="trellis",
         sys_clk_freq=int(50e6), sdram_module_cls="MT48LC16M16", sdram_rate="1:1",
-        with_video_terminal=False, with_video_framebuffer=False, spiflash=False, **kwargs):
+        with_led_chaser=True, with_video_terminal=False, with_video_framebuffer=False,
+        spiflash=False, **kwargs):
         platform = ulx3s.Platform(device=device, revision=revision, toolchain=toolchain)
         if spiflash:
             self.mem_map = {**SoCCore.mem_map, **{"spiflash": 0x80000000}}
@@ -130,9 +131,10 @@ class BaseSoC(SoCCore):
                 self.comb += platform.request("ext0p").eq(self.video_framebuffer.underflow) # FIXME: Remove, used to debug SDRAM underflows.
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
     def add_oled(self):
         pads = self.platform.request("oled_spi")

--- a/litex_boards/targets/redpitaya.py
+++ b/litex_boards/targets/redpitaya.py
@@ -47,7 +47,7 @@ class _CRG(Module):
 
 
 class BaseSoC(SoCCore):
-    def __init__(self, board, sys_clk_freq=int(100e6), **kwargs):
+    def __init__(self, board, sys_clk_freq=int(100e6), with_led_chaser=True, **kwargs):
         platform = redpitaya.Platform(board)
 
         if kwargs["uart_name"] == "serial":
@@ -83,9 +83,10 @@ class BaseSoC(SoCCore):
         self.submodules.crg = _CRG(platform, sys_clk_freq, use_ps7_clk)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/saanlima_pipistrello.py
+++ b/litex_boards/targets/saanlima_pipistrello.py
@@ -153,7 +153,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, **kwargs):
+    def __init__(self, with_led_chaser=True, **kwargs):
         sys_clk_freq = (83 + Fraction(1, 3))*1000*1000
         platform     = pipistrello.Platform()
 
@@ -185,9 +185,10 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/scarabhardware_minispartan6.py
+++ b/litex_boards/targets/scarabhardware_minispartan6.py
@@ -68,7 +68,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(80e6), sdram_rate="1:1", with_video_terminal=False, with_video_framebuffer=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(80e6), sdram_rate="1:1", with_led_chaser=True,
+                 with_video_terminal=False, with_video_framebuffer=False, **kwargs):
         platform = minispartan6.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -100,9 +101,10 @@ class BaseSoC(SoCCore):
                 self.add_video_framebuffer(phy=self.videophy, timings="640x480@75Hz", clock_domain="hdmi")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/simple.py
+++ b/litex_boards/targets/simple.py
@@ -23,7 +23,7 @@ from litex.soc.cores.led import LedChaser
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, platform, with_ethernet=False, **kwargs):
+    def __init__(self, platform, with_ethernet=False, with_led_chaser=True, **kwargs):
         sys_clk_freq = int(1e9/platform.default_clk_period)
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -37,9 +37,10 @@ class BaseSoC(SoCCore):
 
         # Leds -------------------------------------------------------------------------------------
         try:
-            self.submodules.leds = LedChaser(
-                pads         = platform.request_all("user_led"),
-                sys_clk_freq = sys_clk_freq)
+            if with_led_chaser:
+                self.submodules.leds = LedChaser(
+                    pads         = platform.request_all("user_led"),
+                    sys_clk_freq = sys_clk_freq)
         except:
             pass
 

--- a/litex_boards/targets/sqrl_acorn.py
+++ b/litex_boards/targets/sqrl_acorn.py
@@ -72,7 +72,8 @@ class CRG(Module):
 # BaseSoC -----------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, variant="cle-215+", sys_clk_freq=int(100e6), with_pcie=False, with_sata=False, **kwargs):
+    def __init__(self, variant="cle-215+", sys_clk_freq=int(100e6), with_led_chaser=True,
+                 with_pcie=False, with_sata=False, **kwargs):
         platform = acorn.Platform(variant=variant)
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -157,9 +158,10 @@ class BaseSoC(SoCCore):
             self.add_sata(phy=self.sata_phy, mode="read+write")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/sqrl_fk33.py
+++ b/litex_boards/targets/sqrl_fk33.py
@@ -43,7 +43,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(125e6), with_pcie=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), with_led_chaser=True, with_pcie=False, **kwargs):
         platform = fk33.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -92,9 +92,10 @@ class BaseSoC(SoCCore):
                 self.add_constant(k + "_INTERRUPT", i)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/sqrl_xcu1525.py
+++ b/litex_boards/targets/sqrl_xcu1525.py
@@ -57,7 +57,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(125e6), ddram_channel=0, with_pcie=False, with_sata=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), ddram_channel=0, with_led_chaser=True,
+                 with_pcie=False, with_sata=False, **kwargs):
         platform = xcu1525.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -126,9 +127,10 @@ class BaseSoC(SoCCore):
             self.add_sata(phy=self.sata_phy, mode="read+write")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/terasic_de0nano.py
+++ b/litex_boards/targets/terasic_de0nano.py
@@ -59,7 +59,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), sdram_rate="1:1", **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), sdram_rate="1:1", with_led_chaser=True, **kwargs):
         platform = de0nano.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -82,9 +82,10 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/terasic_de10lite.py
+++ b/litex_boards/targets/terasic_de10lite.py
@@ -54,7 +54,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), with_video_terminal=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), with_led_chaser=True, with_video_terminal=False,
+                 **kwargs):
         platform = de10lite.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -81,9 +82,10 @@ class BaseSoC(SoCCore):
             self.add_video_terminal(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/terasic_de10nano.py
+++ b/litex_boards/targets/terasic_de10nano.py
@@ -64,7 +64,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), with_mister_sdram=True, with_mister_video_terminal=False, sdram_rate="1:1", **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), with_led_chaser=True, with_mister_sdram=True,
+                 with_mister_video_terminal=False, sdram_rate="1:1", **kwargs):
         platform = de10nano.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -92,9 +93,10 @@ class BaseSoC(SoCCore):
             self.add_video_terminal(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/terasic_deca.py
+++ b/litex_boards/targets/terasic_deca.py
@@ -52,7 +52,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), with_video_terminal=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), with_led_chaser=True, with_video_terminal=False,
+                 **kwargs):
         self.platform = platform = deca.Platform()
 
         # Defaults to JTAG-UART since no hardware UART.
@@ -74,9 +75,10 @@ class BaseSoC(SoCCore):
             self.add_video_terminal(phy=self.videophy, timings="800x600@60Hz", clock_domain="hdmi")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/terasic_sockit.py
+++ b/litex_boards/targets/terasic_sockit.py
@@ -107,7 +107,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), revision="revd", sdram_rate="1:2", mister_sdram=None, with_video_terminal=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), revision="revd", sdram_rate="1:2", mister_sdram=None,
+                 with_led_chaser=True, with_video_terminal=False, **kwargs):
         platform = terasic_sockit.Platform(revision)
 
         # Defaults to UART over JTAG because serial is attached to the HPS and cannot be used.
@@ -143,9 +144,10 @@ class BaseSoC(SoCCore):
             self.add_video_terminal(phy=self.videophy, timings="1024x768@60Hz", clock_domain="vga")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/tinyfpga_bx.py
+++ b/litex_boards/targets/tinyfpga_bx.py
@@ -29,7 +29,7 @@ mB = 1024*kB
 
 class BaseSoC(SoCCore):
     mem_map = {**SoCCore.mem_map, **{"spiflash": 0x80000000}}
-    def __init__(self, bios_flash_offset, sys_clk_freq=int(16e6), **kwargs):
+    def __init__(self, bios_flash_offset, sys_clk_freq=int(16e6), with_led_chaser=True, **kwargs):
         platform = tinyfpga_bx.Platform()
 
         # Disable Integrated ROM since too large for iCE40.
@@ -58,9 +58,10 @@ class BaseSoC(SoCCore):
         )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/trellisboard.py
+++ b/litex_boards/targets/trellisboard.py
@@ -111,7 +111,8 @@ class _CRGSDRAM(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(75e6), toolchain="trellis", with_ethernet=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(75e6), toolchain="trellis", with_ethernet=False,
+                 with_led_chaser=True, **kwargs):
         platform = trellisboard.Platform(toolchain=toolchain)
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -145,9 +146,10 @@ class BaseSoC(SoCCore):
             self.add_ethernet(phy=self.ethphy)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/trenz_c10lprefkit.py
+++ b/litex_boards/targets/trenz_c10lprefkit.py
@@ -58,7 +58,7 @@ class BaseSoC(SoCCore):
     }
     mem_map.update(SoCCore.mem_map)
 
-    def __init__(self, sys_clk_freq=int(50e6), with_ethernet=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), with_ethernet=False, with_led_chaser=True, **kwargs):
         platform = c10lprefkit.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -92,9 +92,10 @@ class BaseSoC(SoCCore):
             self.add_ethernet(phy=self.ethphy)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/trenz_cyc1000.py
+++ b/litex_boards/targets/trenz_cyc1000.py
@@ -47,7 +47,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), with_led_chaser=True, **kwargs):
         platform = cyc1000.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -69,9 +69,10 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/trenz_max1000.py
+++ b/litex_boards/targets/trenz_max1000.py
@@ -47,7 +47,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), with_led_chaser=True, **kwargs):
         platform = max1000.Platform()
 
         kwargs["integrated_rom_size"]  = 0x6000
@@ -72,9 +72,10 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/trenz_te0725.py
+++ b/litex_boards/targets/trenz_te0725.py
@@ -44,7 +44,7 @@ class BaseSoC(SoCCore):
         }
     }
 
-    def __init__(self, sys_clk_freq=int(100e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), with_led_chaser=True, **kwargs):
         platform = trenz_te0725.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -63,10 +63,11 @@ class BaseSoC(SoCCore):
         self.register_mem("hyperram", self.mem_map["hyperram"], self.hyperram.bus, size)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
-        self.add_csr("leds")
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+            self.add_csr("leds")
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/trenz_tec0117.py
+++ b/litex_boards/targets/trenz_tec0117.py
@@ -53,7 +53,8 @@ class _CRG(Module):
 
 class BaseSoC(SoCCore):
     mem_map = {**SoCCore.mem_map, **{"spiflash": 0x80000000}}
-    def __init__(self, bios_flash_offset, sys_clk_freq=int(25e6), sdram_rate="1:1", **kwargs):
+    def __init__(self, bios_flash_offset, sys_clk_freq=int(25e6), sdram_rate="1:1",
+                 with_led_chaser=True, **kwargs):
         platform = tec0117.Platform()
 
         # Use custom default configuration to fit in LittleBee.
@@ -113,9 +114,10 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Flash --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/xilinx_ac701.py
+++ b/litex_boards/targets/xilinx_ac701.py
@@ -56,7 +56,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), with_ethernet=False, eth_phy="rgmii", with_pcie=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), with_ethernet=False, eth_phy="rgmii",
+                 with_led_chaser=True, with_pcie=False, **kwargs):
         platform = ac701.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -127,9 +128,10 @@ class BaseSoC(SoCCore):
             self.add_pcie(phy=self.pcie_phy, ndmas=1)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 def main():

--- a/litex_boards/targets/xilinx_alveo_u250.py
+++ b/litex_boards/targets/xilinx_alveo_u250.py
@@ -58,7 +58,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(125e6), with_pcie=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), with_led_chaser=True, with_pcie=False, **kwargs):
         platform = alveo_u250.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -95,9 +95,10 @@ class BaseSoC(SoCCore):
             self.add_pcie(phy=self.pcie_phy, ndmas=1)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/xilinx_kc705.py
+++ b/litex_boards/targets/xilinx_kc705.py
@@ -52,7 +52,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(125e6), with_ethernet=False, with_pcie=False, with_sata=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), with_ethernet=False, with_led_chaser=True,
+                 with_pcie=False, with_sata=False, **kwargs):
         platform = kc705.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -126,9 +127,10 @@ class BaseSoC(SoCCore):
             self.add_sata(phy=self.sata_phy, mode="read+write")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/xilinx_kcu105.py
+++ b/litex_boards/targets/xilinx_kcu105.py
@@ -61,7 +61,9 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(125e6), with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", with_pcie=False, with_sata=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), with_ethernet=False, with_etherbone=False,
+                 eth_ip="192.168.1.50", with_led_chaser=True, with_pcie=False, with_sata=False,
+                 **kwargs):
         platform = kcu105.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -140,9 +142,10 @@ class BaseSoC(SoCCore):
             self.add_sata(phy=self.sata_phy, mode="read+write")
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/xilinx_vc707.py
+++ b/litex_boards/targets/xilinx_vc707.py
@@ -48,7 +48,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(125e6), with_pcie=False, **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), with_led_chaser=True, with_pcie=False, **kwargs):
         platform = vc707.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -80,9 +80,10 @@ class BaseSoC(SoCCore):
             self.add_pcie(phy=self.pcie_phy, ndmas=1)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/xilinx_vcu118.py
+++ b/litex_boards/targets/xilinx_vcu118.py
@@ -55,7 +55,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(125e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), with_led_chaser=True, **kwargs):
         platform = vcu118.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -81,9 +81,10 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/xilinx_zcu104.py
+++ b/litex_boards/targets/xilinx_zcu104.py
@@ -56,7 +56,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(125e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), with_led_chaser=True, **kwargs):
         platform = zcu104.Platform()
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -82,9 +82,10 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/xilinx_zybo_z7.py
+++ b/litex_boards/targets/xilinx_zybo_z7.py
@@ -45,7 +45,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), with_led_chaser=True, **kwargs):
         platform = zybo_z7.Platform()
 
         if kwargs["uart_name"] == "serial": kwargs["uart_name"] = "usb_uart" # Use USB-UART Pmod on JB.
@@ -76,9 +76,10 @@ class BaseSoC(SoCCore):
         self.submodules.crg = _CRG(platform, sys_clk_freq)
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/ztex213.py
+++ b/litex_boards/targets/ztex213.py
@@ -62,7 +62,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, variant="ztex2.13a", sys_clk_freq=int(100e6), expansion="debug", **kwargs):
+    def __init__(self, variant="ztex2.13a", sys_clk_freq=int(100e6), expansion="debug",
+                 with_led_chaser=True, **kwargs):
         platform = ztex213.Platform(variant=variant, expansion=expansion)
 
         # SoCCore ----------------------------------------------------------------------------------
@@ -87,9 +88,10 @@ class BaseSoC(SoCCore):
             )
 
         # Leds -------------------------------------------------------------------------------------
-        self.submodules.leds = LedChaser(
-            pads         = platform.request_all("user_led"),
-            sys_clk_freq = sys_clk_freq)
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
 # Build --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Related Issue: #235 

For consistency's sake, I've added the `with_led_chaser=True` kwarg to all boards that use the `LedChaser`, but I'd be happy to only apply the change to some boards if you'd rather do that.