### PR TITLE
Fix cannot find board 'littlebee'

### DIFF
--- a/litex_boards/platforms/trenz_tec0117.py
+++ b/litex_boards/platforms/trenz_tec0117.py
@@ -112,7 +112,7 @@ class Platform(GowinPlatform):
         GowinPlatform.__init__(self, "GW1NR-LV9QN88C6/I5", _io, _connectors, toolchain="gowin", devicename='GW1NR-9')
 
     def create_programmer(self):
-        return OpenFPGALoader("littlebee")
+        return OpenFPGALoader("littleBee")
 
     def do_finalize(self, fragment):
         GowinPlatform.do_finalize(self, fragment)


### PR DESCRIPTION
Seems like openFPGALoader capitalized letter 'B' in the past or made the boards case sensitive. Now flash works properly.

![image](https://user-images.githubusercontent.com/497212/147504141-87d5e69c-1811-43c5-a282-495eac6e057c.png)
