### PR TITLE
Fix bios-flash-offset for tinyFPGA

### DIFF
--- a/litex_boards/targets/tinyfpga_bx.py
+++ b/litex_boards/targets/tinyfpga_bx.py
@@ -69,7 +69,7 @@ class BaseSoC(SoCCore):
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on TinyFPGA BX")
     parser.add_argument("--build",             action="store_true", help="Build bitstream")
-    parser.add_argument("--bios-flash-offset", default=0x60000,     help="BIOS offset in SPI Flash (default: 0x60000)")
+    parser.add_argument("--bios-flash-offset", default=0x50000,     help="BIOS offset in SPI Flash (default: 0x50000)")
     parser.add_argument("--sys-clk-freq",      default=16e6,        help="System clock frequency (default: 16MHz)")
     builder_args(parser)
     soc_core_args(parser)


### PR DESCRIPTION
I was unable to run BIOS until I fixed `bios-flash-offset` to `0x50000.`

Not sure where the original value 0x60000 comes from, but tinyprog on my kit shows that `userdata` area is at `0x50000`.
Could it be that there are different BX variants?

```
$litex tinyprog -m
[
  {
    "boardmeta": {
      "name": "TinyFPGA BX",
      "fpga": "ice40lp8k-cm81",
      "hver": "1.0.0",
      "uuid": "8503d354-fcf6-4c92-9e16-016e3e7f229a"
    },
    "bootmeta": {
      "bootloader": "TinyFPGA USB Bootloader",
      "bver": "1.0.1",
      "update": "https://tinyfpga.com/update/tinyfpga-bx",
      "addrmap": {
        "bootloader": "0x000a0-0x28000",
        "userimage": "0x28000-0x50000",
        "userdata": "0x50000-0x100000"
      }
    },
    "port": "/dev/ttyACM0"
  }
]
```

Also tried to pass argument `--bios-flash-offset=0x50000` but even when I set it hexadecimal or decimal number, I always get python error that this parameter is a string and cannot be used with `+`. However this is just a question out of scope of this PR.