### PR TITLE
lattice_crosslink_nx_evn: allow specifying the FPGA device

### DIFF
--- a/litex_boards/platforms/lattice_crosslink_nx_evn.py
+++ b/litex_boards/platforms/lattice_crosslink_nx_evn.py
@@ -249,9 +249,14 @@ class Platform(LatticePlatform):
     default_clk_name   = "clk12"
     default_clk_period = 1e9/12e6
 
-    def __init__(self, device="LIFCL", toolchain="radiant", **kwargs):
-        assert device in ["LIFCL"]
-        LatticePlatform.__init__(self, device + "-40-9BG400C", _io, _connectors, toolchain=toolchain, **kwargs)
+    def __init__(self, device="LIFCL-40-9BG400C", toolchain="radiant", **kwargs):
+        # Accept "LIFCL" for backwards compatibility.
+        # LIFCL just means Crosslink-NX so we can expect every
+        # Crosslink-NX Evaluation Board to have a LIFCL part.
+        if device == "LIFCL":
+            device == "LIFCL-40-9BG400C"
+        assert device in ["LIFCL-40-9BG400C", "LIFCL-40-8BG400CES"]
+        LatticePlatform.__init__(self, device, _io, _connectors, toolchain=toolchain, **kwargs)
 
     def create_programmer(self, mode = "direct"):
         assert mode in ["direct","flash"]

--- a/litex_boards/targets/lattice_crosslink_nx_evn.py
+++ b/litex_boards/targets/lattice_crosslink_nx_evn.py
@@ -67,8 +67,8 @@ class BaseSoC(SoCCore):
         "sram" : 0x40000000,
         "csr"  : 0xf0000000,
     }
-    def __init__(self, sys_clk_freq=int(75e6), toolchain="radiant", with_led_chaser=True, **kwargs):
-        platform = crosslink_nx_evn.Platform(toolchain=toolchain)
+    def __init__(self, sys_clk_freq=int(75e6), device="LIFCL-40-9BG400C", toolchain="radiant", with_led_chaser=True, **kwargs):
+        platform = crosslink_nx_evn.Platform(device=device, toolchain=toolchain)
         platform.add_platform_command("ldc_set_sysconfig {{MASTER_SPI_PORT=SERIAL}}")
 
         # Disable Integrated SRAM since we want to instantiate LRAM specifically for it
@@ -104,6 +104,7 @@ def main():
     parser.add_argument("--build",         action="store_true", help="Build bitstream")
     parser.add_argument("--load",          action="store_true", help="Load bitstream")
     parser.add_argument("--toolchain",     default="radiant",   help="FPGA toolchain: radiant (default) or prjoxide")
+    parser.add_argument("--device",        default="LIFCL-40-9BG400C", help="FPGA device: LIFCL-40-9BG400C (default) or LIFCL-40-8BG400CES")
     parser.add_argument("--sys-clk-freq",  default=75e6,        help="System clock frequency (default: 75MHz)")
     parser.add_argument("--serial",        default="serial",    help="UART Pins: serial (default, requires R15 and R17 to be soldered) or serial_pmod[0-2]")
     parser.add_argument("--prog-target",   default="direct",    help="Programming Target: direct or flash")
@@ -114,6 +115,7 @@ def main():
 
     soc = BaseSoC(
         sys_clk_freq = int(float(args.sys_clk_freq)),
+        device       = args.device,
         toolchain    = args.toolchain,
         **soc_core_argdict(args)
     )


### PR DESCRIPTION
This board is documented as having the LIFCL-40-9BG400C part, but some
versions of the board exist which were fitted with LIFCL-40-8BG400CES,
an engineering sample part. The distinction is important because the
engineering sample requires a different device ID to be embedded in the
bitstream. If you try to build a bitstream for LIFCL-40-9BG400C and load
it onto LIFCL-40-8BG400CES the configuration fails (indicated by the red
"INITN" LED on this board).

Accept --device to allow the user to specify which FPGA part their board
has.