### PR TITLE
Add support for QMTech 10CL006 board

### DIFF
--- a/litex_boards/platforms/qmtech_10cl006.py
+++ b/litex_boards/platforms/qmtech_10cl006.py
@@ -1,0 +1,162 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2021 Hans Baier <hansfbaier@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.altera import AlteraPlatform
+from litex.build.altera.programmer import USBBlaster
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk
+    ("clk50", 0, Pins("E1"), IOStandard("3.3-V LVTTL")),
+
+    # Button
+    ("key", 0, Pins("F3"),  IOStandard("3.3-V LVTTL")),
+    ("key", 1, Pins("J6"),  IOStandard("3.3-V LVTTL")),
+
+    # Serial
+    ("serial", 0,
+        # Compatible with cheap FT232 based cables (ex: Gaoominy 6Pin Ftdi Ft232Rl Ft232)
+        Subsignal("tx", Pins("J3:7"), IOStandard("3.3-V LVTTL")), # GPIO_07 (JP1 Pin 10)
+        Subsignal("rx", Pins("J3:8"), IOStandard("3.3-V LVTTL"))  # GPIO_05 (JP1 Pin 8)
+    ),
+
+    # SPIFlash (W25Q64)
+    ("spiflash", 0,
+        # clk
+        Subsignal("cs_n", Pins("D2")),
+        Subsignal("clk",  Pins("H1")),
+        Subsignal("mosi", Pins("C1")),
+        Subsignal("miso", Pins("H2")),
+        IOStandard("3.3-V LVTTL"),
+    ),
+
+    # SDR SDRAM
+    ("sdram_clock", 0, Pins("Y6"), IOStandard("3.3-V LVTTL")),
+    ("sdram", 0,
+        Subsignal("a",     Pins(
+            "R7 T7 R8 T8 R6 T5 R5 T4",
+            "R4 T3 T6 R3 T2")),
+        Subsignal("ba",    Pins("N8 L8")),
+        Subsignal("cs_n",  Pins("P8")),
+        Subsignal("cke",   Pins("R1")),
+        Subsignal("ras_n", Pins("M8")),
+        Subsignal("cas_n", Pins("M7")),
+        Subsignal("we_n",  Pins("P6")),
+        Subsignal("dq", Pins(
+            "K5 L3 L4 K6 N3 M6 P3 N5",
+            "N2 N1 L1 L2 K1 K2 J1 J2")),
+        Subsignal("dm", Pins("N6 P1")),
+        IOStandard("3.3-V LVTTL")
+    ),
+]
+
+# The connectors are named after the daughterboard, not the core board
+# because on the different core boards the names vary, but on the
+# daughterboard they stay the same, which we need to connect the
+# daughterboard peripherals to the core board.
+# On this board J2 is U7 and J3 is U8
+_connectors = [
+    ("J2", {
+         # odd row     even row
+          7: "G1",    8: "G2",
+          9: "D1",   10: "C2",
+         11: "B1",   12: "F5",
+         13: "D3",   14: "C3",
+         15: "B3",   16: "A3",
+         17: "B4",   18: "A4",
+         19: "E5",   20: "A2",
+         21: "D4",   22: "E6",
+         23: "C6",   24: "D6",
+         25: "B5",   26: "A5",
+         27: "B6",   28: "A6",
+         29: "B7",   30: "A7",
+         31: "D8",   32: "C8",
+         33: "D9",   34: "C9",
+         35: "B8",   36: "A8",
+         37: "B9",   38: "A9",
+         39: "E9",   40: "E8",
+         41: "E11",  42: "E10",
+         43: "A10",  44: "B10",
+         45: "D12",  46: "D11",
+         47: "B11",  48: "A11",
+         49: "B12",  50: "A12",
+         51: "B13",  52: "A13",
+         53: "B14",  54: "A14",
+         55: "D14",  56: "C14",
+         57: "B16",  58: "A15",
+         59: "C16",  60: "C15",
+    }),
+    ("J3", {
+        # odd row     even row
+         7: "R9",     8: "T9",
+         9: "R10",   10: "T10",
+        11: "R11",   12: "T11",
+        13: "R12",   14: "T12",
+        15: "N9",    16: "M9",
+        17: "M10",   18: "P9",
+        19: "P11",   20: "N11",
+        21: "R13",   22: "T13",
+        23: "T15",   24: "T14",
+        25: "N12",   26: "M11",
+        27: "R14",   28: "N13",
+        29: "N14",   30: "P14",
+        31: "P16",   32: "R16",
+        33: "N16",   34: "N15",
+        35: "M16",   36: "M15",
+        37: "L16",   38: "L15",
+        39: "P15",   40: "M12",
+        41: "L14",   42: "L13",
+        43: "K16",   44: "K15",
+        45: "K12",   46: "J12",
+        47: "J14",   48: "J13",
+        49: "K11",   50: "J11",
+        51: "G11",   52: "F11",
+        53: "F13",   54: "F14",
+        55: "F10",   56: "F9",
+        57: "E16",   58: "E15",
+        59: "D16",   60: "D15",
+    })
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(AlteraPlatform):
+    default_clk_name   = "clk50"
+    default_clk_period = 1e9/50e6
+    core_resources = [ ("user_led", 0, Pins("L9"), IOStandard("3.3-V LVTTL")) ]
+
+    def __init__(self, with_daughterboard=False):
+        device = "10CL006YU256C8G"
+        io = _io
+        connectors = _connectors
+
+        if with_daughterboard:
+            from litex_boards.platforms.qmtech_daughterboard import QMTechDaughterboard
+            daughterboard = QMTechDaughterboard(IOStandard("3.3-V LVTTL"))
+            io += daughterboard.io
+            connectors += daughterboard.connectors
+        else:
+            io += self.core_resources
+
+        AlteraPlatform.__init__(self, device, io, connectors)
+
+        if with_daughterboard:
+            # an ethernet pin takes K22, so make it available
+            self.add_platform_command("set_global_assignment -name CYCLONEII_RESERVE_NCEO_AFTER_CONFIGURATION \"USE AS REGULAR IO\"")
+
+        # Generate PLL clock in STA
+        self.toolchain.additional_sdc_commands.append("derive_pll_clocks")
+        # Calculates clock uncertainties
+        self.toolchain.additional_sdc_commands.append("derive_clock_uncertainty")
+
+    def create_programmer(self):
+        return USBBlaster()
+
+    def do_finalize(self, fragment):
+        AlteraPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)

--- a/litex_boards/targets/qmtech_10cl006.py
+++ b/litex_boards/targets/qmtech_10cl006.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2021 Hans Baier <hansfbaier@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import argparse
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.build.io import DDROutput
+
+from litex_boards.platforms import qmtech_10cl006
+
+from litex.soc.cores.clock import Cyclone10LPPLL
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+
+from litedram.modules import IS42S16160
+from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
+
+from litex.soc.cores.video import VideoVGAPHY
+from liteeth.phy.mii import LiteEthPHYMII
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq, with_ethernet, with_vga, sdram_rate="1:1"):
+        self.rst = Signal()
+        self.clock_domains.cd_sys          = ClockDomain()
+
+        if sdram_rate == "1:2":
+            self.clock_domains.cd_sys2x    = ClockDomain()
+            self.clock_domains.cd_sys2x_ps = ClockDomain(reset_less=True)
+        else:
+            self.clock_domains.cd_sys_ps   = ClockDomain(reset_less=True)
+
+        if with_ethernet:
+            self.clock_domains.cd_eth   = ClockDomain()
+
+        if with_vga:
+            self.clock_domains.cd_vga   = ClockDomain(reset_less=True)
+
+        # # #
+
+        # Clk / Rst
+        clk50 = platform.request("clk50")
+
+        # PLL
+        self.submodules.pll = pll = Cyclone10LPPLL(speedgrade="-C8")
+        self.comb += pll.reset.eq(self.rst)
+        pll.register_clkin(clk50, 50e6)
+        pll.create_clkout(self.cd_sys,    sys_clk_freq)
+        if sdram_rate == "1:2":
+            pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
+            # theoretically 90 degrees, but increase to relax timing
+            pll.create_clkout(self.cd_sys2x_ps, 2*sys_clk_freq, phase=180)
+        else:
+            pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
+
+        if with_ethernet:
+            pll.create_clkout(self.cd_eth,   25e6)
+        if with_vga:
+            pll.create_clkout(self.cd_vga,   40e6)
+
+        # SDRAM clock
+        sdram_clk = ClockSignal("sys2x_ps" if sdram_rate == "1:2" else "sys_ps")
+        self.specials += DDROutput(1, 0, platform.request("sdram_clock"), sdram_clk)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=int(50e6), with_daughterboard=False,
+                 with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", eth_dynamic_ip=False,
+                 with_led_chaser=True, with_video_terminal=False, with_video_framebuffer=False,
+                 ident_version=True, sdram_rate="1:1", **kwargs):
+        platform = qmtech_10cl006.Platform(with_daughterboard=with_daughterboard)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            ident          = "LiteX SoC on QMTECH 10CL006" + (" + Daughterboard" if with_daughterboard else ""),
+            ident_version  = ident_version,
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform,
+                                   sys_clk_freq, with_ethernet or with_etherbone,
+                                   with_video_terminal or with_video_framebuffer,
+                                   sdram_rate=sdram_rate)
+
+        # SDR SDRAM --------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            sdrphy_cls = HalfRateGENSDRPHY if sdram_rate == "1:2" else GENSDRPHY
+            self.submodules.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
+            self.add_sdram("sdram",
+                phy           = self.sdrphy,
+                module        = IS42S16160(sys_clk_freq, sdram_rate),
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
+
+        # Ethernet / Etherbone ---------------------------------------------------------------------
+        if with_ethernet or with_etherbone:
+            self.submodules.ethphy = LiteEthPHYMII(
+                clock_pads = self.platform.request("eth_clocks"),
+                pads       = self.platform.request("eth"))
+            if with_ethernet:
+                self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip)
+            if with_etherbone:
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
+
+        # Video ------------------------------------------------------------------------------------
+        if with_video_terminal or with_video_framebuffer:
+            self.submodules.videophy = VideoVGAPHY(platform.request("vga"), clock_domain="vga")
+            if with_video_terminal:
+                self.add_video_terminal(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
+            if with_video_framebuffer:
+                self.add_video_framebuffer(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on QMTECH 10CL006")
+    parser.add_argument("--build",        action="store_true", help="Build bitstream")
+    parser.add_argument("--load",         action="store_true", help="Load bitstream")
+    parser.add_argument("--sys-clk-freq", default=50e6,        help="System clock frequency (default: 50MHz)")
+    parser.add_argument("--sdram-rate",   default="1:1",       help="SDRAM Rate: 1:1 Full Rate (default) or 1:2 Half Rate")
+    parser.add_argument("--with-daughterboard",  action="store_true",              help="Whether the core board is plugged into the QMTech daughterboard")
+    ethopts = parser.add_mutually_exclusive_group()
+    ethopts.add_argument("--with-ethernet",      action="store_true",              help="Enable Ethernet support")
+    ethopts.add_argument("--with-etherbone",     action="store_true",              help="Enable Etherbone support")
+    parser.add_argument("--eth-ip",              default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
+    parser.add_argument("--eth-dynamic-ip",      action="store_true",              help="Enable dynamic Ethernet IP addresses setting")
+    sdopts = parser.add_mutually_exclusive_group()
+    sdopts.add_argument("--with-spi-sdcard",     action="store_true",              help="Enable SPI-mode SDCard support")
+    sdopts.add_argument("--with-sdcard",         action="store_true",              help="Enable SDCard support")
+    parser.add_argument("--no-ident-version",    action="store_false",             help="Disable build time output")
+    viopts = parser.add_mutually_exclusive_group()
+    viopts.add_argument("--with-video-terminal",    action="store_true", help="Enable Video Terminal (VGA)")
+    viopts.add_argument("--with-video-framebuffer", action="store_true", help="Enable Video Framebuffer (VGA)")
+
+    builder_args(parser)
+    soc_core_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq = int(float(args.sys_clk_freq)),
+        with_daughterboard     = args.with_daughterboard,
+        with_ethernet          = args.with_ethernet,
+        with_etherbone         = args.with_etherbone,
+        eth_ip                 = args.eth_ip,
+        eth_dynamic_ip         = args.eth_dynamic_ip,
+        ident_version          = args.no_ident_version,
+        with_video_terminal    = args.with_video_terminal,
+        with_video_framebuffer = args.with_video_framebuffer,
+        sdram_rate             = args.sdram_rate,
+        **soc_core_argdict(args)
+    )
+
+    if args.with_spi_sdcard:
+        soc.add_spi_sdcard()
+    if args.with_sdcard:
+        soc.add_sdcard()
+
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build(run=args.build)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".sof"))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi Florent, 
here is another board.
Unfortunately I could not test it yet, 
because when I try to build with any board, I get the following error:
```
python3 litex_boards/targets/qmtech_10cl006.py --build
INFO:SoC:        __   _ __      _  __  
INFO:SoC:       / /  (_) /____ | |/_/  
INFO:SoC:      / /__/ / __/ -_)>  <    
INFO:SoC:     /____/_/\__/\__/_/|_|  
INFO:SoC:  Build your hardware, easily!
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:Creating SoC... (2021-10-05 12:13:19)
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:FPGA device : 10CL006YU256C8G.
INFO:SoC:System clock: 50.00MHz.
INFO:SoCBusHandler:Creating Bus Handler...
INFO:SoCBusHandler:32-bit wishbone Bus, 4.0GiB Address Space.
INFO:SoCBusHandler:Adding reserved Bus Regions...
INFO:SoCBusHandler:Bus Handler created.
INFO:SoCCSRHandler:Creating CSR Handler...
INFO:SoCCSRHandler:32-bit CSR Bus, 32-bit Aligned, 16.0KiB Address Space, 2048B Paging, big Ordering (Up to 32 Locations).
INFO:SoCCSRHandler:Adding reserved CSRs...
INFO:SoCCSRHandler:CSR Handler created.
INFO:SoCIRQHandler:Creating IRQ Handler...
INFO:SoCIRQHandler:IRQ Handler (up to 32 Locations).
INFO:SoCIRQHandler:Adding reserved IRQs...
INFO:SoCIRQHandler:IRQ Handler created.
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:Initial SoC:
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:32-bit wishbone Bus, 4.0GiB Address Space.
INFO:SoC:32-bit CSR Bus, 32-bit Aligned, 16.0KiB Address Space, 2048B Paging, big Ordering (Up to 32 Locations).
INFO:SoC:IRQ Handler (up to 32 Locations).
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoCBusHandler:io0 Region added at Origin: 0x80000000, Size: 0x80000000, Mode: RW, Cached: False Linker: False.
INFO:SoC:CPU overriding rom mapping from 0x0 to 0x0.
INFO:SoC:CPU overriding sram mapping from 0x1000000 to 0x10000000.
INFO:SoC:CPU overriding main_ram mapping from 0x40000000 to 0x40000000.
INFO:SoCBusHandler:cpu_bus0 added as Bus Master.
INFO:SoCBusHandler:cpu_bus1 added as Bus Master.
INFO:SoCBusHandler:rom Region added at Origin: 0x00000000, Size: 0x00020000, Mode: R, Cached: True Linker: False.
INFO:SoCBusHandler:rom added as Bus Slave.
INFO:SoC:RAM rom added Origin: 0x00000000, Size: 0x00020000, Mode: R, Cached: True Linker: False.
INFO:SoCBusHandler:sram Region added at Origin: 0x10000000, Size: 0x00002000, Mode: RW, Cached: True Linker: False.
INFO:SoCBusHandler:sram added as Bus Slave.
INFO:SoC:RAM sram added Origin: 0x10000000, Size: 0x00002000, Mode: RW, Cached: True Linker: False.
INFO:SoCIRQHandler:uart IRQ allocated at Location 0.
INFO:SoCIRQHandler:timer0 IRQ allocated at Location 1.
INFO:Cyclone10LPPLL:Creating Cyclone10LPPLL, speedgrade -C8.
INFO:Cyclone10LPPLL:Registering Single Ended ClkIn of 50.00MHz.
INFO:Cyclone10LPPLL:Creating ClkOut0 sys of 50.00MHz (+-10000.00ppm).
INFO:Cyclone10LPPLL:Creating ClkOut1 sys_ps of 50.00MHz (+-10000.00ppm).
INFO:SoCBusHandler:main_ram Region added at Origin: 0x40000000, Size: 0x02000000, Mode: RW, Cached: True Linker: False.
INFO:SoCBusHandler:main_ram added as Bus Slave.
INFO:Cyclone10LPPLL:Config:
n          : 1
clk0_freq  : 50.00MHz
clk0_divide: 26
clk0_phase : 0.00°
clk1_freq  : 50.00MHz
clk1_divide: 26
clk1_phase : 90.00°
vco        : 1300.00MHz
m          : 26
INFO:SoCBusHandler:csr Region added at Origin: 0xf0000000, Size: 0x00010000, Mode: RW, Cached: False Linker: False.
INFO:SoCBusHandler:csr added as Bus Slave.
INFO:SoCCSRHandler:bridge added as CSR Master.
INFO:SoCBusHandler:Interconnect: InterconnectShared (2 <-> 4).
INFO:SoCCSRHandler:ctrl CSR allocated at Location 0.
INFO:SoCCSRHandler:identifier_mem CSR allocated at Location 1.
INFO:SoCCSRHandler:leds CSR allocated at Location 2.
INFO:SoCCSRHandler:sdram CSR allocated at Location 3.
INFO:SoCCSRHandler:timer0 CSR allocated at Location 4.
INFO:SoCCSRHandler:uart CSR allocated at Location 5.
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:Finalized SoC:
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:32-bit wishbone Bus, 4.0GiB Address Space.
IO Regions: (1)
io0                 : Origin: 0x80000000, Size: 0x80000000, Mode: RW, Cached: False Linker: False
Bus Regions: (4)
rom                 : Origin: 0x00000000, Size: 0x00020000, Mode: R, Cached: True Linker: False
sram                : Origin: 0x10000000, Size: 0x00002000, Mode: RW, Cached: True Linker: False
main_ram            : Origin: 0x40000000, Size: 0x02000000, Mode: RW, Cached: True Linker: False
csr                 : Origin: 0xf0000000, Size: 0x00010000, Mode: RW, Cached: False Linker: False
Bus Masters: (2)
- cpu_bus0
- cpu_bus1
Bus Slaves: (4)
- rom
- sram
- main_ram
- csr
INFO:SoC:32-bit CSR Bus, 32-bit Aligned, 16.0KiB Address Space, 2048B Paging, big Ordering (Up to 32 Locations).
CSR Locations: (6)
- ctrl           : 0
- identifier_mem : 1
- leds           : 2
- sdram          : 3
- timer0         : 4
- uart           : 5
INFO:SoC:IRQ Handler (up to 32 Locations).
IRQ Locations: (2)
- uart   : 0
- timer0 : 1
INFO:SoC:--------------------------------------------------------------------------------
make: Entering directory '/devel/riscv/litex-root/litex-boards/build/qmtech_10cl006/software/libc'
if [ -d "/devel/riscv/litex-root/litex/litex/soc/software/libc/riscv" ]; then \
	cp /devel/riscv/litex-root/litex/litex/soc/software/libc/riscv/* /devel/riscv/litex-root/pythondata-software-picolibc/pythondata_software_picolibc/data/newlib/libc/machine/riscv/ ;\
fi
meson /devel/riscv/litex-root/pythondata-software-picolibc/pythondata_software_picolibc/data \
	-Dmultilib=false \
	-Dpicocrt=false \
	-Datomic-ungetc=false \
	-Dthread-local-storage=false \
	-Dio-long-long=true \
	-Dformat-default=integer \
	-Dincludedir=picolibc/riscv64-unknown-elf/include \
	-Dlibdir=picolibc/riscv64-unknown-elf/lib \
	--cross-file cross.txt
WARNING: Unknown CPU family riscv, please report this at https://github.com/mesonbuild/meson/issues/new
The Meson build system
Version: 0.53.2
Source dir: /devel/riscv/litex-root/pythondata-software-picolibc/pythondata_software_picolibc/data
Build dir: /devel/riscv/litex-root/litex-boards/build/qmtech_10cl006/software/libc
Build type: cross build
Project name: picolibc
Project version: 1.7.2
C compiler for the build machine: ccache cc (gcc 10.3.0 "cc (Ubuntu 10.3.0-1ubuntu1~20.04) 10.3.0")
C linker for the build machine: cc ld.bfd 2.34
C compiler for the host machine: riscv64-unknown-elf-gcc (gcc 8.3.0 "riscv64-unknown-elf-gcc (SiFive GCC 8.3.0-2019.08.0) 8.3.0")
C linker for the host machine: riscv64-unknown-elf-gcc ld.bfd 2.32.0-2019
Build machine cpu family: x86_64
Build machine cpu: x86_64
Host machine cpu family: riscv
Host machine cpu: vexriscv
Target machine cpu family: riscv
Target machine cpu: vexriscv
Compiler for C supports arguments -fno-stack-protector: YES 
Compiler for C supports arguments -fno-common: YES 
Compiler for C supports arguments -frounding-math: YES 
Program scripts/duplicate-names found: YES (/devel/riscv/litex-root/pythondata-software-picolibc/pythondata_software_picolibc/data/scripts/duplicate-names)
Compiler for C supports link arguments -Wl,--defsym=_start=0: YES 
Compiler for C supports link arguments -Wl,-alias,main,testalias: NO 
Compiler for C supports function attribute alias: YES 
Compiler for C supports function attribute format: YES 
Configuring picolibc.specs using configuration
Configuring picolibcpp.specs using configuration
Configuring test.specs using configuration
Configuring picolibc.ld using configuration
Configuring picolibcpp.ld using configuration
Compiler for C supports arguments -Wno-missing-braces -Wmissing-braces: YES 
Compiler for C supports arguments -Wno-implicit-int -Wimplicit-int: YES 
Compiler for C supports arguments -Wno-return-type -Wreturn-type: YES 
Compiler for C supports arguments -Werror=implicit-function-declaration: YES 
Compiler for C supports arguments -Werror=vla: YES 
Checking if "long double check" compiles: YES 
Checking if "long double same as double" compiles: NO 
Checking if "packed structs may contain bitfields" compiles: YES 
Checking if "has __builtin_mul_overflow" links: YES 
Checking if "supports _Complex" compiles: YES 
Checking if "has __builtin_expect" links: YES 
Compiler for C supports arguments -Werror: YES 
Checking if "attribute __alloc_size__" compiles: NO 
Compiler for C supports arguments -Werror: YES 
Checking if "attributes constructor/destructor" compiles: YES 
Checking if "test for __builtin_alloca" links: YES 
Checking if "test for __builtin_ffs" links: YES 
Checking if "test for __builtin_ffsl" links: YES 
Checking if "test for __builtin_ffsll" links: YES 
Checking if "test for __builtin_ctz" links: YES 
Checking if "test for __builtin_ctzl" links: YES 
Checking if "test for __builtin_ctzll" links: YES 
Checking if "test for __builtin_copysignl" links: NO 
Checking if "test for __builtin_copysign" links: NO 
Checking if "test for __builtin_isinfl" links: YES 
Checking if "test for __builtin_isinf" links: YES 
Checking if "test for __builtin_isnanl" links: YES 
Checking if "test for __builtin_isnan" links: YES 
Checking if "test for __builtin_finitel" links: YES 
Checking if "test for __builtin_isfinite" links: YES 
Compiler for C supports arguments -fno-tree-loop-distribute-patterns: YES 
Compiler for C supports arguments -fno-builtin: YES 
Compiler for C supports arguments -ffunction-sections: YES 
Compiler for C supports arguments -ftls-model=local-exec: YES 
Message: host_cpu_family riscv
Compiler for C supports arguments -fstack-protector-all: YES 
Compiler for C supports arguments -fstack-protector-strong: YES 
Compiler for C supports arguments -fno-builtin-malloc: YES 
Compiler for C supports arguments -fno-builtin-free: YES 
Message: libc/string/memcpy.c: machine overrides generic
Message: libc/string/memmove.S: machine overrides generic
Message: libc/string/memset.S: machine overrides generic
Message: libc/string/strcpy.c: machine overrides generic
Message: libc/string/strlen.c: machine overrides generic
Message: libc/string/strcmp.S: machine overrides generic
Message: libc/include/sys/fenv.h: machine overrides generic
Message: libc/include/machine/math.h: machine overrides generic
Compiler for C supports arguments -fno-builtin-exp2: YES 
Message: Set c_args_exp2
Message: libm/math/ef_sqrt.c: machine overrides generic
Message: libm/math/e_sqrt.c: machine overrides generic
Message: libm/math/s_fabs.c: machine overrides generic
Message: libm/math/sf_fabs.c: machine overrides generic
Message: libm/common/s_finite.c: machine overrides generic
Message: libm/common/s_copysign.c: machine overrides generic
Message: libm/common/s_isinf.c: machine overrides generic
Message: libm/common/s_isnan.c: machine overrides generic
Message: libm/common/s_fma.c: machine overrides generic
Message: libm/common/s_fmax.c: machine overrides generic
Message: libm/common/s_fmin.c: machine overrides generic
Message: libm/common/s_fpclassify.c: machine overrides generic
Message: libm/common/s_lrint.c: machine overrides generic
Message: libm/common/s_llrint.c: machine overrides generic
Message: libm/common/s_lround.c: machine overrides generic
Message: libm/common/s_llround.c: machine overrides generic
Message: libm/common/sf_finite.c: machine overrides generic
Message: libm/common/sf_copysign.c: machine overrides generic
Message: libm/common/sf_isinf.c: machine overrides generic
Message: libm/common/sf_isnan.c: machine overrides generic
Message: libm/common/sf_fma.c: machine overrides generic
Message: libm/common/sf_fmax.c: machine overrides generic
Message: libm/common/sf_fmin.c: machine overrides generic
Message: libm/common/sf_fpclassify.c: machine overrides generic
Message: libm/common/sf_lrint.c: machine overrides generic
Message: libm/common/sf_llrint.c: machine overrides generic
Message: libm/common/sf_lround.c: machine overrides generic
Message: libm/common/sf_llround.c: machine overrides generic
Message: libm/fenv/feclearexcept.c: machine overrides generic
Message: libm/fenv/fegetenv.c: machine overrides generic
Message: libm/fenv/fegetexceptflag.c: machine overrides generic
Message: libm/fenv/fegetround.c: machine overrides generic
Message: libm/fenv/feholdexcept.c: machine overrides generic
Message: libm/fenv/feraiseexcept.c: machine overrides generic
Message: libm/fenv/fesetenv.c: machine overrides generic
Message: libm/fenv/fesetexceptflag.c: machine overrides generic
Message: libm/fenv/fesetround.c: machine overrides generic
Message: libm/fenv/fetestexcept.c: machine overrides generic
Message: libm/fenv/feupdateenv.c: machine overrides generic
Configuring picolibc.h using configuration
Build targets in project: 35

Found ninja-1.10.0 at /usr/bin/ninja
meson compile                                                                                       

ERROR: Neither directory contains a build file meson.build.
make: *** [/devel/riscv/litex-root/litex/litex/soc/software/libc/Makefile:38: __libc.a] Error 1
make: Leaving directory '/devel/riscv/litex-root/litex-boards/build/qmtech_10cl006/software/libc'
Traceback (most recent call last):
  File "litex_boards/targets/qmtech_10cl006.py", line 183, in <module>
    main()
  File "litex_boards/targets/qmtech_10cl006.py", line 176, in main
    builder.build(run=args.build)
  File "/devel/riscv/litex-root/litex/litex/soc/integration/builder.py", line 304, in build
    self._generate_rom_software(compile_bios=use_bios)
  File "/devel/riscv/litex-root/litex/litex/soc/integration/builder.py", line 249, in _generate_rom_software
    subprocess.check_call(["make", "-C", dst_dir, "-f", makefile])
  File "/usr/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['make', '-C', '/devel/riscv/litex-root/litex-boards/build/qmtech_10cl006/software/libc', '-f', '/devel/riscv/litex-root/litex/litex/soc/software/libc/Makefile']' returned non-zero exit status 2.
```
And there is no meson.build file anywhere.