### PR TITLE
Add initial RZ-EasyFPGA support!

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The Colorlight5A is a very nice board to start with, cheap, powerful, easy to us
 | Nexys4DDR      | Xilinx Artix7       | XC7A100T      | 100MHz  | FTDI | 16-bit 128MB DDR2  |     No    | 100Mbps RMII   |  16MB QSPI* |   Yes  |
 | Nexys Video    | Xilinx Artix7       | XC7A200T      | 100MHz  | FTDI | 16-bit 512MB DDR3  |     No    |   1Gbps RMII   |  32MB QSPI* |   Yes  |
 | QMTech XC7A35T | Xilinx Artix7       | XC7A35T       | 100MHz  | FTDI | 16-bit 256MB DDR3  |     No    |   1Gbps GMII** |  16MB QSPI  |   Yes**|
+| RZ-EasyFPGA    | Intel Cyclone4      | EP4CE6        |  25MHz  | IOs  | 16-bit   8MB SDR   |     No    |       No       |      No     |   No   |
 | SP605          | Xilinx Spartan6     | XC6SLX45T     | 100MHz  | FTDI | 16-bit 128MB DDR3* |  Gen1 X1* |   1Gbps GMII   |   8MB QSPI* |   Yes* |
 | Tagus          | Xilinx Artix7       | XC7A200T      | 100MHz  | PCIe | 16-bit 256MB DDR3  |  Gen2 X1  |  1Gbps-BASE-X* |  16MB QSPI* |   No   |
 | VC707          | Xilinx Virex7       | XC7VX485T     | 125MHz  | FTDI | 64-bit   1GB DDR3  |  Gen3 X8* |   1Gbps GMII   |  16MB QSPI* |   Yes* |

--- a/litex_boards/__init__.py
+++ b/litex_boards/__init__.py
@@ -25,6 +25,7 @@ vendors = [
     "qwertyembedded",
     "radiona",
     "rhsresearchllc",
+    "rz",
     "saanlima",
     "scarabhardware",
     "siglent",

--- a/litex_boards/platforms/rz_easyfpga.py
+++ b/litex_boards/platforms/rz_easyfpga.py
@@ -1,0 +1,46 @@
+#
+# This file is part of LiteX-Boards.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.altera import AlteraPlatform
+from litex.build.altera.programmer import USBBlaster
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk
+    ("clk50", 0, Pins("23"), IOStandard("3.3-V LVTTL")),
+
+    # Leds
+    ("user_led", 0, Pins("84"), IOStandard("3.3-V LVTTL")),
+    ("user_led", 1, Pins("85"), IOStandard("3.3-V LVTTL")),
+    ("user_led", 2, Pins("86"), IOStandard("3.3-V LVTTL")),
+    ("user_led", 3, Pins("87"), IOStandard("3.3-V LVTTL")),
+
+    # Serial
+    ("serial", 0,
+        # Compatible with cheap FT232 based cables (ex: Gaoominy 6Pin Ftdi Ft232Rl Ft232)
+        # GND on JP1 Pin 12.
+        Subsignal("tx", Pins("114"), IOStandard("3.3-V LVTTL")),
+        Subsignal("rx", Pins("115"),  IOStandard("3.3-V LVTTL"))
+    )
+]
+
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(AlteraPlatform):
+    default_clk_name   = "clk50"
+    default_clk_period = 1e9/50e6
+
+    def __init__(self):
+        AlteraPlatform.__init__(self, "EP4CE6E22C8", _io)
+
+    def create_programmer(self):
+        return USBBlaster()
+
+    def do_finalize(self, fragment):
+        AlteraPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)

--- a/litex_boards/platforms/rz_easyfpga.py
+++ b/litex_boards/platforms/rz_easyfpga.py
@@ -28,8 +28,8 @@ _io = [
     ),
 
     # SDRAM
-    # It may help to add a header cable to some pins to mitigate potential electrical problems on the board
-    # (especially pin 67, but perhaps also 66 and 68)
+    # It may help to add a header cable to some pins to mitigate suspected electrical problems on the board
+    # (especially pin 67, but perhaps also 66 and 68; adding pins to the whole addr bus seemed to work too)
     ("sdram_clock", 0, Pins("43"), IOStandard("3.3-V LVTTL")),
     ("sdram", 0,
         Subsignal("a", Pins(

--- a/litex_boards/platforms/rz_easyfpga.py
+++ b/litex_boards/platforms/rz_easyfpga.py
@@ -29,7 +29,7 @@ _io = [
 
     # SDRAM
     # It may help to add a header cable to some pins to mitigate suspected electrical problems on the board
-    # (especially pin 67, but perhaps also 66 and 68; adding pins to the whole addr bus seemed to work too)
+    # (especially pin 67, but adding cables to the whole addr bus seemed to be the most robust)
     ("sdram_clock", 0, Pins("43"), IOStandard("3.3-V LVTTL")),
     ("sdram", 0,
         Subsignal("a", Pins(

--- a/litex_boards/platforms/rz_easyfpga.py
+++ b/litex_boards/platforms/rz_easyfpga.py
@@ -24,56 +24,7 @@ _io = [
         # Compatible with cheap FT232 based cables (ex: Gaoominy 6Pin Ftdi Ft232Rl Ft232)
         # GND on JP1 Pin 12.
         Subsignal("tx", Pins("114"), IOStandard("3.3-V LVTTL")),
-        Subsignal("rx", Pins("115"),  IOStandard("3.3-V LVTTL"))
-    ),
-
-    # SPI Flash (also used for bistream programming, need to use AS mode and set as "input/output" after configuration)
-    # no idea why they can't support it in JTAG mode
-    ("spiflash4x", 0,
-        Subsignal("cs_n", Pins("8")),
-        Subsignal("clk", Pins("12")),
-        Subsignal("dq", Pins("13 6 132 133")),
-        IOStandard("3.3-V LVTTL")
-    ),
-    ("spiflash", 0,
-        Subsignal("cs_n", Pins("8")),
-        Subsignal("clk", Pins("12")),
-        Subsignal("mosi", Pins("13")),
-        Subsignal("miso", Pins("6")),
-        Subsignal("wp", Pins("132")),
-        Subsignal("hold", Pins("133")),
-        IOStandard("3.3-V LVTTL"),
-    ),
-
-    # set_instance_assignment -name DCLK_PIN OFF -to DCLK
-    # set_instance_assignment -name DATA0_PIN OFF -to D0
-    # set_instance_assignment -name IO_MAXIMUM_TOGGLE_RATE "0MHz" -to *
-
-    # set_global_assignment -name CYCLONEII_RESERVE_NCEO_AFTER_CONFIGURATION "USE AS REGULAR IO"
-    # set_global_assignment -name RESERVE_DATA0_AFTER_CONFIGURATION "USE AS REGULAR IO"
-    # set_global_assignment -name RESERVE_DATA1_AFTER_CONFIGURATION "USE AS REGULAR IO"
-    # set_global_assignment -name RESERVE_FLASH_NCE_AFTER_CONFIGURATION "USE AS REGULAR IO"
-    # set_global_assignment -name RESERVE_DCLK_AFTER_CONFIGURATION "USE AS REGULAR IO"
-    # set_global_assignment -name SDC_FILE rz_easyfpga.sdc
-
-
-    # SDRAM
-    ("sdram_clock", 0, Pins("43"), IOStandard("3.3-V LVTTL")),
-    ("sdram", 0,
-        Subsignal("a", Pins(
-            "76 77 80 83 68 67 66 65",
-            "64 60 75 59")),
-        Subsignal("ba",    Pins("73 74")),
-        Subsignal("cs_n",  Pins("72")),
-        Subsignal("cke",   Pins("58")),
-        Subsignal("ras_n", Pins("71")),
-        Subsignal("cas_n", Pins("70")),
-        Subsignal("we_n",  Pins("69")),
-        Subsignal("dq", Pins(
-            "28 30 31 32 33 34 38 39",
-            "54 53 52 51 50 49 46 44")),
-        Subsignal("dm", Pins("42 55")),
-        IOStandard("3.3-V LVTTL")
+        Subsignal("rx", Pins("115"), IOStandard("3.3-V LVTTL"))
     ),
 ]
 

--- a/litex_boards/platforms/rz_easyfpga.py
+++ b/litex_boards/platforms/rz_easyfpga.py
@@ -26,6 +26,25 @@ _io = [
         Subsignal("tx", Pins("114"), IOStandard("3.3-V LVTTL")),
         Subsignal("rx", Pins("115"), IOStandard("3.3-V LVTTL"))
     ),
+
+    # SDRAM
+    ("sdram_clock", 0, Pins("43"), IOStandard("3.3-V LVTTL")),
+    ("sdram", 0,
+        Subsignal("a", Pins(
+            "76 77 80 83 68 67 66 65",
+            "64 60 75 59")),
+        Subsignal("ba",    Pins("73 74")),
+        Subsignal("cs_n",  Pins("72")),
+        Subsignal("cke",   Pins("58")),
+        Subsignal("ras_n", Pins("71")),
+        Subsignal("cas_n", Pins("70")),
+        Subsignal("we_n",  Pins("69")),
+        Subsignal("dq", Pins(
+            "28 30 31 32 33 34 38 39",
+            "54 53 52 51 50 49 46 44")),
+        Subsignal("dm", Pins("42 55")),
+        IOStandard("3.3-V LVTTL")
+    ),
 ]
 
 
@@ -44,3 +63,7 @@ class Platform(AlteraPlatform):
     def do_finalize(self, fragment):
         AlteraPlatform.do_finalize(self, fragment)
         self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)
+        # Generate PLL clock in STA
+        self.toolchain.additional_sdc_commands.append("derive_pll_clocks")
+        # Calculates clock uncertainties
+        self.toolchain.additional_sdc_commands.append("derive_clock_uncertainty")

--- a/litex_boards/platforms/rz_easyfpga.py
+++ b/litex_boards/platforms/rz_easyfpga.py
@@ -1,6 +1,7 @@
 #
 # This file is part of LiteX-Boards.
 #
+# Copyright (c) 2021 Alain Lou <alainzlou@gmail.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.build.generic_platform import *
@@ -21,13 +22,14 @@ _io = [
 
     # Serial
     ("serial", 0,
-        # Compatible with cheap FT232 based cables (ex: Gaoominy 6Pin Ftdi Ft232Rl Ft232)
-        # GND on JP1 Pin 12.
+        # Uses the 9 pin serial connector
         Subsignal("tx", Pins("114"), IOStandard("3.3-V LVTTL")),
         Subsignal("rx", Pins("115"), IOStandard("3.3-V LVTTL"))
     ),
 
     # SDRAM
+    # It may help to add a header cable to some pins to mitigate potential electrical problems on the board
+    # (especially pin 67, but perhaps also 66 and 68)
     ("sdram_clock", 0, Pins("43"), IOStandard("3.3-V LVTTL")),
     ("sdram", 0,
         Subsignal("a", Pins(

--- a/litex_boards/platforms/rz_easyfpga.py
+++ b/litex_boards/platforms/rz_easyfpga.py
@@ -23,8 +23,8 @@ _io = [
     ("serial", 0,
         # Compatible with cheap FT232 based cables (ex: Gaoominy 6Pin Ftdi Ft232Rl Ft232)
         # GND on JP1 Pin 12.
-        Subsignal("tx", Pins("128"), IOStandard("3.3-V LVTTL")),
-        Subsignal("rx", Pins("126"), IOStandard("3.3-V LVTTL"))
+        Subsignal("tx", Pins("114"), IOStandard("3.3-V LVTTL")),
+        Subsignal("rx", Pins("115"), IOStandard("3.3-V LVTTL"))
     ),
 
     # SDRAM

--- a/litex_boards/platforms/rz_easyfpga.py
+++ b/litex_boards/platforms/rz_easyfpga.py
@@ -23,8 +23,8 @@ _io = [
     ("serial", 0,
         # Compatible with cheap FT232 based cables (ex: Gaoominy 6Pin Ftdi Ft232Rl Ft232)
         # GND on JP1 Pin 12.
-        Subsignal("tx", Pins("114"), IOStandard("3.3-V LVTTL")),
-        Subsignal("rx", Pins("115"), IOStandard("3.3-V LVTTL"))
+        Subsignal("tx", Pins("128"), IOStandard("3.3-V LVTTL")),
+        Subsignal("rx", Pins("126"), IOStandard("3.3-V LVTTL"))
     ),
 
     # SDRAM

--- a/litex_boards/platforms/rz_easyfpga.py
+++ b/litex_boards/platforms/rz_easyfpga.py
@@ -25,7 +25,56 @@ _io = [
         # GND on JP1 Pin 12.
         Subsignal("tx", Pins("114"), IOStandard("3.3-V LVTTL")),
         Subsignal("rx", Pins("115"),  IOStandard("3.3-V LVTTL"))
-    )
+    ),
+
+    # SPI Flash (also used for bistream programming, need to use AS mode and set as "input/output" after configuration)
+    # no idea why they can't support it in JTAG mode
+    ("spiflash4x", 0,
+        Subsignal("cs_n", Pins("8")),
+        Subsignal("clk", Pins("12")),
+        Subsignal("dq", Pins("13 6 132 133")),
+        IOStandard("3.3-V LVTTL")
+    ),
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("8")),
+        Subsignal("clk", Pins("12")),
+        Subsignal("mosi", Pins("13")),
+        Subsignal("miso", Pins("6")),
+        Subsignal("wp", Pins("132")),
+        Subsignal("hold", Pins("133")),
+        IOStandard("3.3-V LVTTL"),
+    ),
+
+    # set_instance_assignment -name DCLK_PIN OFF -to DCLK
+    # set_instance_assignment -name DATA0_PIN OFF -to D0
+    # set_instance_assignment -name IO_MAXIMUM_TOGGLE_RATE "0MHz" -to *
+
+    # set_global_assignment -name CYCLONEII_RESERVE_NCEO_AFTER_CONFIGURATION "USE AS REGULAR IO"
+    # set_global_assignment -name RESERVE_DATA0_AFTER_CONFIGURATION "USE AS REGULAR IO"
+    # set_global_assignment -name RESERVE_DATA1_AFTER_CONFIGURATION "USE AS REGULAR IO"
+    # set_global_assignment -name RESERVE_FLASH_NCE_AFTER_CONFIGURATION "USE AS REGULAR IO"
+    # set_global_assignment -name RESERVE_DCLK_AFTER_CONFIGURATION "USE AS REGULAR IO"
+    # set_global_assignment -name SDC_FILE rz_easyfpga.sdc
+
+
+    # SDRAM
+    ("sdram_clock", 0, Pins("43"), IOStandard("3.3-V LVTTL")),
+    ("sdram", 0,
+        Subsignal("a", Pins(
+            "76 77 80 83 68 67 66 65",
+            "64 60 75 59")),
+        Subsignal("ba",    Pins("73 74")),
+        Subsignal("cs_n",  Pins("72")),
+        Subsignal("cke",   Pins("58")),
+        Subsignal("ras_n", Pins("71")),
+        Subsignal("cas_n", Pins("70")),
+        Subsignal("we_n",  Pins("69")),
+        Subsignal("dq", Pins(
+            "28 30 31 32 33 34 38 39",
+            "54 53 52 51 50 49 46 44")),
+        Subsignal("dm", Pins("42 55")),
+        IOStandard("3.3-V LVTTL")
+    ),
 ]
 
 

--- a/litex_boards/targets/rz_easyfpga.py
+++ b/litex_boards/targets/rz_easyfpga.py
@@ -57,7 +57,7 @@ class BaseSoC(SoCCore):
 
         # Limit internal rom and sram size
         kwargs["integrated_rom_size"]  = 0x6000
-        kwargs["integrated_sram_size"] = 0x800
+        kwargs["integrated_sram_size"] = 0x1000
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq,
@@ -69,13 +69,13 @@ class BaseSoC(SoCCore):
         self.submodules.crg = _CRG(platform, sys_clk_freq)
 
         # SDR SDRAM --------------------------------------------------------------------------------
-        if not self.integrated_main_ram_size:
-            self.submodules.sdrphy = GENSDRPHY(platform.request("sdram"), sys_clk_freq)
-            self.add_sdram("sdram",
-                phy           = self.sdrphy,
-                module        = HY57V641620FTP(sys_clk_freq, "1:1"), # Hynix
-                l2_cache_size = kwargs.get("l2_size", 0)
-            )
+        # if not self.integrated_main_ram_size:
+        #     self.submodules.sdrphy = GENSDRPHY(platform.request("sdram"), sys_clk_freq)
+        #     self.add_sdram("sdram",
+        #         phy           = self.sdrphy,
+        #         module        = HY57V641620FTP(sys_clk_freq, "1:1"), # Hynix
+        #         l2_cache_size = 0
+        #     )
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:

--- a/litex_boards/targets/rz_easyfpga.py
+++ b/litex_boards/targets/rz_easyfpga.py
@@ -20,18 +20,12 @@ from litex.soc.integration.builder import *
 from litex.soc.integration.soc import SoCRegion
 from litex.soc.cores.led import LedChaser
 
-from litedram.modules import HY57V641620FTP
-from litedram.phy import GENSDRPHY
-
-kB = 1024
-
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(Module):
     def __init__(self, platform, sys_clk_freq, sdram_rate="1:1"):
         self.rst = Signal()
         self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_sys_ps = ClockDomain(reset_less=True)
 
         # # #
 
@@ -39,31 +33,23 @@ class _CRG(Module):
         clk50 = platform.request("clk50")
 
         # PLL
-        self.submodules.pll = pll = CycloneIVPLL(speedgrade="-8")
+        self.submodules.pll = pll = CycloneIVPLL(speedgrade="-6")
         self.comb += pll.reset.eq(self.rst)
         pll.register_clkin(clk50, 50e6)
         pll.create_clkout(self.cd_sys, sys_clk_freq)
-        pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
-
-        # SDRAM clock
-        self.comb += platform.request("sdram_clock").eq(self.cd_sys_ps.clk)
 
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    mem_map = {**SoCCore.mem_map, **{"spiflash": 0x80000000}}
-    def __init__(self, bios_flash_offset, spi_flash_module="W25Q16JV", sys_clk_freq=int(50e6),
-                 with_led_chaser=True, **kwargs):
+    def __init__(self, sys_clk_freq=int(50e6), with_led_chaser=True, **kwargs):
+
         print(kwargs)
 
         platform = rz_easyfpga.Platform()
 
-        # Use external ROM since too large for Cyclone IV EP4CE6
-        kwargs["integrated_rom_size"]  = 0
-        kwargs["integrated_sram_size"] = 0x800
-
-        # Set CPU variant / reset address
-        kwargs["cpu_reset_address"] = self.mem_map["spiflash"] + bios_flash_offset
+        # Limit internal rom and sram size
+        kwargs["integrated_rom_size"]  = 0x6000
+        kwargs["integrated_sram_size"] = 0x1000
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq,
@@ -73,32 +59,6 @@ class BaseSoC(SoCCore):
 
         # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = _CRG(platform, sys_clk_freq)
-
-        # SDR SDRAM --------------------------------------------------------------------------------
-        if not self.integrated_main_ram_size:
-            self.submodules.sdrphy = GENSDRPHY(platform.request("sdram"), sys_clk_freq)
-            self.add_sdram("sdram",
-                phy           = self.sdrphy,
-                module        = HY57V641620FTP(sys_clk_freq, "1:1"), # Hynix
-                l2_cache_size = kwargs.get("l2_size", 0)
-            )
-
-        # SPI Flash --------------------------------------------------------------------------------
-        from litespi.modules import W25Q16JV
-        from litespi.opcodes import SpiNorFlashOpCodes as Codes
-
-        # lambdas for lazy module instantiation.
-        spi_flash_modules = {
-            "W25Q16JV":  lambda: W25Q16JV( Codes.READ_1_1_4),
-        }
-        self.add_spi_flash(mode="4x", module=spi_flash_modules[spi_flash_module](), with_master=False)
-
-        # Add ROM linker region --------------------------------------------------------------------
-        self.bus.add_region("rom", SoCRegion(
-            origin = self.mem_map["spiflash"] + bios_flash_offset,
-            size   = 32*kB,
-            linker = True)
-        )
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:
@@ -113,15 +73,11 @@ def main():
     parser.add_argument("--build",        action="store_true", help="Build bitstream")
     parser.add_argument("--load",         action="store_true", help="Load bitstream")
     parser.add_argument("--sys-clk-freq", default=50e6,        help="System clock frequency (default: 50MHz)")
-    parser.add_argument("--bios-flash-offset", default=0x20000,     help="BIOS offset in SPI Flash (default: 0x20000)")
     builder_args(parser)
     soc_core_args(parser)
     args = parser.parse_args()
 
-    dfu_flash_offset = 0x40000
-
     soc = BaseSoC(
-        bios_flash_offset = dfu_flash_offset + args.bios_flash_offset,
         sys_clk_freq = int(float(args.sys_clk_freq)),
         **soc_core_argdict(args)
     )

--- a/litex_boards/targets/rz_easyfpga.py
+++ b/litex_boards/targets/rz_easyfpga.py
@@ -2,7 +2,7 @@
 
 #
 # This file is part of LiteX-Boards.
-#
+# Copyright (c) 2021 Alain Lou <alainzlou@gmail.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
@@ -17,16 +17,15 @@ from litex_boards.platforms import rz_easyfpga
 from litex.soc.cores.clock import CycloneIVPLL
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
-from litex.soc.integration.soc import SoCRegion
 from litex.soc.cores.led import LedChaser
 
-from litedram.modules import HY57V641620FTP
-from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
+from litedram.modules import MT48LC4M16
+from litedram.phy import GENSDRPHY
 
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(Module):
-    def __init__(self, platform, sys_clk_freq, sdram_rate="1:1"):
+    def __init__(self, platform, sys_clk_freq):
         self.rst = Signal()
         self.clock_domains.cd_sys = ClockDomain()
         self.clock_domains.cd_sys_ps = ClockDomain(reset_less=True)
@@ -41,25 +40,15 @@ class _CRG(Module):
         self.comb += pll.reset.eq(self.rst)
         pll.register_clkin(clk50, 50e6)
         pll.create_clkout(self.cd_sys, sys_clk_freq)
-        if sdram_rate == "1:2":
-            pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
-            # theoretically 90 degrees, but increase to relax timing
-            pll.create_clkout(self.cd_sys2x_ps, 2*sys_clk_freq, phase=180)
-        else:
-            pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
 
         # SDRAM clock
-        sdram_clk = ClockSignal("sys2x_ps" if sdram_rate == "1:2" else "sys_ps")
-        self.specials += DDROutput(1, 0, platform.request("sdram_clock"), sdram_clk)
-
+        self.comb += platform.request("sdram_clock").eq(self.cd_sys_ps.clk)
 
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), with_led_chaser=True, sdram_rate="1:1", **kwargs):
-
-        print(kwargs)
-
+    def __init__(self, sys_clk_freq=int(25e6), with_led_chaser=True, **kwargs):
         platform = rz_easyfpga.Platform()
 
         # Limit internal rom and sram size
@@ -77,11 +66,11 @@ class BaseSoC(SoCCore):
 
         # SDR SDRAM --------------------------------------------------------------------------------
         if not self.integrated_main_ram_size:
-            sdrphy_cls = HalfRateGENSDRPHY if sdram_rate == "1:2" else GENSDRPHY
+            sdrphy_cls = GENSDRPHY
             self.submodules.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
             self.add_sdram("sdram",
                 phy           = self.sdrphy,
-                module        = HY57V641620FTP(sys_clk_freq, sdram_rate), # Hynix
+                module        = MT48LC4M16(sys_clk_freq, "1:1"), # Hynix HY57V641620FTP-7
                 l2_cache_size = 0
             )
 
@@ -97,7 +86,6 @@ def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on RZ-EasyFPGA")
     parser.add_argument("--build",        action="store_true", help="Build bitstream")
     parser.add_argument("--load",         action="store_true", help="Load bitstream")
-    parser.add_argument("--sdram-rate",   default="1:1",       help="SDRAM Rate: 1:1 Full Rate (default) or 1:2 Half Rate")
     parser.add_argument("--sys-clk-freq", default=25e6,        help="System clock frequency (default: 25MHz)")
     builder_args(parser)
     soc_core_args(parser)

--- a/litex_boards/targets/rz_easyfpga.py
+++ b/litex_boards/targets/rz_easyfpga.py
@@ -20,6 +20,9 @@ from litex.soc.integration.builder import *
 from litex.soc.integration.soc import SoCRegion
 from litex.soc.cores.led import LedChaser
 
+from litedram.modules import HY57V641620FTP
+from litedram.phy import GENSDRPHY
+
 kB = 1024
 
 # CRG ----------------------------------------------------------------------------------------------
@@ -28,6 +31,7 @@ class _CRG(Module):
     def __init__(self, platform, sys_clk_freq, sdram_rate="1:1"):
         self.rst = Signal()
         self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sys_ps = ClockDomain(reset_less=True)
 
         # # #
 
@@ -39,18 +43,27 @@ class _CRG(Module):
         self.comb += pll.reset.eq(self.rst)
         pll.register_clkin(clk50, 50e6)
         pll.create_clkout(self.cd_sys, sys_clk_freq)
+        pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
+
+        # SDRAM clock
+        self.comb += platform.request("sdram_clock").eq(self.cd_sys_ps.clk)
 
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), with_led_chaser=True, **kwargs):
+    mem_map = {**SoCCore.mem_map, **{"spiflash": 0x80000000}}
+    def __init__(self, bios_flash_offset, spi_flash_module="W25Q16JV", sys_clk_freq=int(50e6),
+                 with_led_chaser=True, **kwargs):
         print(kwargs)
 
         platform = rz_easyfpga.Platform()
 
-        self.integrated_main_ram_size = 0x2000
-        kwargs["integrated_rom_size"]  = 0x6000
-        kwargs["integrated_sram_size"] = 0x1000
+        # Use external ROM since too large for Cyclone IV EP4CE6
+        kwargs["integrated_rom_size"]  = 0
+        kwargs["integrated_sram_size"] = 0x800
+
+        # Set CPU variant / reset address
+        kwargs["cpu_reset_address"] = self.mem_map["spiflash"] + bios_flash_offset
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq,
@@ -60,6 +73,32 @@ class BaseSoC(SoCCore):
 
         # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = _CRG(platform, sys_clk_freq)
+
+        # SDR SDRAM --------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.submodules.sdrphy = GENSDRPHY(platform.request("sdram"), sys_clk_freq)
+            self.add_sdram("sdram",
+                phy           = self.sdrphy,
+                module        = HY57V641620FTP(sys_clk_freq, "1:1"), # Hynix
+                l2_cache_size = kwargs.get("l2_size", 0)
+            )
+
+        # SPI Flash --------------------------------------------------------------------------------
+        from litespi.modules import W25Q16JV
+        from litespi.opcodes import SpiNorFlashOpCodes as Codes
+
+        # lambdas for lazy module instantiation.
+        spi_flash_modules = {
+            "W25Q16JV":  lambda: W25Q16JV( Codes.READ_1_1_4),
+        }
+        self.add_spi_flash(mode="4x", module=spi_flash_modules[spi_flash_module](), with_master=False)
+
+        # Add ROM linker region --------------------------------------------------------------------
+        self.bus.add_region("rom", SoCRegion(
+            origin = self.mem_map["spiflash"] + bios_flash_offset,
+            size   = 32*kB,
+            linker = True)
+        )
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:
@@ -74,11 +113,15 @@ def main():
     parser.add_argument("--build",        action="store_true", help="Build bitstream")
     parser.add_argument("--load",         action="store_true", help="Load bitstream")
     parser.add_argument("--sys-clk-freq", default=50e6,        help="System clock frequency (default: 50MHz)")
+    parser.add_argument("--bios-flash-offset", default=0x20000,     help="BIOS offset in SPI Flash (default: 0x20000)")
     builder_args(parser)
     soc_core_args(parser)
     args = parser.parse_args()
 
+    dfu_flash_offset = 0x40000
+
     soc = BaseSoC(
+        bios_flash_offset = dfu_flash_offset + args.bios_flash_offset,
         sys_clk_freq = int(float(args.sys_clk_freq)),
         **soc_core_argdict(args)
     )

--- a/litex_boards/targets/rz_easyfpga.py
+++ b/litex_boards/targets/rz_easyfpga.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import argparse
+
+from migen import *
+
+from litex.build.io import DDROutput
+
+from litex_boards.platforms import rz_easyfpga
+
+from litex.soc.cores.clock import CycloneIVPLL
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.cores.led import LedChaser
+
+kB = 1024
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq, sdram_rate="1:1"):
+        self.rst = Signal()
+        self.clock_domains.cd_sys = ClockDomain()
+
+        # # #
+
+        # Clk / Rst
+        clk50 = platform.request("clk50")
+
+        # PLL
+        self.submodules.pll = pll = CycloneIVPLL(speedgrade="-8")
+        self.comb += pll.reset.eq(self.rst)
+        pll.register_clkin(clk50, 50e6)
+        pll.create_clkout(self.cd_sys, sys_clk_freq)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=int(50e6), with_led_chaser=True, **kwargs):
+        print(kwargs)
+
+        platform = rz_easyfpga.Platform()
+
+        self.integrated_main_ram_size = 0x2000
+        kwargs["integrated_rom_size"]  = 0x6000
+        kwargs["integrated_sram_size"] = 0x1000
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            ident          = "LiteX SoC on RZ-EasyFPGA",
+            ident_version  = True,
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on RZ-EasyFPGA")
+    parser.add_argument("--build",        action="store_true", help="Build bitstream")
+    parser.add_argument("--load",         action="store_true", help="Load bitstream")
+    parser.add_argument("--sys-clk-freq", default=50e6,        help="System clock frequency (default: 50MHz)")
+    builder_args(parser)
+    soc_core_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq = int(float(args.sys_clk_freq)),
+        **soc_core_argdict(args)
+    )
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build(run=args.build)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".sof"))
+
+if __name__ == "__main__":
+    main()

--- a/litex_boards/targets/rz_easyfpga.py
+++ b/litex_boards/targets/rz_easyfpga.py
@@ -56,7 +56,7 @@ class BaseSoC(SoCCore):
         platform = rz_easyfpga.Platform()
 
         # Limit internal rom and sram size
-        kwargs["integrated_rom_size"]  = 0x6000
+        kwargs["integrated_rom_size"]  = 0x6200
         kwargs["integrated_sram_size"] = 0x1000
 
         # SoCCore ----------------------------------------------------------------------------------

--- a/litex_boards/targets/rz_easyfpga.py
+++ b/litex_boards/targets/rz_easyfpga.py
@@ -69,13 +69,14 @@ class BaseSoC(SoCCore):
         self.submodules.crg = _CRG(platform, sys_clk_freq)
 
         # SDR SDRAM --------------------------------------------------------------------------------
-        # if not self.integrated_main_ram_size:
-        #     self.submodules.sdrphy = GENSDRPHY(platform.request("sdram"), sys_clk_freq)
-        #     self.add_sdram("sdram",
-        #         phy           = self.sdrphy,
-        #         module        = HY57V641620FTP(sys_clk_freq, "1:1"), # Hynix
-        #         l2_cache_size = 0
-        #     )
+        self.integrated_main_ram_size = 0
+
+        self.submodules.sdrphy = GENSDRPHY(platform.request("sdram"), sys_clk_freq)
+        self.add_sdram("sdram",
+            phy           = self.sdrphy,
+            module        = HY57V641620FTP(sys_clk_freq, "1:1"), # Hynix
+            l2_cache_size = 0
+        )
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:

--- a/litex_boards/targets/rz_easyfpga.py
+++ b/litex_boards/targets/rz_easyfpga.py
@@ -12,7 +12,7 @@ from migen import *
 
 from litex.build.io import DDROutput
 
-from litex_boards.platforms import rz_easyfpga
+from litex_boards.platforms import easyfpga
 
 from litex.soc.cores.clock import CycloneIVPLL
 from litex.soc.integration.soc_core import *
@@ -49,7 +49,7 @@ class _CRG(Module):
 
 class BaseSoC(SoCCore):
     def __init__(self, sys_clk_freq=int(25e6), with_led_chaser=True, **kwargs):
-        platform = rz_easyfpga.Platform()
+        platform = easyfpga.Platform()
 
         # Limit internal rom and sram size
         kwargs["integrated_rom_size"]  = 0x6200


### PR DESCRIPTION
There is potentially one board issue which is noted in the #253 issue (specifically [this comment](https://github.com/litex-hub/litex-boards/issues/253#issuecomment-920558638)) and also [this code comment](https://github.com/litex-hub/litex-boards/compare/master...alainlou:master#diff-792c8ead031c2124b2580e48db8fbcc74cb5dbb89ba2f1496b5809527568513dR31)

Other than that, we have it working with:
- 4 LEDs
- UART
- External SDRAM

Thank you to these people for a ton of help and support with this so far!
@tcal-x @jevinskie

Usage:
`./rz_easyfpga.py --cpu-type=vexriscv --cpu-variant=minimal`