### PR TITLE
FIX: OrangeCrab Feather SPI pad name

### DIFF
--- a/litex_boards/platforms/gsd_orangecrab.py
+++ b/litex_boards/platforms/gsd_orangecrab.py
@@ -207,10 +207,10 @@ feather_i2c = [
 ]
 
 feather_spi = [
-    ("spi",0,
+    ("spi", 0,
         Subsignal("miso", Pins("GPIO:14"), IOStandard("LVCMOS33")),
         Subsignal("mosi", Pins("GPIO:16"), IOStandard("LVCMOS33")),
-        Subsignal("sck",  Pins("GPIO:15"), IOStandard("LVCMOS33"))
+        Subsignal("clk",  Pins("GPIO:15"), IOStandard("LVCMOS33"))
     )
 ]
 


### PR DESCRIPTION
**Problems**

`SPIMaster` pad names are `clk`, `cs_n`, `mosi`, and `miso`.
However, `feather_spi` is using `sck` instead of `clk`, therefore
it is not able to use as-is for `SPIMaster`, for example,
with `add_spi` on Linux On LiteX VexRiscv.

**Solution**

In fact, `spisdcard` and other SPI related pad names are
using `clk`, only `feather_spi` is using `sck`.
Therefore, rename `sck` to `clk`.