### PR TITLE
rz_easyfpga: cleanup and ease of use

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The Colorlight5A is a very nice board to start with, cheap, powerful, easy to us
 | QMTech XC7A35T | Xilinx Artix7       | XC7A35T       | 100MHz  | FTDI | 16-bit 256MB DDR3  |     No    |   1Gbps GMII** |  16MB QSPI  |   Yes**|
 | QMTech Wukong1 | Xilinx Artix7       | XC7A100T      | 100MHz  | FTDI | 16-bit 256MB DDR3  |     No    |   1Gbps GMII   |  16MB QSPI  |   Yes**|
 | QMTech Wukong2 | Xilinx Artix7       | XC7A100T/200T | 100MHz  | FTDI | 16-bit 256MB DDR3  |     No    |   1Gbps GMII   |  16MB QSPI  |   Yes  |
-| RZ-EasyFPGA    | Intel Cyclone4      | EP4CE6        |  25MHz  | IOs  | 16-bit   8MB SDR   |     No    |       No       |      No     |   No   |
+| RZ-EasyFPGA    | Intel Cyclone4      | EP4CE6        |  50MHz  | IOs  | 16-bit   8MB SDR   |     No    |       No       |      No     |   No   |
 | SP605          | Xilinx Spartan6     | XC6SLX45T     | 100MHz  | FTDI | 16-bit 128MB DDR3* |  Gen1 X1* |   1Gbps GMII   |   8MB QSPI* |   Yes* |
 | Tagus          | Xilinx Artix7       | XC7A200T      | 100MHz  | PCIe | 16-bit 256MB DDR3  |  Gen2 X1  |  1Gbps-BASE-X* |  16MB QSPI* |   No   |
 | VC707          | Xilinx Virex7       | XC7VX485T     | 125MHz  | FTDI | 64-bit   1GB DDR3  |  Gen3 X8* |   1Gbps GMII   |  16MB QSPI* |   Yes* |

--- a/litex_boards/platforms/rz_easyfpga.py
+++ b/litex_boards/platforms/rz_easyfpga.py
@@ -62,7 +62,3 @@ class Platform(AlteraPlatform):
     def do_finalize(self, fragment):
         AlteraPlatform.do_finalize(self, fragment)
         self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)
-        # Generate PLL clock in STA
-        self.toolchain.additional_sdc_commands.append("derive_pll_clocks")
-        # Calculates clock uncertainties
-        self.toolchain.additional_sdc_commands.append("derive_clock_uncertainty")

--- a/litex_boards/targets/rz_easyfpga.py
+++ b/litex_boards/targets/rz_easyfpga.py
@@ -2,6 +2,7 @@
 
 #
 # This file is part of LiteX-Boards.
+#
 # Copyright (c) 2021 Alain Lou <alainzlou@gmail.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -63,6 +64,10 @@ class BaseSoC(SoCCore):
         # Limit internal rom and sram size
         kwargs["integrated_rom_size"]  = 0x6200
         kwargs["integrated_sram_size"] = 0x1000
+
+        # Can only support minimal variant of vexriscv
+        if kwargs.get("cpu_type", "vexriscv") == "vexriscv":
+            kwargs["cpu_variant"] = "minimal"
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq,


### PR DESCRIPTION
- update README
- delete some unnecessary toolchain commands (copied from trenz boards)
- use minimal cpu_variant by default when vexriscv is selected