### PR TITLE
sipeed_tang_nano_4k: add option to build with Gowin EMCU

### DIFF
--- a/litex_boards/targets/sipeed_tang_nano_4k.py
+++ b/litex_boards/targets/sipeed_tang_nano_4k.py
@@ -148,14 +148,12 @@ def main():
         # FIXME: ARM software not supported yet
         args.no_compile_software = True
 
-    soc_core_kwargs = soc_core_argdict(args)
     soc = BaseSoC(
         sys_clk_freq=int(float(args.sys_clk_freq)),
-        **soc_core_kwargs
+        **soc_core_argdict(args)
     )
 
-    builder_kwargs = builder_argdict(args)
-    builder = Builder(soc, **builder_kwargs)
+    builder = Builder(soc, **builder_argdict(args))
     builder.build(run=args.build)
 
     if args.load:

--- a/litex_boards/targets/sipeed_tang_nano_4k.py
+++ b/litex_boards/targets/sipeed_tang_nano_4k.py
@@ -72,14 +72,14 @@ class BaseSoC(SoCCore):
         kwargs["integrated_rom_size"] = 0
         kwargs["cpu_reset_address"]   = self.mem_map["spiflash"] + 0
 
-        kwargs["cpu_type"] = 'vexriscv'
-        kwargs["cpu_variant"] = 'minimal'
-
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq,
             ident         = "LiteX SoC on Tang Nano 4K",
             ident_version = True,
             **kwargs)
+
+        if self.cpu_type == 'vexriscv':
+            assert self.cpu_variant == 'minimal', 'use --cpu-variant=minimal to fit into number of BSRAMs'
 
         # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = _CRG(platform, sys_clk_freq, with_video_pll=with_video_terminal)

--- a/litex_boards/targets/sipeed_tang_nano_4k.py
+++ b/litex_boards/targets/sipeed_tang_nano_4k.py
@@ -94,7 +94,9 @@ class BaseSoC(SoCCore):
         from litespi.opcodes import SpiNorFlashOpCodes as Codes
         self.add_spi_flash(mode="1x", module=W25Q32(Codes.READ_1_1_1), with_master=False)
 
-        if self.cpu_type != 'gowin_emcu':
+        if self.cpu_type == 'gowin_emcu':
+            self.cpu.connect_uart(platform.request('serial'))
+        else:
         # Add ROM linker region --------------------------------------------------------------------
             self.bus.add_region("rom", SoCRegion(
                 origin = self.mem_map["spiflash"] + 0,


### PR DESCRIPTION
Add options to build with Gowin ARM hard CPU (--cpu-type=gowin_emcu). 
Software is not ready for ARM, so by default stays with vexriscv as before.

I changed options a bit so that vexriscv now requires --cpu-variant=minimal on command line - so that vexriscv is not hardcoded anymore, any CPU can be chosen from the command line.
