### PR TITLE
efinix_trion_xx: append device with timing model

### DIFF
--- a/litex_boards/platforms/efinix_trion_t120_bga576_dev_kit.py
+++ b/litex_boards/platforms/efinix_trion_t120_bga576_dev_kit.py
@@ -124,7 +124,7 @@ class Platform(EfinixPlatform):
     default_clk_period = 1e9/40e6
 
     def __init__(self):
-        EfinixPlatform.__init__(self, "T120F576", _io, _connectors, toolchain="efinity")
+        EfinixPlatform.__init__(self, "T120F576I4", _io, _connectors, toolchain="efinity")
 
     def create_programmer(self):
         return EfinixProgrammer()

--- a/litex_boards/platforms/efinix_trion_t20_bga256_dev_kit.py
+++ b/litex_boards/platforms/efinix_trion_t20_bga256_dev_kit.py
@@ -70,7 +70,7 @@ class Platform(EfinixPlatform):
     default_clk_period = 1e9/50e6
 
     def __init__(self):
-        EfinixPlatform.__init__(self, "T20F256", _io, _connectors, toolchain="efinity")
+        EfinixPlatform.__init__(self, "T20F256C4", _io, _connectors, toolchain="efinity")
 
     def create_programmer(self):
         return EfinixProgrammer()


### PR DESCRIPTION
With PR [1069](https://github.com/enjoy-digital/litex/pull/1069) device information must contains the timing model.
This PR updates efinix platforms to respect new policy (I4 and C4 are based on boards datasheet).