### PR TITLE
Wrong pin / use default setup without CPU

### DIFF
--- a/litex_boards/platforms/qmtech_10cl006.py
+++ b/litex_boards/platforms/qmtech_10cl006.py
@@ -29,7 +29,7 @@ _io = [
     ),
 
     # SDR SDRAM
-    ("sdram_clock", 0, Pins("Y6"), IOStandard("3.3-V LVTTL")),
+    ("sdram_clock", 0, Pins("P2"), IOStandard("3.3-V LVTTL")),
     ("sdram", 0,
         Subsignal("a",     Pins(
             "R7 T7 R8 T8 R6 T5 R5 T4",


### PR DESCRIPTION
This pin was wrong.
Now that the c library builds I could test the target.
Unfortunately I could not find a configuration which would fit the device.
Even SERV with 0x1000 sram would not fit (by a bit).
Since there is no hierarchial design I have no idea where to save some gates/mem.
So I disabled the CPU and just added an uartbone to be able to interact with the remaining components.
