### PR TITLE
Basys3: Invert reset button, so that the board is reset when btnc is pushed.

### DIFF
--- a/litex_boards/targets/digilent_basys3.py
+++ b/litex_boards/targets/digilent_basys3.py
@@ -29,7 +29,7 @@ class _CRG(Module):
         self.clock_domains.cd_vga       = ClockDomain(reset_less=True)
 
         self.submodules.pll = pll = S7MMCM(speedgrade=-1)
-        self.comb += pll.reset.eq(~platform.request("user_btnc") | self.rst)
+        self.comb += pll.reset.eq(platform.request("user_btnc") | self.rst)
 
         pll.register_clkin(platform.request("clk100"), 100e6)
         pll.create_clkout(self.cd_sys, sys_clk_freq)


### PR DESCRIPTION
Currently, the Litex design on the board only operates if you hold the reset button (BTNC) down.   This PR inverts the sense of the button, so that LiteX operates normally without the button pressed, and is reset when the button is pushed.   Tested on Basys3 rev C.

Signed-off-by: Tim Callahan <tcal@google.com>
