### PR TITLE
Titanium spi

### DIFF
--- a/litex_boards/targets/efinix_titanium_ti60_f225_dev_kit.py
+++ b/litex_boards/targets/efinix_titanium_ti60_f225_dev_kit.py
@@ -60,9 +60,9 @@ class BaseSoC(SoCCore):
 
         # SPI Flash --------------------------------------------------------------------------------
         if with_spi_flash:
-            from litespi.modules import W25Q32JV
+            from litespi.modules import W25Q64JW
             from litespi.opcodes import SpiNorFlashOpCodes as Codes
-            self.add_spi_flash(mode="1x", module=W25Q32JV(Codes.READ_1_1_1), with_master=True)
+            self.add_spi_flash(mode="1x", module=W25Q64JW(Codes.READ_1_1_1), with_master=True)
 
 # Build --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Tested and works well:

```
Initializing W25Q64JW SPI Flash @0x00800000...
Enabling Quad mode...
SPI Flash clk configured to 25 MHz
Memspeed at 0x800000 (Sequential, 4.0KiB)...
   Read speed: 2.3MiB/s
Memspeed at 0x800000 (Random, 4.0KiB)...
   Read speed: 1.3MiB/s

```