### PR TITLE
lattice_crosslink_nx_evn: don't set MASTER_SPI_PORT=SERIAL

### DIFF
--- a/litex_boards/targets/lattice_crosslink_nx_evn.py
+++ b/litex_boards/targets/lattice_crosslink_nx_evn.py
@@ -69,7 +69,6 @@ class BaseSoC(SoCCore):
     }
     def __init__(self, sys_clk_freq=int(75e6), device="LIFCL-40-9BG400C", toolchain="radiant", with_led_chaser=True, **kwargs):
         platform = crosslink_nx_evn.Platform(device=device, toolchain=toolchain)
-        platform.add_platform_command("ldc_set_sysconfig {{MASTER_SPI_PORT=SERIAL}}")
 
         # Disable Integrated SRAM since we want to instantiate LRAM specifically for it
         kwargs["integrated_sram_size"] = 0


### PR DESCRIPTION
Setting MASTER_SPI_PORT=SERIAL causes the SPI flash pins to be reserved
for use by the sysCONFIG logic, and prevents user logic from assigning
them. This made it impossible to have a Litex design which accesses the
SPI flash on this board.

Remove the setting, so that we get the default behaviour which permits
user logic to assign these pins. In the unlikely event that someone
needs the pins to stay reserved for sysCONFIG after configuration (I'm
not sure why this would be needed) they could explicitly add this
command in their design.