### PR TITLE
Fix Sipeed Tang Nano 4k example compilation; adapt Gowin PLL class changes

### DIFF
--- a/litex_boards/targets/sipeed_tang_nano.py
+++ b/litex_boards/targets/sipeed_tang_nano.py
@@ -57,7 +57,7 @@ class _CRG(Module):
         rst_n = platform.request("user_btn", 0)
 
         # PLL.
-        self.submodules.pll = pll = GW1NPLL(device="GW1N-1")
+        self.submodules.pll = pll = GW1NPLL(devicename=platform.devicename, device=platform.device)
         self.comb += pll.reset.eq(~rst_n)
         pll.register_clkin(clk24, 24e6)
         pll.create_clkout(self.cd_sys, sys_clk_freq)

--- a/litex_boards/targets/sipeed_tang_nano_4k.py
+++ b/litex_boards/targets/sipeed_tang_nano_4k.py
@@ -12,7 +12,7 @@ import argparse
 from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer
 
-from litex.soc.cores.clock.gowin_gw1nsr import  GW1NSRPLL
+from litex.soc.cores.clock.gowin_gw1n import GW1NPLL
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.soc import SoCRegion
 from litex.soc.integration.builder import *
@@ -40,7 +40,7 @@ class _CRG(Module):
         rst_n = platform.request("user_btn", 0)
 
         # PLL
-        self.submodules.pll = pll = GW1NSRPLL(device="GW1NSR-4C")
+        self.submodules.pll = pll = GW1NPLL(devicename=platform.devicename, device=platform.device)
         self.comb += pll.reset.eq(~rst_n)
         pll.register_clkin(clk27, 27e6)
         pll.create_clkout(self.cd_sys, sys_clk_freq)
@@ -48,7 +48,7 @@ class _CRG(Module):
 
         # Video PLL
         if with_video_pll:
-            self.submodules.video_pll = video_pll = GW1NSRPLL(device="GW1NSR-4C")
+            self.submodules.video_pll = video_pll = GW1NPLL(devicename=platform.devicename, device=platform.device)
             self.comb += video_pll.reset.eq(~rst_n)
             video_pll.register_clkin(clk27, 27e6)
             self.clock_domains.cd_hdmi   = ClockDomain()

--- a/litex_boards/targets/sipeed_tang_nano_4k.py
+++ b/litex_boards/targets/sipeed_tang_nano_4k.py
@@ -72,6 +72,9 @@ class BaseSoC(SoCCore):
         kwargs["integrated_rom_size"] = 0
         kwargs["cpu_reset_address"]   = self.mem_map["spiflash"] + 0
 
+        kwargs["cpu_type"] = 'vexriscv'
+        kwargs["cpu_variant"] = 'minimal'
+
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq,
             ident         = "LiteX SoC on Tang Nano 4K",


### PR DESCRIPTION
sipeed_tang_nano_4k.py did not compile for me because standard VexRiscv required too many BSRAMs (15 vs 10 available):
```
ERROR (RP0002) : The number(15) of BSRAM in the design exceeds the resource limit(10) of current device. And RAM_STYLE maybe the useful user assignment to change the inference result
```

And minimal VexRiscv at least compiles.


Besides changes made to sipeed_tang_nano.py sipeed_tang_nano_4k.py to match https://github.com/enjoy-digital/litex/pull/1115 .