### PR TITLE
colorlight_5a_75x: Disable full_memory_we for l2 cache by default

### DIFF
--- a/litex_boards/targets/colorlight_5a_75x.py
+++ b/litex_boards/targets/colorlight_5a_75x.py
@@ -152,9 +152,11 @@ class BaseSoC(SoCCore):
             else:
                 sdram_cls  = M12L16161A
             self.add_sdram("sdram",
-                phy           = self.sdrphy,
-                module        = sdram_cls(sys_clk_freq, sdram_rate),
-                l2_cache_size = kwargs.get("l2_size", 8192)
+                phy                     = self.sdrphy,
+                module                  = sdram_cls(sys_clk_freq, sdram_rate),
+                l2_cache_size           = kwargs.get("l2_size", 8192),
+                l2_cache_full_memory_we = False,
+
             )
 
         # Ethernet / Etherbone ---------------------------------------------------------------------


### PR DESCRIPTION
Leads to an increase in DP16KD usage, first noticed in https://github.com/enjoy-digital/liteeth/issues/70.
With full_mem_we:
```
Info: 	              DP16KD:    41/   56    73%
```
Without:
```
Info: 	              DP16KD:    29/   56    51%
```

Might also be relevant for other yosys/ecp5 targets.

Versions:
Yosys 0.9+4241 (git sha1 8733e1923, gcc 11.1.0 -march=native -mtune=generic -O2 -fno-plt -fPIC -Os)
nextpnr-ecp5 -- Next Generation Place and Route (Version ef1fbfc6)

Command:
```
python colorlight_5a_75x.py --build
```