### PR TITLE
Add Alchitry Au as new board

### DIFF
--- a/litex_boards/platforms/alchitry_au.py
+++ b/litex_boards/platforms/alchitry_au.py
@@ -1,0 +1,129 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2021 Nathaniel Lewis <github@nrlewis.dev>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# The Alchitry Au is the "gold" standard for FPGA development boards.
+#
+# The larger of the twin successors to the Mojo V3, this board is produced
+# by SparkFun - https://www.sparkfun.com/products/16527.
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import XilinxPlatform
+from litex.build.openocd import OpenOCD
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("clk100", 0, Pins("N14"), IOStandard("LVCMOS33")),
+    ("cpu_reset", 0, Pins("P6"), IOStandard("LVCMOS33")),
+
+    # Leds
+    ("user_led", 0, Pins("K13"), IOStandard("LVCMOS33")),
+    ("user_led", 1, Pins("K12"), IOStandard("LVCMOS33")),
+    ("user_led", 2, Pins("L14"), IOStandard("LVCMOS33")),
+    ("user_led", 3, Pins("L13"), IOStandard("LVCMOS33")),
+    ("user_led", 4, Pins("M16"), IOStandard("LVCMOS33")),
+    ("user_led", 5, Pins("M14"), IOStandard("LVCMOS33")),
+    ("user_led", 6, Pins("M12"), IOStandard("LVCMOS33")),
+    ("user_led", 7, Pins("N16"), IOStandard("LVCMOS33")),
+
+    # Serial
+    ("serial", 0,
+        Subsignal("tx", Pins("P16")),
+        Subsignal("rx", Pins("P15")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # I2C
+    ("i2c", 0,
+        Subsignal("scl", Pins("E6")),
+        Subsignal("sda", Pins("K5")),
+        IOStandard("LVCMOS33"),
+    ),
+
+    # SPIFlash
+    ("spiflash", 0,  # clock needs to be accessed through STARTUPE2
+        Subsignal("cs_n", Pins("L12")),
+        Subsignal("mosi", Pins("J13")),
+        Subsignal("miso", Pins("J14")),
+        Subsignal("wp",   Pins("K15")),
+        Subsignal("hold", Pins("K16")),
+        IOStandard("LVCMOS33")
+    ),
+    ("spiflash4x", 0,  # clock needs to be accessed through STARTUPE2
+        Subsignal("cs_n", Pins("L12")),
+        Subsignal("dq",   Pins("J13", "J14", "K15", "K16")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # DDR3 SDRAM
+    ("ddram", 0,
+        Subsignal("a", Pins(
+            "F12 G16 G15 E16 H11 G12 H16",
+            "H12 J16 H13 E12 H14 F13 J15"),
+            IOStandard("SSTL135")),
+        Subsignal("ba",    Pins("E13 F15 E15"), IOStandard("SSTL135")),
+        Subsignal("ras_n", Pins("D11"),  IOStandard("SSTL135")),
+        Subsignal("cas_n", Pins("D14"),  IOStandard("SSTL135")),
+        Subsignal("we_n",  Pins("E11"),  IOStandard("SSTL135")),
+        Subsignal("dm", Pins("A14 C9"), IOStandard("SSTL135")),
+        Subsignal("dq", Pins(
+            "A13 B16 B14 C11 C13 C16 C12 C14",
+            "D8  B11 C8  B10 A12 A8  B12 A9"),
+            IOStandard("SSTL135"),
+            Misc("IN_TERM=UNTUNED_SPLIT_50")),
+        Subsignal("dqs_p",
+            Pins("B15 B9"),
+            IOStandard("DIFF_SSTL135"),
+            Misc("IN_TERM=UNTUNED_SPLIT_50")),
+        Subsignal("dqs_n",
+            Pins("A15 A10"),
+            IOStandard("DIFF_SSTL135"),
+            Misc("IN_TERM=UNTUNED_SPLIT_50")),
+        Subsignal("clk_p", Pins("G14"), IOStandard("DIFF_SSTL135")),
+        Subsignal("clk_n", Pins("F14"), IOStandard("DIFF_SSTL135")),
+        Subsignal("cke",   Pins("D15"), IOStandard("SSTL135")),
+        Subsignal("odt",   Pins("G11"), IOStandard("SSTL135")),
+        Subsignal("cs_n",  Pins("D16"), IOStandard("SSTL135")),
+        Subsignal("reset_n", Pins("D13"), IOStandard("SSTL135")),
+        Misc("SLEW=FAST"),
+    ),
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(XilinxPlatform):
+    default_clk_name   = "clk100"
+    default_clk_period = 1e9/100e6
+
+    def __init__(self, variant="au"):
+        device = {
+            "au":  "xc7a35t-ftg256-1",
+            "au+": "xc7a100t-ftg256-2",
+        }[variant]
+
+        XilinxPlatform.__init__(self, device, _io, toolchain="vivado")
+        self.add_platform_command("set_property INTERNAL_VREF 0.675 [get_iobanks 15]")
+
+        self.toolchain.bitstream_commands = [
+            "set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]",
+            "set_property BITSTREAM.CONFIG.CONFIGRATE 33 [current_design]",
+            "set_property CONFIG_VOLTAGE 3.3 [current_design]",
+            "set_property CFGBVS VCCO [current_design]",
+            "set_property BITSTREAM.CONFIG.SPI_32BIT_ADDR NO [current_design]",
+            "set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 1 [current_design]",
+            "set_property BITSTREAM.CONFIG.SPI_FALL_EDGE YES [current_design]",
+        ]
+        self.toolchain.additional_commands = \
+            ["write_cfgmem -force -format bin -interface spix1 -size 4 "
+             "-loadbit \"up 0x0 {build_name}.bit\" -file {build_name}.bin"]
+
+    def create_programmer(self):
+        return OpenOCD("openocd_xc7_ft2232.cfg", "bscan_spi_xc7a35t.bit")
+
+    def do_finalize(self, fragment):
+        XilinxPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk100", loose=True), 1e9/100e6)

--- a/litex_boards/targets/alchitry_au.py
+++ b/litex_boards/targets/alchitry_au.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2021 Nathaniel Lewis <github@nrlewis.dev>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import argparse
+import sys
+
+from migen import *
+
+from litex_boards.platforms import alchitry_au
+from litex.build.xilinx.vivado import vivado_build_args, vivado_build_argdict
+
+from litex.soc.interconnect.csr import *
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+
+from litex.soc.cores.clock import *
+from litex.soc.cores.led import LedChaser
+
+from litedram.modules import AS4C128M16
+from litedram.phy import s7ddrphy
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst = Signal()
+        self.clock_domains.cd_sys       = ClockDomain()
+        self.clock_domains.cd_sys4x     = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
+        self.clock_domains.cd_idelay    = ClockDomain()
+
+        # Clk/Rst
+        clk100 = platform.request("clk100")
+
+        # PLL
+        self.submodules.pll = pll = S7PLL()
+        self.comb += pll.reset.eq(~platform.request("cpu_reset") | self.rst)
+        pll.register_clkin(clk100, 100e6)
+        pll.create_clkout(self.cd_sys,       sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x,     4*sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x_dqs, 4*sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_idelay,    200e6)
+        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
+
+        self.submodules.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
+
+# BaseSoC -----------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    mem_map = {**SoCCore.mem_map, **{"spiflash": 0x80000000}}
+    def __init__(self, variant="au", sys_clk_freq=int(83333333), with_spi_flash=False, with_led_chaser=True, **kwargs):
+        platform = alchitry_au.Platform(variant=variant)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            ident          = "LiteX SoC on Alchitry Au(+)",
+            ident_version  = True,
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = CRG(platform, sys_clk_freq)
+
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.submodules.ddrphy = s7ddrphy.A7DDRPHY(platform.request("ddram"),
+                memtype          = "DDR3",
+                nphases          = 4,
+                sys_clk_freq     = sys_clk_freq,
+                iodelay_clk_freq = 200e6)
+            self.add_sdram("sdram",
+                phy           = self.ddrphy,
+                module        = AS4C128M16(sys_clk_freq, "1:4"),
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
+
+        # SPI Flash --------------------------------------------------------------------------------
+        if with_spi_flash:
+            from litespi.modules import SST26VF032B
+            from litespi.opcodes import SpiNorFlashOpCodes as Codes
+            self.add_spi_flash(mode="4x", module=SST26VF032B(Codes.READ_1_1_1), with_master=True)
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on Alchitry Au(+)")
+    parser.add_argument("--build",           action="store_true", help="Build bitstream")
+    parser.add_argument("--load",            action="store_true", help="Load bitstream")
+    parser.add_argument("--flash",           action="store_true", help="Flash bitstream")
+    parser.add_argument("--variant",         default="au",        help="Board variant: au (default) or au+")
+    parser.add_argument("--sys-clk-freq",    default=83333333,    help="System clock frequency (default: 83.333333 MHz)")
+    parser.add_argument("--with-spi-flash",  action="store_true", help="Enable SPI Flash (MMAPed)")
+    builder_args(parser)
+    soc_core_args(parser)
+    vivado_build_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        variant        = args.variant,
+        sys_clk_freq   = int(float(args.sys_clk_freq)),
+        with_spi_flash = args.with_spi_flash,
+        **soc_core_argdict(args)
+    )
+
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build(**vivado_build_argdict(args), run=args.build)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".bit"))
+
+    if args.flash:
+        prog = soc.platform.create_programmer()
+        prog.flash(0, os.path.join(builder.gateware_dir, soc.build_name + ".bin"))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add the Au board from Alchitry to LiteX.

System frequency is 83.333333 MHz, as the -1 speed grade xc7a35t can only manage 667 MHz DDR3L RAM.

Gated by https://github.com/enjoy-digital/litedram/pull/274 (timings for the RAM module on the board)

```
./alchitry_au.py --build --with-spi-flash --load
```