### PR TITLE
rz_easyfpga: adjust SDRAM clk phase, also add 1:2 rate

### DIFF
--- a/litex_boards/platforms/rz_easyfpga.py
+++ b/litex_boards/platforms/rz_easyfpga.py
@@ -28,8 +28,6 @@ _io = [
     ),
 
     # SDRAM
-    # It may help to add a header cable to some pins to mitigate suspected electrical problems on the board
-    # (especially pin 67, but adding cables to the whole addr bus seemed to be the most robust)
     ("sdram_clock", 0, Pins("43"), IOStandard("3.3-V LVTTL")),
     ("sdram", 0,
         Subsignal("a", Pins(
@@ -48,7 +46,6 @@ _io = [
         IOStandard("3.3-V LVTTL")
     ),
 ]
-
 
 # Platform -----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Thanks @enjoy-digital for the pointer! You were right, the SDRAM clk phase did need to be adjusted. Adding wires had somehow mitigated this.

Reference: #270