### PR TITLE
QMTech boards: fix swapped RX/TX lines, remove double uart replacer

### DIFF
--- a/litex_boards/platforms/qmtech_daughterboard.py
+++ b/litex_boards/platforms/qmtech_daughterboard.py
@@ -14,8 +14,8 @@ class QMTechDaughterboard:
         """
         self.io = [
             ("serial", 0,
-                Subsignal("rx", Pins("J2:15")),
-                Subsignal("tx", Pins("J2:16")),
+                Subsignal("rx", Pins("J2:16")),
+                Subsignal("tx", Pins("J2:15")),
                 io_standard
             ),
 

--- a/litex_boards/targets/qmtech_xc7a35t.py
+++ b/litex_boards/targets/qmtech_xc7a35t.py
@@ -76,8 +76,6 @@ class BaseSoC(SoCCore):
         platform = qmtech_xc7a35t.Platform(toolchain=toolchain, with_daughterboard=with_daughterboard)
 
         # SoCCore ----------------------------------------------------------------------------------
-        if kwargs["uart_name"] == "serial":
-            kwargs["uart_name"] = "jtag_uart"
         SoCCore.__init__(self, platform, sys_clk_freq,
             ident          = "LiteX SoC on QMTech XC7A35T" + (" + Daughterboard" if with_daughterboard else ""),
             ident_version  = ident_version,


### PR DESCRIPTION
Hi Florent, here two fixes:
UART lines were swapped (for all boards that use the daughterboard).
Also removed a redundant statement for the XC7A35T board.