### PR TITLE
Add support for QMTech 5CEFA2 board (Cyclone V)

### DIFF
--- a/litex_boards/platforms/qmtech_5cefa2.py
+++ b/litex_boards/platforms/qmtech_5cefa2.py
@@ -1,0 +1,161 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2021 Hans Baier <hansfbaier@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.altera import AlteraPlatform
+from litex.build.altera.programmer import USBBlaster
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk
+    ("clk50", 0, Pins("M9"), IOStandard("3.3-V LVTTL")),
+
+    # Button
+    ("key", 0, Pins("AB13"),  IOStandard("3.3-V LVTTL")),
+    ("key", 1, Pins("V18"),  IOStandard("3.3-V LVTTL")),
+
+    # Serial
+    ("serial", 0,
+        Subsignal("tx", Pins("J3:8"), IOStandard("3.3-V LVTTL")),
+        Subsignal("rx", Pins("J3:7"), IOStandard("3.3-V LVTTL"))
+    ),
+
+    # SPIFlash (MT25QL128ABA)
+    ("spiflash", 0,
+        # clk
+        Subsignal("cs_n", Pins("R4")),
+        Subsignal("clk",  Pins("V3")),
+        Subsignal("mosi", Pins("AB4")),
+        Subsignal("miso", Pins("AB3")),
+        IOStandard("3.3-V LVTTL"),
+    ),
+
+    # SDR SDRAM
+    ("sdram_clock", 0, Pins("AB11"), IOStandard("3.3-V LVTTL")),
+    ("sdram", 0,
+        Subsignal("a",     Pins(
+            "P8 P7 N8 N6 U6 U7 V6 U8",
+            "T8 W8 R6 T9 Y9")),
+        Subsignal("ba",    Pins("T7 P9")),
+        Subsignal("cs_n",  Pins("AB5")),
+        Subsignal("cke",   Pins("V9")),
+        Subsignal("ras_n", Pins("AB6")),
+        Subsignal("cas_n", Pins("AA7")),
+        Subsignal("we_n",  Pins("W9")),
+        Subsignal("dq", Pins(
+            "AA12 Y11 AA10 AB10 Y10 AA9 AB8 AA8",
+            " U10 T10 U11  R12  U12 P12 R10 R11")),
+        Subsignal("dm", Pins("AB7 V10")),
+        IOStandard("3.3-V LVTTL")
+    ),
+]
+
+# The connectors are named after the daughterboard, not the core board
+# because on the different core boards the names vary, but on the
+# daughterboard they stay the same, which we need to connect the
+# daughterboard peripherals to the core board.
+# On this board J2 is U7 and J3 is U8
+_connectors = [
+    ("J2", {
+         # odd row   even row
+          7: "AA2",   8: "AA1",
+          9: "Y3",   10: "W2",
+         11: "U1",   12: "U2",
+         13: "N1",   14: "N2",
+         15: "L1",   16: "L2",
+         17: "G1",   18: "G2",
+         19: "E2",   20: "D3",
+         21: "C1",   22: "C2",
+         23: "G6",   24: "H6",
+         25: "G8",   26: "H8",
+         27: "F7",   28: "E7",
+         29: "D6",   30: "C6",
+         31: "E9",   32: "D9",
+         33: "B5",   34: "A5",
+         35: "B6",   36: "B7",
+         37: "A7",   38: "A8",
+         39: "A9",   40: "A10",
+         41: "B10",  42: "C9",
+         43: "G10",  44: "F10",
+         45: "C11",  46: "B11",
+         47: "B12",  48: "A12",
+         49: "E12",  50: "D12",
+         51: "D13",  52: "C13",
+         53: "B13",  54: "A13",
+         55: "A15",  56: "A14",
+         57: "B15",  58: "C15",
+         59: "C16",  60: "B16",
+    }),
+    ("J3", {
+        # odd row     even row
+         7: "AA14",   8: "AA13",
+         9: "AA15",  10: "AB15",
+        11: "Y15",   12: "Y14",
+        13: "AB18",  14: "AB17",
+        15: "Y17",   16: "Y16",
+        17: "AA18",  18: "AA17",
+        19: "AA20",  20: "AA19",
+        21: "Y20",   22: "Y19",
+        23: "AB21",  24: "AB20",
+        25: "AA22",  26: "AB22",
+        27: "W22",   28: "Y22",
+        29: "Y21",   30: "W21",
+        31: "U22",   32: "V21",
+        33: "V20",   34: "W19",
+        35: "U21",   36: "U20",
+        37: "R22",   38: "T22",
+        39: "P22",   40: "R21",
+        41: "T20",   42: "T19",
+        43: "P16",   44: "P17",
+        45: "N20",   46: "N21",
+        47: "M21",   48: "M20",
+        49: "M18",   50: "N19",
+        51: "L18",   52: "L19",
+        53: "M22",   54: "L22",
+        55: "L17",   56: "K17",
+        57: "K22",   58: "K21",
+        59: "M16",   60: "N16",
+    })
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(AlteraPlatform):
+    default_clk_name   = "clk50"
+    default_clk_period = 1e9/50e6
+    core_resources = [ ("user_led", 0, Pins("D17"), IOStandard("3.3-V LVTTL")) ]
+
+    def __init__(self, with_daughterboard=False):
+        device = "5CEFA2F23C8"
+        io = _io
+        connectors = _connectors
+
+        if with_daughterboard:
+            from litex_boards.platforms.qmtech_daughterboard import QMTechDaughterboard
+            daughterboard = QMTechDaughterboard(IOStandard("3.3-V LVTTL"))
+            io += daughterboard.io
+            connectors += daughterboard.connectors
+        else:
+            io += self.core_resources
+
+        AlteraPlatform.__init__(self, device, io, connectors)
+
+        if with_daughterboard:
+            # an ethernet pin takes the config pin, so make it available
+            self.add_platform_command("set_global_assignment -name CYCLONEII_RESERVE_NCEO_AFTER_CONFIGURATION \"USE AS REGULAR IO\"")
+
+        # Generate PLL clock in STA
+        self.toolchain.additional_sdc_commands.append("derive_pll_clocks")
+        # Calculates clock uncertainties
+        self.toolchain.additional_sdc_commands.append("derive_clock_uncertainty")
+
+    def create_programmer(self):
+        return USBBlaster()
+
+    def do_finalize(self, fragment):
+        AlteraPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)

--- a/litex_boards/targets/qmtech_5cefa2.py
+++ b/litex_boards/targets/qmtech_5cefa2.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2021 Hans Baier <hansfbaier@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Note: The CPU actually runs at over 100MHz, but the SDRAM only works up to 75MHz
+
+import os
+import argparse
+
+from migen import *
+
+from litex.build.io import DDROutput
+
+from litex_boards.platforms import qmtech_5cefa2
+
+from litex.soc.cores.clock import CycloneVPLL
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+
+from litedram.modules import IS42S16160
+from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
+
+from litex.soc.cores.video import VideoVGAPHY
+from liteeth.phy.mii import LiteEthPHYMII
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq, with_ethernet, with_vga, sdram_rate="1:1"):
+        self.rst = Signal()
+        self.clock_domains.cd_sys          = ClockDomain()
+
+        if sdram_rate == "1:2":
+            self.clock_domains.cd_sys2x    = ClockDomain()
+            self.clock_domains.cd_sys2x_ps = ClockDomain(reset_less=True)
+        else:
+            self.clock_domains.cd_sys_ps   = ClockDomain(reset_less=True)
+
+        if with_ethernet:
+            self.clock_domains.cd_eth   = ClockDomain()
+
+        if with_vga:
+            self.clock_domains.cd_vga   = ClockDomain(reset_less=True)
+
+        # # #
+
+        # Clk / Rst
+        clk50 = platform.request("clk50")
+
+        # PLL
+        self.submodules.pll = pll = CycloneVPLL(speedgrade="-C8")
+        self.comb += pll.reset.eq(self.rst)
+        pll.register_clkin(clk50, 50e6)
+        pll.create_clkout(self.cd_sys,    sys_clk_freq)
+        if sdram_rate == "1:2":
+            pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
+            # theoretically 90 degrees, but increase to relax timing
+            pll.create_clkout(self.cd_sys2x_ps, 2*sys_clk_freq, phase=180)
+        else:
+            pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
+
+        if with_ethernet:
+            pll.create_clkout(self.cd_eth,   25e6)
+        if with_vga:
+            pll.create_clkout(self.cd_vga,   40e6)
+
+        # SDRAM clock
+        sdram_clk = ClockSignal("sys2x_ps" if sdram_rate == "1:2" else "sys_ps")
+        self.specials += DDROutput(1, 0, platform.request("sdram_clock"), sdram_clk)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=int(75e6), with_daughterboard=False,
+                 with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", eth_dynamic_ip=False,
+                 with_led_chaser=True, with_video_terminal=False, with_video_framebuffer=False,
+                 ident_version=True, sdram_rate="1:1", **kwargs):
+        platform = qmtech_5cefa2.Platform(with_daughterboard=with_daughterboard)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            ident          = "LiteX SoC on QMTECH 5CEFA2" + (" + Daughterboard" if with_daughterboard else ""),
+            ident_version  = ident_version,
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform,
+                                   sys_clk_freq, with_ethernet or with_etherbone,
+                                   with_video_terminal or with_video_framebuffer,
+                                   sdram_rate=sdram_rate)
+
+        # SDR SDRAM --------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            sdrphy_cls = HalfRateGENSDRPHY if sdram_rate == "1:2" else GENSDRPHY
+            self.submodules.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
+            self.add_sdram("sdram",
+                phy           = self.sdrphy,
+                module        = IS42S16160(sys_clk_freq, sdram_rate),
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
+
+        # Ethernet / Etherbone ---------------------------------------------------------------------
+        if with_ethernet or with_etherbone:
+            self.submodules.ethphy = LiteEthPHYMII(
+                clock_pads = self.platform.request("eth_clocks"),
+                pads       = self.platform.request("eth"))
+            if with_ethernet:
+                self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip)
+            if with_etherbone:
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
+
+        # Video ------------------------------------------------------------------------------------
+        if with_video_terminal or with_video_framebuffer:
+            self.submodules.videophy = VideoVGAPHY(platform.request("vga"), clock_domain="vga")
+            if with_video_terminal:
+                self.add_video_terminal(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
+            if with_video_framebuffer:
+                self.add_video_framebuffer(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on QMTECH 5CEFA2")
+    parser.add_argument("--build",        action="store_true", help="Build bitstream")
+    parser.add_argument("--load",         action="store_true", help="Load bitstream")
+    parser.add_argument("--sys-clk-freq", default=75e6,        help="System clock frequency (default: 75MHz)")
+    parser.add_argument("--sdram-rate",   default="1:1",       help="SDRAM Rate: 1:1 Full Rate (default) or 1:2 Half Rate")
+    parser.add_argument("--with-daughterboard",  action="store_true",              help="Whether the core board is plugged into the QMTech daughterboard")
+    ethopts = parser.add_mutually_exclusive_group()
+    ethopts.add_argument("--with-ethernet",      action="store_true",              help="Enable Ethernet support")
+    ethopts.add_argument("--with-etherbone",     action="store_true",              help="Enable Etherbone support")
+    parser.add_argument("--eth-ip",              default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address")
+    parser.add_argument("--eth-dynamic-ip",      action="store_true",              help="Enable dynamic Ethernet IP addresses setting")
+    sdopts = parser.add_mutually_exclusive_group()
+    sdopts.add_argument("--with-spi-sdcard",     action="store_true",              help="Enable SPI-mode SDCard support")
+    sdopts.add_argument("--with-sdcard",         action="store_true",              help="Enable SDCard support")
+    parser.add_argument("--with-spi-flash",      action="store_true",              help="Enable SPI Flash (MMAPed)")
+    parser.add_argument("--no-ident-version",    action="store_false",             help="Disable build time output")
+    viopts = parser.add_mutually_exclusive_group()
+    viopts.add_argument("--with-video-terminal",    action="store_true", help="Enable Video Terminal (VGA)")
+    viopts.add_argument("--with-video-framebuffer", action="store_true", help="Enable Video Framebuffer (VGA)")
+
+    builder_args(parser)
+    soc_core_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq = int(float(args.sys_clk_freq)),
+        with_daughterboard     = args.with_daughterboard,
+        with_ethernet          = args.with_ethernet,
+        with_etherbone         = args.with_etherbone,
+        eth_ip                 = args.eth_ip,
+        eth_dynamic_ip         = args.eth_dynamic_ip,
+        ident_version          = args.no_ident_version,
+        with_video_terminal    = args.with_video_terminal,
+        with_video_framebuffer = args.with_video_framebuffer,
+        with_spi_flash         = args.with_spi_flash,
+        sdram_rate             = args.sdram_rate,
+        **soc_core_argdict(args)
+    )
+
+    if args.with_spi_sdcard:
+        soc.add_spi_sdcard()
+    if args.with_sdcard:
+        soc.add_sdcard()
+
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build(run=args.build)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".sof"))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A new board arrived!
```
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2021 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Nov  5 2021 09:48:15
 BIOS CRC passed (cfd8447f)

 Migen git sha1: 7507a2b
 LiteX git sha1: 9ecb1e61

--=============== SoC ==================--
CPU:		VexRiscv @ 75MHz
BUS:		WISHBONE 32-bit @ 4GiB
CSR:		32-bit data
ROM:		128KiB
SRAM:		8KiB
L2:		8KiB
SDRAM:		32768KiB 16-bit @ 75MT/s (CL-2 CWL-2)

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB     
   Read: 0x40000000-0x40200000 2.0MiB     
Memtest OK
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 16.2MiB/s
   Read speed: 19.2MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
             Timeout
No boot medium found

--============= Console ================--

litex> 
```
The CPU would run at well over 100MHz, but the RAM only goes up to 75MHz.