### PR TITLE
terasic DECA: set IO bank voltages to prevent damage by accidental misconfiguration

### DIFF
--- a/litex_boards/platforms/terasic_deca.py
+++ b/litex_boards/platforms/terasic_deca.py
@@ -295,6 +295,15 @@ class Platform(AlteraPlatform):
     def __init__(self):
         AlteraPlatform.__init__(self, "10M50DAF484C6GES", _io, _connectors)
         # Disable config pin so bank8 can use 1.2V.
+        self.add_platform_command("set_global_assignment -name IOBANK_VCCIO 2.5V -section_id 1A")
+        self.add_platform_command("set_global_assignment -name IOBANK_VCCIO 2.5V -section_id 1B")
+        self.add_platform_command("set_global_assignment -name IOBANK_VCCIO 2.5V -section_id 2")
+        self.add_platform_command("set_global_assignment -name IOBANK_VCCIO 3.3V -section_id 3")
+        self.add_platform_command("set_global_assignment -name IOBANK_VCCIO 3.3V -section_id 4")
+        self.add_platform_command("set_global_assignment -name IOBANK_VCCIO 1.5V -section_id 5")
+        self.add_platform_command("set_global_assignment -name IOBANK_VCCIO 1.5V -section_id 6")
+        self.add_platform_command("set_global_assignment -name IOBANK_VCCIO 1.8V -section_id 7")
+        self.add_platform_command("set_global_assignment -name IOBANK_VCCIO 1.2V -section_id 8")
         self.add_platform_command("set_global_assignment -name AUTO_RESTART_CONFIGURATION ON")
         self.add_platform_command("set_global_assignment -name ENABLE_CONFIGURATION_PINS OFF")
         self.add_platform_command("set_global_assignment -name ENABLE_BOOT_SEL_PIN OFF")


### PR DESCRIPTION
This is necessary for preventing the user damaging the board unawares, I think.