### PR TITLE
sqrl_acorn: add vivado programmer option, fix warnings

### DIFF
--- a/litex_boards/platforms/sqrl_acorn.py
+++ b/litex_boards/platforms/sqrl_acorn.py
@@ -124,7 +124,9 @@ class Platform(XilinxPlatform):
         self.toolchain.bitstream_commands = [
             "set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]",
             "set_property BITSTREAM.CONFIG.CONFIGRATE 16 [current_design]",
-            "set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]"
+            "set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]",
+            "set_property CFGBVS VCCO [current_design]",
+            "set_property CONFIG_VOLTAGE 3.3 [current_design]",
         ]
         self.toolchain.additional_commands = \
             ["write_cfgmem -force -format bin -interface spix4 -size 16 "

--- a/litex_boards/platforms/sqrl_acorn.py
+++ b/litex_boards/platforms/sqrl_acorn.py
@@ -12,7 +12,7 @@
 # RHSResearchLLC that are documented at: https://github.com/RHSResearchLLC/NiteFury-and-LiteFury.
 
 from litex.build.generic_platform import *
-from litex.build.xilinx import XilinxPlatform
+from litex.build.xilinx import XilinxPlatform, VivadoProgrammer
 from litex.build.openocd import OpenOCD
 
 # IOs ----------------------------------------------------------------------------------------------
@@ -130,8 +130,12 @@ class Platform(XilinxPlatform):
             ["write_cfgmem -force -format bin -interface spix4 -size 16 "
              "-loadbit \"up 0x0 {build_name}.bit\" -file {build_name}.bin"]
 
-    def create_programmer(self):
-        return OpenOCD("openocd_xc7_ft232.cfg", "bscan_spi_xc7a200t.bit")
+    def create_programmer(self, name='openocd'):
+        if name == 'openocd':
+            return OpenOCD("openocd_xc7_ft232.cfg", "bscan_spi_xc7a200t.bit")
+        elif name == 'vivado':
+            # TODO: some board versions may have s25fl128s
+            return VivadoProgrammer(flash_part='s25fl256sxxxxxx0-spi-x1_x2_x4')
 
     def do_finalize(self, fragment):
         XilinxPlatform.do_finalize(self, fragment)


### PR DESCRIPTION
OpenOCD still struggles to program Artix flash when it's not the only device in a JTAG chain - but Vivado handles this easily, so I find the option useful.

CFGBVS and CONFIG_VOLTAGE should be correctly set in all designs according to Vivado.
