### PR TITLE
QMTech Altera fixes

### DIFF
--- a/litex_boards/platforms/qmtech_10cl006.py
+++ b/litex_boards/platforms/qmtech_10cl006.py
@@ -18,13 +18,6 @@ _io = [
     ("key", 0, Pins("F3"),  IOStandard("3.3-V LVTTL")),
     ("key", 1, Pins("J6"),  IOStandard("3.3-V LVTTL")),
 
-    # Serial
-    ("serial", 0,
-        # Compatible with cheap FT232 based cables (ex: Gaoominy 6Pin Ftdi Ft232Rl Ft232)
-        Subsignal("tx", Pins("J3:7"), IOStandard("3.3-V LVTTL")), # GPIO_07 (JP1 Pin 10)
-        Subsignal("rx", Pins("J3:8"), IOStandard("3.3-V LVTTL"))  # GPIO_05 (JP1 Pin 8)
-    ),
-
     # SPIFlash (W25Q64)
     ("spiflash", 0,
         # clk
@@ -128,7 +121,14 @@ _connectors = [
 class Platform(AlteraPlatform):
     default_clk_name   = "clk50"
     default_clk_period = 1e9/50e6
-    core_resources = [ ("user_led", 0, Pins("L9"), IOStandard("3.3-V LVTTL")) ]
+    core_resources = [
+        ("user_led", 0, Pins("L9"), IOStandard("3.3-V LVTTL")),
+        ("serial", 0,
+            # Compatible with cheap FT232 based cables (ex: Gaoominy 6Pin Ftdi Ft232Rl Ft232)
+            Subsignal("tx", Pins("J3:7"), IOStandard("3.3-V LVTTL")), # GPIO_07 (JP1 Pin 10)
+            Subsignal("rx", Pins("J3:8"), IOStandard("3.3-V LVTTL"))  # GPIO_05 (JP1 Pin 8)
+        ),
+    ]
 
     def __init__(self, with_daughterboard=False):
         device = "10CL006YU256C8G"

--- a/litex_boards/platforms/qmtech_5cefa2.py
+++ b/litex_boards/platforms/qmtech_5cefa2.py
@@ -18,12 +18,6 @@ _io = [
     ("key", 0, Pins("AB13"),  IOStandard("3.3-V LVTTL")),
     ("key", 1, Pins("V18"),  IOStandard("3.3-V LVTTL")),
 
-    # Serial
-    ("serial", 0,
-        Subsignal("tx", Pins("J3:8"), IOStandard("3.3-V LVTTL")),
-        Subsignal("rx", Pins("J3:7"), IOStandard("3.3-V LVTTL"))
-    ),
-
     # SPIFlash (MT25QL128ABA)
     ("spiflash", 0,
         # clk
@@ -127,7 +121,13 @@ _connectors = [
 class Platform(AlteraPlatform):
     default_clk_name   = "clk50"
     default_clk_period = 1e9/50e6
-    core_resources = [ ("user_led", 0, Pins("D17"), IOStandard("3.3-V LVTTL")) ]
+    core_resources = [
+        ("user_led", 0, Pins("D17"), IOStandard("3.3-V LVTTL")),
+        ("serial", 0,
+            Subsignal("tx", Pins("J3:8"), IOStandard("3.3-V LVTTL")),
+            Subsignal("rx", Pins("J3:7"), IOStandard("3.3-V LVTTL"))
+        ),
+ ]
 
     def __init__(self, with_daughterboard=False):
         device = "5CEFA2F23C8"
@@ -145,7 +145,7 @@ class Platform(AlteraPlatform):
         AlteraPlatform.__init__(self, device, io, connectors)
 
         if with_daughterboard:
-            # an ethernet pin takes the config pin, so make it available
+            # ethernet takes the config pin, so make it available
             self.add_platform_command("set_global_assignment -name CYCLONEII_RESERVE_NCEO_AFTER_CONFIGURATION \"USE AS REGULAR IO\"")
 
         # Generate PLL clock in STA

--- a/litex_boards/platforms/qmtech_daughterboard.py
+++ b/litex_boards/platforms/qmtech_daughterboard.py
@@ -77,7 +77,6 @@ class QMTechDaughterboard:
                 Subsignal("cmd",  Pins("J3:12")),
                 Subsignal("clk",  Pins("J3:11")),
                 Subsignal("cd",   Pins("J3:8")),
-                Misc("SLEW=FAST"),
                 io_standard,
             ),
         ]

--- a/litex_boards/platforms/qmtech_ep4ce15.py
+++ b/litex_boards/platforms/qmtech_ep4ce15.py
@@ -19,13 +19,6 @@ _io = [
     ("key", 0, Pins("Y13"),  IOStandard("3.3-V LVTTL")),
     ("key", 1, Pins("W13"),  IOStandard("3.3-V LVTTL")),
 
-    # Serial
-    ("serial", 0,
-        # Compatible with cheap FT232 based cables (ex: Gaoominy 6Pin Ftdi Ft232Rl Ft232)
-        Subsignal("tx", Pins("J3:7"), IOStandard("3.3-V LVTTL")), # GPIO_07 (JP1 Pin 10)
-        Subsignal("rx", Pins("J3:8"), IOStandard("3.3-V LVTTL"))  # GPIO_05 (JP1 Pin 8)
-    ),
-
     # SPIFlash (W25Q64)
     ("spiflash", 0,
         # clk
@@ -129,7 +122,13 @@ _connectors = [
 class Platform(AlteraPlatform):
     default_clk_name   = "clk50"
     default_clk_period = 1e9/50e6
-    core_resources = [ ("user_led", 0, Pins("E4"), IOStandard("3.3-V LVTTL")) ]
+    core_resources = [
+        ("user_led", 0, Pins("E4"), IOStandard("3.3-V LVTTL")),
+        ("serial", 0,
+            Subsignal("tx", Pins("J3:7"), IOStandard("3.3-V LVTTL")),
+            Subsignal("rx", Pins("J3:8"), IOStandard("3.3-V LVTTL"))
+        ),
+    ]
 
     def __init__(self, with_daughterboard=False):
         device = "EP4CE15F23C8"

--- a/litex_boards/targets/qmtech_10cl006.py
+++ b/litex_boards/targets/qmtech_10cl006.py
@@ -21,7 +21,7 @@ from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
 from litex.soc.cores.led import LedChaser
 
-from litedram.modules import IS42S16160
+from litedram.modules import W9825G6KH6
 from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
 
 from litex.soc.cores.video import VideoVGAPHY
@@ -99,7 +99,7 @@ class BaseSoC(SoCCore):
             self.submodules.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
             self.add_sdram("sdram",
                 phy           = self.sdrphy,
-                module        = IS42S16160(sys_clk_freq, sdram_rate),
+                module        = W9825G6KH6(sys_clk_freq, sdram_rate),
                 l2_cache_size = kwargs.get("l2_size", 8192)
             )
 

--- a/litex_boards/targets/qmtech_5cefa2.py
+++ b/litex_boards/targets/qmtech_5cefa2.py
@@ -62,7 +62,8 @@ class _CRG(Module):
             # theoretically 90 degrees, but increase to relax timing
             pll.create_clkout(self.cd_sys2x_ps, 2*sys_clk_freq, phase=180)
         else:
-            pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
+            # for 105 MHz: 10; 95 MHz: 15; 85MHz: 30 work
+            pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=10)
 
         if with_ethernet:
             pll.create_clkout(self.cd_eth,   25e6)
@@ -76,7 +77,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(75e6), with_daughterboard=False,
+    def __init__(self, sys_clk_freq=int(105e6), with_daughterboard=False,
                  with_ethernet=False, with_etherbone=False, eth_ip="192.168.1.50", eth_dynamic_ip=False,
                  with_led_chaser=True, with_video_terminal=False, with_video_framebuffer=False,
                  ident_version=True, sdram_rate="1:1", **kwargs):
@@ -134,7 +135,7 @@ def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on QMTECH 5CEFA2")
     parser.add_argument("--build",        action="store_true", help="Build bitstream")
     parser.add_argument("--load",         action="store_true", help="Load bitstream")
-    parser.add_argument("--sys-clk-freq", default=75e6,        help="System clock frequency (default: 75MHz)")
+    parser.add_argument("--sys-clk-freq", default=105e6,        help="System clock frequency (default: 105MHz)")
     parser.add_argument("--sdram-rate",   default="1:1",       help="SDRAM Rate: 1:1 Full Rate (default) or 1:2 Half Rate")
     parser.add_argument("--with-daughterboard",  action="store_true",              help="Whether the core board is plugged into the QMTech daughterboard")
     ethopts = parser.add_mutually_exclusive_group()

--- a/litex_boards/targets/qmtech_5cefa2.py
+++ b/litex_boards/targets/qmtech_5cefa2.py
@@ -22,7 +22,7 @@ from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
 from litex.soc.cores.led import LedChaser
 
-from litedram.modules import IS42S16160
+from litedram.modules import W9825G6KH6
 from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
 
 from litex.soc.cores.video import VideoVGAPHY
@@ -100,7 +100,7 @@ class BaseSoC(SoCCore):
             self.submodules.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
             self.add_sdram("sdram",
                 phy           = self.sdrphy,
-                module        = IS42S16160(sys_clk_freq, sdram_rate),
+                module        = W9825G6KH6(sys_clk_freq, sdram_rate),
                 l2_cache_size = kwargs.get("l2_size", 8192)
             )
 

--- a/litex_boards/targets/qmtech_ep4ce15.py
+++ b/litex_boards/targets/qmtech_ep4ce15.py
@@ -21,7 +21,7 @@ from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
 from litex.soc.cores.led import LedChaser
 
-from litedram.modules import IS42S16160
+from litedram.modules import W9825G6KH6
 from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
 
 from litex.soc.cores.video import VideoVGAPHY
@@ -97,7 +97,7 @@ class BaseSoC(SoCCore):
             self.submodules.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
             self.add_sdram("sdram",
                 phy           = self.sdrphy,
-                module        = IS42S16160(sys_clk_freq, sdram_rate),
+                module        = W9825G6KH6(sys_clk_freq, sdram_rate),
                 l2_cache_size = kwargs.get("l2_size", 8192)
             )
 


### PR DESCRIPTION
Finally! Got it running at 105MHz!
Spent half a day on this:
![image](https://user-images.githubusercontent.com/148607/140595812-f407fb4d-329a-4489-ad57-41503d277543.png)

Also the serial needed another fix to be able to switch correctly from core board to daughterboard.
This possibly depends on my pull request in LiteDRAM.

```
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2021 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Nov  6 2021 09:39:32
 BIOS CRC passed (fff2de9e)

 Migen git sha1: 7507a2b
 LiteX git sha1: 9ecb1e61

--=============== SoC ==================--
CPU:		VexRiscv @ 105MHz
BUS:		WISHBONE 32-bit @ 4GiB
CSR:		32-bit data
ROM:		128KiB
SRAM:		8KiB
L2:		8KiB
SDRAM:		32768KiB 16-bit @ 105MT/s (CL-3 CWL-3)

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB     
   Read: 0x40000000-0x40200000 2.0MiB     
Memtest OK
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 22.4MiB/s
   Read speed: 26.5MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
             Timeout
No boot medium found

--============= Console ================--

litex> mem_test 0x40000000 0x2000000
Memtest at 0x40000000 (32.0MiB)...
  Write: 0x40000000-0x42000000 32.0MiB    
   Read: 0x40000000-0x42000000 32.0MiB    
Memtest OK


```