### PR TITLE
beaglewire platform and target added

### DIFF
--- a/litex_boards/platforms/beaglewire.py
+++ b/litex_boards/platforms/beaglewire.py
@@ -1,0 +1,83 @@
+#
+# This file is part of LiteX-Boards.
+# Copyright (c) 2021 Omkar Bhilare <ombhilare999@gmail.com>
+# Copyright (c) 2021 Michael Welling <mwelling@ieee.org>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.lattice import LatticePlatform
+from litex.build.lattice.programmer import TinyProgProgrammer
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("clk100", 0, Pins("61"), IOStandard("LVCMOS33")),
+
+    # Leds
+    ("user_led", 0, Pins("28 29 31 32"), IOStandard("LVCMOS33")),
+
+    ("user_btn_n",    0, Pins( "25"), IOStandard("LVCMOS33")),
+
+    # SPIFlash
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("71"), IOStandard("LVCMOS33")),
+        Subsignal("clk",  Pins("70"), IOStandard("LVCMOS33")),
+        Subsignal("mosi", Pins("67"), IOStandard("LVCMOS33")),
+        Subsignal("miso", Pins("68"), IOStandard("LVCMOS33")),
+    ),
+
+    # SDR SDRAM
+    ("sdram_clock", 0, Pins("93"), IOStandard("LVCMOS33")),
+    ("sdram", 0,
+        Subsignal("a",     Pins("118 117 116 101 81 83 90 91 82 84 119 85 87")),
+        Subsignal("dq",    Pins("96 97 98 99 95 80 79 78")),
+        Subsignal("we_n",  Pins("128")),
+        Subsignal("ras_n", Pins("124")),
+        Subsignal("cas_n", Pins("125")),
+        Subsignal("cs_n",  Pins("122")),
+        Subsignal("cke",   Pins("88")),
+        Subsignal("ba",    Pins("121 120")),
+        Subsignal("dm",    Pins("94")),
+        IOStandard("LVCMOS33"), Misc("SLEWRATE=FAST")
+    ),
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = [
+    # A2-H2, Pins 1-13
+    # H9-A6, Pins 14-24
+    # G1-J2, Pins 25-31
+    ("GPIO",  "37 39 42 44 38 41 43 45"),
+    ("GPIO1", "47  49  55  60  48  52  56  62"),
+    ("GPIO2", "107 112 114 129 110 113 115 130"),
+    ("GPIO3", "7   9   15  12  4   8   10  11"),
+    ("grove", "73 74 75 76 104 102 106 105")
+]
+
+# Default peripherals
+serial = [
+    ("serial", 0,
+        Subsignal("tx", Pins("GPIO:0")),
+        Subsignal("rx", Pins("GPIO:1")),
+        IOStandard("LVCMOS33")
+    )
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(LatticePlatform):
+    default_clk_name   = "clk100"
+    default_clk_period = 1e9/100e6
+
+    def __init__(self, toolchain="icestorm"):
+        LatticePlatform.__init__(self, "ice40-hx8k-tq144:4k", _io, _connectors, toolchain=toolchain)
+        self.add_extension(serial)
+
+    def create_programmer(self):
+        return TinyProgProgrammer()
+
+    def do_finalize(self, fragment):
+        LatticePlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk100", loose=True), 1e9/100e6)

--- a/litex_boards/targets/beaglewire_crossover.py
+++ b/litex_boards/targets/beaglewire_crossover.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+# Copyright (c) 2021 Omkar Bhilare <ombhilare999@gmail.com>
+# Copyright (c) 2021 Michael Welling <mwelling@ieee.org>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import sys
+import argparse
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.build.io import DDROutput
+
+from litex.build.io import CRG
+
+
+from litex_boards.platforms import beaglewire
+
+from litex.soc.interconnect import wishbone
+from litex.soc.cores.spi_flash import SpiFlash
+from litex.soc.cores.clock import iCE40PLL
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+from litex.soc.cores.uart import UARTWishboneBridge
+from litedram import modules as litedram_modules
+from litedram.phy import GENSDRPHY
+from litedram.modules import MT48LC32M8
+from litex.soc.integration.builder import Builder
+from litex.soc.interconnect.csr import AutoCSR, CSRStatus, CSRStorage
+
+kB = 1024
+mB = 1024*kB
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst = Signal()
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_por = ClockDomain(reset_less=True)
+
+        # # #
+
+        # Clk/Rst
+        clk100 = platform.request("clk100")
+        rst_n = platform.request("user_btn_n")
+
+        # Power On Reset
+        por_count = Signal(16, reset=2**16-1)
+        por_done  = Signal()
+        self.comb += self.cd_por.clk.eq(ClockSignal())
+        self.comb += por_done.eq(por_count == 0)
+        self.sync.por += If(~por_done, por_count.eq(por_count - 1))
+
+        # PLL
+        self.submodules.pll = pll = iCE40PLL()
+        self.comb += pll.reset.eq(rst_n) # FIXME: Add proper iCE40PLL reset support and add back | self.rst.
+        pll.register_clkin(clk100, 100e6)
+        pll.create_clkout(self.cd_sys, sys_clk_freq, with_reset=False)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~por_done | ~pll.locked)
+        platform.add_period_constraint(self.cd_sys.clk, 1e9/sys_clk_freq)
+
+        # SDRAM clock
+        self.specials += DDROutput(0, 1, platform.request("sdram_clock"),  ClockSignal("sys"))
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    mem_map = {**SoCCore.mem_map, **{"spiflash": 0x80000000}}
+    def __init__(self, bios_flash_offset, sys_clk_freq=int(50e6), **kwargs):
+        platform = beaglewire.Platform()
+
+        # Disable Integrated ROM since too large for iCE40.
+        kwargs["integrated_rom_size"]  = 0
+        kwargs["integrated_sram_size"]  = 2*kB
+
+        # Set CPU variant / reset address
+        kwargs["cpu_reset_address"] = self.mem_map["spiflash"] + bios_flash_offset
+        kwargs["uart_name"]   = "crossover"
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq, 
+            ident          = "LiteX SoC on Beaglewire",
+            ident_version  = True,
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+
+        # Wishbone ---------------------------------------------------------------------------------
+        self.submodules.uart_bridge = UARTWishboneBridge(
+               platform.request("serial"),
+               sys_clk_freq,
+               baudrate=115200)
+        self.add_wb_master(self.uart_bridge.wishbone)
+
+        # SPI Flash --------------------------------------------------------------------------------
+        self.add_spi_flash(mode="1x", dummy_cycles=8)
+
+        # Add ROM linker region --------------------------------------------------------------------
+        self.bus.add_region("rom", SoCRegion(
+            origin = self.mem_map["spiflash"] + bios_flash_offset,
+            size   = 32*kB,
+            linker = True)
+        )
+
+        # Leds -------------------------------------------------------------------------------------
+        self.submodules.leds = LedChaser(
+            pads         = platform.request_all("user_led"),
+            sys_clk_freq = sys_clk_freq)
+        self.add_csr("leds")
+
+        self.submodules.sdrphy = GENSDRPHY(platform.request("sdram"), sys_clk_freq )
+        self.add_sdram("sdram",
+            phy                     = self.sdrphy,
+            module                  = MT48LC32M8(sys_clk_freq, "1:1"),
+            l2_cache_size           = kwargs.get("l2_size", 1024)
+        )
+
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on Beaglewire")
+    parser.add_argument("--build",             action="store_true", help="Build bitstream")
+    parser.add_argument("--bios-flash-offset", default=0x60000,     help="BIOS offset in SPI Flash (default: 0x60000)")
+    parser.add_argument("--sys-clk-freq",      default=50e6,        help="System clock frequency (default: 50MHz)")
+    parser.add_argument("--output_dir",        default="build",         help="Output directory of csr")
+    parser.add_argument("--csr_csv",           default="build/csr.csv", help="csr.csv")
+    builder_args(parser)
+    soc_core_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+         bios_flash_offset = args.bios_flash_offset,
+         sys_clk_freq      = int(float(args.sys_clk_freq)),
+         **soc_core_argdict(args)
+    )
+    builder = Builder(soc,  **builder_argdict(args))
+    builder.build(run=args.build)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added beaglewire platform and target file.
- Platform file for beaglewire can be found [here](https://github.com/litex-hub/litex-boards/blob/db9c98b28afcb64058662ff254f465cd63ff6a2a/litex_boards/platforms/beaglewire.py)
- Target file for beaglewire can be found [here](https://github.com/litex-hub/litex-boards/blob/db9c98b28afcb64058662ff254f465cd63ff6a2a/litex_boards/targets/beaglewire_crossover.py)
- Detailed guide for how to use the beaglewire litex can be found [here](https://beaglewire.github.io/Blogs/BeagleWire-Litex.html)

Demo of working litex on beaglewire with uart wb crossover: https://www.youtube.com/watch?v=mx4KWYq29I0

kindly review it and let me know if any changes are required. 

regards,
omkar bhilare
ombhilare999@gmail.com