### PR TITLE
quicklogic_quickfeather: add eos_s3 arm software support

### DIFF
--- a/litex_boards/targets/libeos/Bootconfig.h
+++ b/litex_boards/targets/libeos/Bootconfig.h
@@ -1,0 +1,4 @@
+#ifndef __BOOT_CONFIG_H
+#define __BOOT_CONFIG_H
+
+#endif

--- a/litex_boards/targets/libeos/FreeRTOSConfig.h
+++ b/litex_boards/targets/libeos/FreeRTOSConfig.h
@@ -1,0 +1,175 @@
+/*
+    FreeRTOS V8.2.2 - Copyright (C) 2015 Real Time Engineers Ltd.
+    All rights reserved
+
+    VISIT http://www.FreeRTOS.org TO ENSURE YOU ARE USING THE LATEST VERSION.
+
+    This file is part of the FreeRTOS distribution.
+
+    FreeRTOS is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License (version 2) as published by the
+    Free Software Foundation >>!AND MODIFIED BY!<< the FreeRTOS exception.
+
+    ***************************************************************************
+    >>!   NOTE: The modification to the GPL is included to allow you to     !<<
+    >>!   distribute a combined work that includes FreeRTOS without being   !<<
+    >>!   obliged to provide the source code for proprietary components     !<<
+    >>!   outside of the FreeRTOS kernel.                                   !<<
+    ***************************************************************************
+
+    FreeRTOS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  Full license text is available on the following
+    link: http://www.freertos.org/a00114.html
+
+    ***************************************************************************
+     *                                                                       *
+     *    FreeRTOS provides completely free yet professionally developed,    *
+     *    robust, strictly quality controlled, supported, and cross          *
+     *    platform software that is more than just the market leader, it     *
+     *    is the industry's de facto standard.                               *
+     *                                                                       *
+     *    Help yourself get started quickly while simultaneously helping     *
+     *    to support the FreeRTOS project by purchasing a FreeRTOS           *
+     *    tutorial book, reference manual, or both:                          *
+     *    http://www.FreeRTOS.org/Documentation                              *
+     *                                                                       *
+    ***************************************************************************
+
+    http://www.FreeRTOS.org/FAQHelp.html - Having a problem?  Start by reading
+    the FAQ page "My application does not run, what could be wrong?".  Have you
+    defined configASSERT()?
+
+    http://www.FreeRTOS.org/support - In return for receiving this top quality
+    embedded software for free we request you assist our global community by
+    participating in the support forum.
+
+    http://www.FreeRTOS.org/training - Investing in training allows your team to
+    be as productive as possible as early as possible.  Now you can receive
+    FreeRTOS training directly from Richard Barry, CEO of Real Time Engineers
+    Ltd, and the world's leading authority on the world's leading RTOS.
+
+    http://www.FreeRTOS.org/plus - A selection of FreeRTOS ecosystem products,
+    including FreeRTOS+Trace - an indispensable productivity tool, a DOS
+    compatible FAT file system, and our tiny thread aware UDP/IP stack.
+
+    http://www.FreeRTOS.org/labs - Where new FreeRTOS products go to incubate.
+    Come and try FreeRTOS+TCP, our new open source TCP/IP stack for FreeRTOS.
+
+    http://www.OpenRTOS.com - Real Time Engineers ltd. license FreeRTOS to High
+    Integrity Systems ltd. to sell under the OpenRTOS brand.  Low cost OpenRTOS
+    licenses offer ticketed support, indemnification and commercial middleware.
+
+    http://www.SafeRTOS.com - High Integrity Systems also provide a safety
+    engineered and independently SIL3 certified version for use in safety and
+    mission critical applications that require provable dependability.
+
+    1 tab == 4 spaces!
+*/
+
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#include "Fw_global_config.h"
+
+/*-----------------------------------------------------------
+ * Application specific definitions.
+ *
+ * These definitions should be adjusted for your particular hardware and
+ * application requirements.
+ *
+ * THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+ * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+ *
+ * See http://www.freertos.org/a00110.html.
+ *----------------------------------------------------------*/
+
+
+#define configSUPPORT_STATIC_ALLOCATION 0
+#define configUSE_TICKLESS_IDLE         1
+#define configUSE_PREEMPTION			1
+#define configUSE_IDLE_HOOK				0
+#define configUSE_TICK_HOOK				0
+#define configCPU_CLOCK_HZ				(_S3x_Clk_Get_Rate(S3X_M4_S0_S3_CLK))
+#define configTICK_RATE_HZ				( ( TickType_t ) 1000 )
+#define configMAX_PRIORITIES			( 22 )
+#define configMINIMAL_STACK_SIZE		( ( unsigned short ) 384 )
+#define configTOTAL_HEAP_SIZE ( ( size_t ) ( 60 * 1024 ) )
+#define configMAX_TASK_NAME_LEN			( 16 )
+#define configUSE_TRACE_FACILITY		1
+#define configUSE_16_BIT_TICKS			0
+#define configIDLE_SHOULD_YIELD			1
+#define configUSE_MUTEXES			1
+#define configQUEUE_REGISTRY_SIZE		32
+#define configCHECK_FOR_STACK_OVERFLOW	        2
+#define configUSE_RECURSIVE_MUTEXES		1
+#define configUSE_MALLOC_FAILED_HOOK	0
+#define configUSE_APPLICATION_TASK_TAG	        0
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS 3
+#define configUSE_COUNTING_SEMAPHORES	        1
+#define configGENERATE_RUN_TIME_STATS	        0
+#define configHEAP4_DEBUG			1
+#define configQUEUE_FULL_DEBUG		1
+#define configSTACK_USAGE_DEBUG		0
+#define configFORCED_KEYSTRING		1
+#define	INCLUDE_xTimerPendFunctionCall			1
+
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES 		        0
+#define configMAX_CO_ROUTINE_PRIORITIES         ( 2 )
+
+/* Software timer definitions. */
+#define configUSE_TIMERS			1
+#define configTIMER_TASK_PRIORITY		(20)
+#define configTIMER_QUEUE_LENGTH		10
+#define configTIMER_TASK_STACK_DEPTH	( configMINIMAL_STACK_SIZE )
+
+#define INCLUDE_vTaskPrioritySet		1
+#define INCLUDE_uxTaskPriorityGet		1
+#define INCLUDE_vTaskDelete			1
+#define INCLUDE_vTaskCleanUpResources	        1
+#define INCLUDE_vTaskSuspend			1
+#define INCLUDE_vTaskDelayUntil			1
+#define INCLUDE_vTaskDelay			1
+#define INCLUDE_xTaskGetCurrentTaskHandle		1
+#define INCLUDE_xTimerGetTimerDaemonTaskHandle	1
+
+#define __NVIC_PRIO_BITS          3
+
+/* Cortex-M specific definitions. */
+#ifdef __NVIC_PRIO_BITS
+	#define configPRIO_BITS       		__NVIC_PRIO_BITS
+#else
+	#define configPRIO_BITS       		4        /* 15 priority levels */
+#endif
+
+/* The lowest interrupt priority that can be used in a call to a "set priority" function. */
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY ((1 << configPRIO_BITS) - 1)
+
+/* The highest interrupt priority that can be used by any interrupt service
+routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT CALL
+INTERRUPT SAFE FREERTOS API FUNCTIONS FROM ANY INTERRUPT THAT HAS A HIGHER
+PRIORITY THAN THIS! (higher priorities are lower numeric values. */
+#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY	5
+
+/* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
+See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY 	( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS) )
+
+/* Interrupt priorities used by the kernel port layer itself.  These are generic
+to all Cortex-M ports, and do not rely on any particular library functions. */
+#define configKERNEL_INTERRUPT_PRIORITY 		( configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8 - configPRIO_BITS) )
+
+/* Normal assert() semantics without relying on the provision of an assert.h
+header file. */
+#define configASSERT( x ) if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
+
+/* Definitions that map the FreeRTOS port interrupt handlers to their CMSIS standard names. */
+#define vPortSVCHandler SVC_Handler
+#define xPortPendSVHandler PendSV_Handler
+#define CPU_Tick_Handler SysTick_Handler
+#define CPU_Tick_Handler SysTick_Handler
+
+
+#endif /* FREERTOS_CONFIG_H */

--- a/litex_boards/targets/libeos/Fw_global_config.h
+++ b/litex_boards/targets/libeos/Fw_global_config.h
@@ -1,0 +1,28 @@
+/*==========================================================
+ * Copyright 2020 QuickLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *==========================================================*/
+
+#ifndef FW_GLOBAL_CONFIG_H_INCLUDED
+#define FW_GLOBAL_CONFIG_H_INCLUDED
+
+#define ENABLE_VOICE_SOLUTION 0
+
+#define uartHandlerUpdate(id, x)
+#define DEBUG_UART UART_ID_HW
+
+// required by some QORC SDK files
+#define _EnD_Of_Fw_global_config_h 1
+
+#endif

--- a/litex_boards/targets/libeos/Makefile
+++ b/litex_boards/targets/libeos/Makefile
@@ -1,0 +1,60 @@
+include ../include/generated/variables.mak
+include $(SOC_DIRECTORY)/software/common.mak
+
+# FPGA binary is typically loaded by the bootloader;
+# set LOAD_FPGA=1 to embed FPGA binary in this app and load it on start
+# (useful for debugging)
+LOAD_FPGA ?= 0
+
+CFLAGS += -I$(LIBEOS_DIRECTORY) \
+	-I$(QORC_SDK)/BSP/quickfeather/inc \
+	-I$(QORC_SDK)/HAL/inc \
+	-I$(QORC_SDK)/Libraries/CMSIS/inc \
+	-I$(QORC_SDK)/Libraries/DatablockManager/inc \
+	-I$(QORC_SDK)/Libraries/FPGA/inc \
+	-I$(QORC_SDK)/Libraries/Power/inc \
+	-I$(QORC_SDK)/Libraries/Utils/inc \
+	-I$(QORC_SDK)/FreeRTOS/include \
+	-I$(QORC_SDK)/FreeRTOS/portable/GCC/ARM_CM4F_quicklogic_s3XX
+
+# rename uart_init() to avoid conflict - LiteX has a function with the same name
+CFLAGS += -Duart_init=eos_uart_init
+
+# provide stack end symbol named _fstack in LiteX linker script to vectors_CM4F_gcc using __StackTop name
+CFLAGS += -D__StackTop=_fstack
+
+OBJECTS = libeos_exceptions.o libeos_main.o pincfg_table_quickfeather.o s3x_pwrcfg.o sec_debug.o \
+	vectors_CM4F_gcc.o \
+	eoss3_hal_uart.o eoss3_hal_timer.o eoss3_hal_wdt.o eoss3_hal_spi.o eoss3_hal_pad_config.o qf_hardwaresetup.o \
+	dbg_uart.o \
+	s3x_clock.o s3x_clock_hal.o s3x_pi.o s3x_qos.o s3x_lpm.o s3x_dfs.o s3x_cpuload.o \
+	tasks.o heap_4.o port.o list.o timers.o queue.o
+
+VPATH = $(LIBEOS_DIRECTORY):\
+	$(QORC_SDK)/HAL/src:$(QORC_SDK)/HAL/startup:\
+	$(QORC_SDK)/BSP/quickfeather/src:\
+	$(QORC_SDK)/FreeRTOS:$(QORC_SDK)/FreeRTOS/portable/MemMang:\
+	$(QORC_SDK)/FreeRTOS/portable/GCC/ARM_CM4F_quicklogic_s3XX:\
+	$(QORC_SDK)/Libraries/FPGA/src:$(QORC_SDK)/Libraries/Utils/src:$(QORC_SDK)/Libraries/Power/src
+
+ifeq ($(LOAD_FPGA), 1)
+	CFLAGS += -I$(BUILDINC_DIRECTORY)/../../gateware
+	CFLAGS += -DLOAD_FPGA
+	OBJECTS += fpga_loader.o
+endif
+
+all: libeos.a
+
+libeos.a: $(OBJECTS)
+	$(AR) crs $@ $^
+
+# pull in dependency info for *existing* .o files
+-include $(OBJECTS:.o=.d)
+
+%.o: %.c
+	$(call compile, -fno-lto)
+
+.PHONY: all clean
+
+clean:
+	$(RM) $(OBJECTS) libeos.a .*~ *~

--- a/litex_boards/targets/libeos/RtosTask.h
+++ b/litex_boards/targets/libeos/RtosTask.h
@@ -1,0 +1,115 @@
+/*==========================================================
+ * Copyright 2020 QuickLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *==========================================================*/
+
+/*==========================================================
+ *
+ *    File   : RtosTask.h
+ *    Purpose: Define the Task handles, queues and priorities
+ *
+ *
+ *=========================================================*/
+
+#ifndef __RTOSTASK_H__
+#define __RTOSTASK_H__
+#include <string.h>
+#include "FreeRTOS.h"
+#include "task.h"
+#include <queue.h>
+#include "portable.h"
+
+#define STACK_BAISC_UNIT        4
+#define STACK_SIZE_ALLOC(size)  (size * STACK_BAISC_UNIT)
+
+/*====================================================*/
+
+/* Enum so that all of these are visibile in 1 place */
+typedef enum {
+    PRIORITY_LOWEST = 0,
+
+    PRIORITY_LOWER  = (configMAX_PRIORITIES/4),
+
+    PRIORITY_NORMAL = (configMAX_PRIORITIES/2),
+
+    PRIORITY_HIGH  = ((configMAX_PRIORITIES*3)/4),
+
+    PRIORITY_HAL_TIMER = configMAX_PRIORITIES-2,
+    PRIORITY_LOADER = configMAX_PRIORITIES-1,
+
+    PRIORITY_HIGHEST = configMAX_PRIORITIES,
+} TaskPriorities;
+
+
+#define PRIORITY_TASK_BLE              ((unsigned)(PRIORITY_NORMAL))
+#define STACK_SIZE_TASK_BLE            (256)
+extern xTaskHandle xHandleTaskBLE;
+extern QueueHandle_t BLE_MsgQ;
+extern signed portBASE_TYPE StartRtosTaskBLE( void);
+
+#define PRIORITY_TASK_AP_COMM              ((unsigned)(PRIORITY_NORMAL))
+#define STACK_SIZE_TASK_AP_COMM        (256)
+extern xTaskHandle xHandleTaskAPComm;
+extern QueueHandle_t xHandleQueueAPComm;
+extern signed portBASE_TYPE StartRtosTaskApComm(void);  // to remove warnings		uxPriority not used in the function
+
+
+#define PRIORITY_TASK_AUDIO               ((unsigned)(PRIORITY_HIGH))
+#define STACK_SIZE_TASK_AUDIO        (256)
+extern xTaskHandle xHandleTaskAudio;
+extern QueueHandle_t xHandleQueueAudio;
+extern signed portBASE_TYPE StartRtosTaskAudio( void);  // to remove warnings
+
+
+#define PRIORITY_TASK_NEURONS              ((unsigned)(PRIORITY_HIGH))
+#define STACK_SIZE_TASK_NEURONS        (256)
+extern xTaskHandle xHandleTaskNeurons;
+extern QueueHandle_t NeuronMsgQ;
+extern signed portBASE_TYPE StartRtosTaskNeurons( void);  // to remove warnings
+
+#define PRIORITY_TASK_DATASAVE       ((unsigned)(PRIORITY_LOWER))
+#define STACK_SIZE_TASK_DATASAVE     (256)
+extern xTaskHandle xHandleTaskDataSave;
+extern signed portBASE_TYPE StartRtosTaskDataSave( void);	// to remove warnings
+
+
+#define PRIORITY_TASK_SENSIML_RECO           ((unsigned)(PRIORITY_NORMAL))
+#define STACK_SIZE_TASK_SENSIML_RECO    (256)
+extern signed portBASE_TYPE StartRtosTaskRecognition(void);	// to remove warnings
+
+#define PRIORITY_TASK_FFESENSORS              ((unsigned)(PRIORITY_HIGH))
+#define STACK_SIZE_TASK_FFESENSORS        (256)
+extern xTaskHandle xHandleTaskFFESensors;
+extern QueueHandle_t FFESensorsMsgQ;
+extern signed portBASE_TYPE StartRtosTaskFFESensors( void);
+
+#define PRIORITY_TASK_ADC                 (((unsigned)(PRIORITY_HIGH))+1)
+#define STACK_SIZE_TASK_ADC              (256)
+extern xTaskHandle xHandleTaskADC;
+extern QueueHandle_t xHandleQueueADC;
+extern signed portBASE_TYPE StartRtosTaskADC( void);
+
+#define PRIORITY_TASK_HOST              ((unsigned)(PRIORITY_NORMAL))
+#define STACK_SIZE_TASK_HOST            (256)
+extern xTaskHandle xHandleTaskHost;
+extern QueueHandle_t Host_MsgQ;
+extern signed portBASE_TYPE StartRtosTaskHost( void);
+
+#define PRIORITY_TASK_H2D_RX              ((unsigned)(PRIORITY_HIGH))
+#define STACK_SIZE_TASK_H2D_RX            (256)
+extern xTaskHandle xHandleTaskH2DRx;
+extern QueueHandle_t H2DRx_MsgQ;
+//extern signed portBASE_TYPE _start_rtos_task_h2drx( void);
+
+#endif /* __RTOSTASK_H__ */

--- a/litex_boards/targets/libeos/libeos_exceptions.c
+++ b/litex_boards/targets/libeos/libeos_exceptions.c
@@ -1,0 +1,162 @@
+/*==========================================================
+ * Copyright 2020 QuickLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *==========================================================*/
+
+/*==========================================================
+ *
+ *    File   : exceptions.c
+ *    Purpose: This file contains the default exception handlers
+ *             and exception table.
+ *
+ *=========================================================*/
+
+#include <stdio.h>
+#include <assert.h>
+#include "Fw_global_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+#include "string.h"
+#include "eoss3_hal_def.h"
+#include "eoss3_hal_pad_config.h"
+#include "eoss3_dev.h"
+#include "eoss3_hal_rtc.h"
+#include "eoss3_hal_uart.h"
+#include "eoss3_hal_gpio.h"
+#include "sec_debug.h"
+
+
+void HardFault_Handler(void) {
+	while (1);
+}
+
+int ucount = 0;
+int urxcount = 0;
+
+void Uart_Handler(void) {
+	if ((UART->UART_MIS & UART_MIS_RX))
+	{
+		uart_isr_handler(UART_ID_HW);
+		urxcount ++;
+		UART->UART_ICR = UART_IC_RX;
+	}
+	else if (UART->UART_MIS & UART_MIS_RX_TIMEOUT) {
+		uart_isr_handler(UART_ID_HW);
+		ucount ++;
+		UART->UART_ICR = UART_IC_RX_TIMEOUT;
+	}
+	INTR_CTRL->OTHER_INTR &= UART_INTR_DETECT;
+}
+
+extern void HAL_Timer_ISR(void);
+
+void Timer_Handler(void) {
+	HAL_Timer_ISR();
+	INTR_CTRL->OTHER_INTR &= TIMER_INTR_DETECT;
+	NVIC_ClearPendingIRQ(Timer_IRQn);
+}
+
+extern void WDT_ISR(void);
+
+void CpuWdtInt_Handler(void) {
+	WDT_ISR();
+	INTR_CTRL->OTHER_INTR &= WDOG_INTR_DETECT;
+	NVIC_ClearPendingIRQ(CpuWdtInt_IRQn);
+}
+
+void Pkfb_Handler(void) {
+	INTR_CTRL->OTHER_INTR &= PKFB_INTR_DETECT;
+}
+
+HAL_FBISRfunction FB_ISR [MAX_FB_INTERRUPTS] = {NULL, NULL, NULL, NULL};
+
+void FbMsg_Handler(void) {
+#if (configSAVE_IRQ_HISTORY == 1)
+	sec_save_irq_history("FbMsg\0", xTaskGetTickCountFromISR());
+#endif
+	// detect which one of the FB generators interrupted
+	if ( INTR_CTRL->FB_INTR_RAW & FB_0_INTR_RAW) {
+		// call that particular ISR
+		if (FB_ISR[FB_INTERRUPT_0])
+			FB_ISR[FB_INTERRUPT_0]();
+		// clear that interrupt at FB level
+		INTR_CTRL->FB_INTR = (FB_0_INTR_DETECT);
+	}
+	if ( INTR_CTRL->FB_INTR_RAW & FB_1_INTR_RAW) {
+		// call that particular ISR
+		if (FB_ISR[FB_INTERRUPT_1])
+			FB_ISR[FB_INTERRUPT_1]();
+		// clear that interrupt at FB level
+		INTR_CTRL->FB_INTR = (FB_1_INTR_DETECT);
+	}
+	if ( INTR_CTRL->FB_INTR_RAW & FB_2_INTR_RAW) {
+		// call that particular ISR
+		if (FB_ISR[FB_INTERRUPT_2])
+			FB_ISR[FB_INTERRUPT_2]();
+		// clear that interrupt at FB level
+		INTR_CTRL->FB_INTR = (FB_2_INTR_DETECT);
+	}
+	if ( INTR_CTRL->FB_INTR_RAW & FB_3_INTR_RAW) {
+		// call that particular ISR
+		if (FB_ISR[FB_INTERRUPT_3])
+			FB_ISR[FB_INTERRUPT_3]();
+		// clear that interrupt at FB level
+		INTR_CTRL->FB_INTR = (FB_3_INTR_DETECT);
+	}
+}
+
+
+void FB_RegisterISR(UINT32_t fbIrq, HAL_FBISRfunction ISRfn)
+{
+  if (fbIrq < MAX_FB_INTERRUPTS)
+    FB_ISR [fbIrq] = ISRfn;
+}
+
+void FB_ConfigureInterrupt(UINT32_t fbIrq, UINT8_t type, UINT8_t polarity, UINT8_t destAP, UINT8_t destM4)
+{
+  // Edge or level and polarity
+  if (type == FB_INTERRUPT_TYPE_LEVEL){
+    INTR_CTRL->FB_INTR_TYPE &= ~(1 << fbIrq);
+    if (polarity == FB_INTERRUPT_POL_LEVEL_LOW)
+      INTR_CTRL->FB_INTR_POL &= ~(1 << fbIrq);
+    else
+      INTR_CTRL->FB_INTR_POL |= (1 << fbIrq);
+  } else {
+    INTR_CTRL->FB_INTR_TYPE |=  (1 << fbIrq);
+    if ( polarity == FB_INTERRUPT_POL_EDGE_FALL)
+      INTR_CTRL->FB_INTR_POL &= ~(1 << fbIrq);
+    else
+      INTR_CTRL->FB_INTR_POL |= (1 << fbIrq);
+  }
+
+  // Destination AP
+  if (destAP == FB_INTERRUPT_DEST_AP_DISBLE)
+    INTR_CTRL->FB_INTR_EN_AP &= ~(1 << fbIrq);
+  else
+    INTR_CTRL->FB_INTR_EN_AP |= (1 << fbIrq);
+
+  // Destination M4
+  if (destM4 == FB_INTERRUPT_DEST_M4_DISBLE)
+    INTR_CTRL->FB_INTR_EN_M4 &= ~(1 << fbIrq);
+  else
+    INTR_CTRL->FB_INTR_EN_M4 |= (1 << fbIrq);
+}
+
+void vApplicationStackOverflowHook(TaskHandle_t pxTask, char *pcTaskName)
+{
+	( void ) pcTaskName;
+	( void ) pxTask;
+	taskDISABLE_INTERRUPTS();
+	invoke_soft_fault();
+}

--- a/litex_boards/targets/libeos/libeos_exceptions.h
+++ b/litex_boards/targets/libeos/libeos_exceptions.h
@@ -1,0 +1,12 @@
+#ifndef LIBEOS_EXCEPTIONS_H
+#define LIBEOS_EXCEPTIONS_H
+
+void HardFault_Handler(void);
+void Uart_Handler(void);
+void CpuWdtInt_Handler(void);
+void Pkfb_Handler(void);
+void Timer_Handler(void);
+void FbMsg_Handler(void);
+void vApplicationStackOverflowHook(TaskHandle_t pxTask, char *pcTaskName);
+
+#endif // LIBEOS_EXCEPTIONS_H

--- a/litex_boards/targets/libeos/libeos_main.c
+++ b/litex_boards/targets/libeos/libeos_main.c
@@ -1,0 +1,38 @@
+#include "Fw_global_config.h"
+#include "qf_hardwaresetup.h"
+#include "s3x_clock.h"
+#include "FreeRTOS.h"
+#include "RtosTask.h"
+#if LOAD_FPGA
+#include "fpga_loader.h"
+#include "quicklogic_quickfeather_bit.h"
+#endif
+
+// LiteX BIOS entry point
+int main(int i, char **c);
+
+void main_task(void *pParameter);
+void SystemInit(void);
+
+void main_task(void *pParameter)
+{
+	(void)(pParameter);
+	main(0, NULL);
+}
+
+void SystemInit(void)
+{
+	xTaskHandle hMain;
+	qf_hardwareSetup();
+
+#if LOAD_FPGA
+	load_fpga_with_mem_init(sizeof(axFPGABitStream), axFPGABitStream, sizeof(axFPGAMemInit), axFPGAMemInit);
+	fpga_iomux_init(sizeof(axFPGAIOMuxInit), axFPGAIOMuxInit);
+#endif
+
+	NVIC_SetPriority(Uart_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY);
+
+	xTaskCreate(main_task, "main", 1024, NULL, (UBaseType_t)(PRIORITY_NORMAL), &hMain);
+	vTaskStartScheduler();
+	while(1);
+}

--- a/litex_boards/targets/libeos/pincfg_table_quickfeather.c
+++ b/litex_boards/targets/libeos/pincfg_table_quickfeather.c
@@ -1,0 +1,85 @@
+/*==========================================================
+ * Copyright 2020 QuickLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *==========================================================*/
+
+#include "Fw_global_config.h"
+#include "eoss3_hal_pad_config.h"
+#include "eoss3_hal_gpio.h"
+
+PadConfig pincfg_table[] =
+{
+  { // UART TX
+    .ucPin = PAD_44,
+    .ucFunc = PAD44_FUNC_SEL_UART_TXD,
+    .ucCtrl = PAD_CTRL_SRC_A0,
+    .ucMode = PAD_MODE_OUTPUT_EN,
+    .ucPull = PAD_NOPULL,
+    .ucDrv = PAD_DRV_STRENGHT_4MA,
+    .ucSpeed = PAD_SLEW_RATE_SLOW,
+    .ucSmtTrg = PAD_SMT_TRIG_DIS,
+  },
+  { // UART RX
+    .ucPin = PAD_45,
+    .ucFunc = PAD45_FUNC_SEL_UART_RXD,
+    .ucCtrl = PAD_CTRL_SRC_A0,
+    .ucMode = PAD_MODE_INPUT_EN,
+    .ucPull = PAD_NOPULL,
+  },
+  { // blue LED
+    .ucPin = PAD_18,
+    .ucFunc = PAD18_FUNC_SEL_FBIO_18,
+    .ucCtrl = PAD_CTRL_SRC_FPGA,
+    .ucMode = PAD_MODE_OUTPUT_EN,
+    .ucPull = PAD_NOPULL,
+    .ucDrv = PAD_DRV_STRENGTH_4MA,
+    .ucSpeed = PAD_SLEW_RATE_SLOW,
+    .ucSmtTrg = PAD_SMT_TRIG_DIS,
+  },
+  { // green LED
+    .ucPin = PAD_21,
+    .ucFunc = PAD21_FUNC_SEL_FBIO_21,
+    .ucCtrl = PAD_CTRL_SRC_FPGA,
+    .ucMode = PAD_MODE_OUTPUT_EN,
+    .ucPull = PAD_NOPULL,
+    .ucDrv = PAD_DRV_STRENGTH_4MA,
+    .ucSpeed = PAD_SLEW_RATE_SLOW,
+    .ucSmtTrg = PAD_SMT_TRIG_DIS,
+  },
+  { // red LED
+    .ucPin = PAD_22,
+    .ucFunc = PAD22_FUNC_SEL_FBIO_22,
+    .ucCtrl = PAD_CTRL_SRC_FPGA,
+    .ucMode = PAD_MODE_OUTPUT_EN,
+    .ucPull = PAD_NOPULL,
+    .ucDrv = PAD_DRV_STRENGTH_4MA,
+    .ucSpeed = PAD_SLEW_RATE_SLOW,
+    .ucSmtTrg = PAD_SMT_TRIG_DIS,
+  },
+  { // user button
+    .ucPin = PAD_6,
+    .ucFunc = PAD6_FUNC_SEL_FBIO_6,
+    .ucCtrl = PAD_CTRL_SRC_FPGA,
+    .ucMode = PAD_MODE_INPUT_EN,
+    .ucPull = PAD_PULLUP,
+    .ucDrv = PAD_DRV_STRENGTH_4MA,
+    .ucSpeed = PAD_SLEW_RATE_SLOW,
+    .ucSmtTrg = PAD_SMT_TRIG_DIS
+  },
+};
+
+GPIOCfgTypeDef gpiocfg_table[] = {};
+
+int sizeof_pincfg_table = sizeof(pincfg_table) / sizeof(pincfg_table[0]);
+int sizeof_gpiocfg_table = sizeof(gpiocfg_table) / sizeof(gpiocfg_table[0]);

--- a/litex_boards/targets/libeos/s3x_pwrcfg.c
+++ b/litex_boards/targets/libeos/s3x_pwrcfg.c
@@ -1,0 +1,309 @@
+/*==========================================================
+ * Copyright 2020 QuickLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *==========================================================*/
+
+#include "Fw_global_config.h"
+#include "s3x_clock.h"
+#include "eoss3_hal_audio.h"
+#include "s3x_dfs.h"
+#include "s3x_pi.h"
+
+UINT8_t S3clkd_size, S3_dfs_max_index;
+
+S3x_ClkD S3clk [] = {
+    [CLK_C10] =  {
+        .name = "C10",
+        .clkd_id = CLK_C10,
+        .type = SRC_CLK,
+        .sync_clk = SYNC_CLKD(2, CLK_C01, CLK_C09),
+        .cru_ctrl = CRU_CTRL(0x0, 0x1fe, 9, 0x4, 0x50, 0x7f, 0),
+        .flags = HW_GATED,
+        .def_max_rate = HSOSC_DEF_RATE,
+        .init_state = INIT_STATE(F_48MHZ, 0x5f, INIT_GATE_ON),
+    },
+    [CLK_C02] = {
+        .name = "C2",
+        .clkd_id = CLK_C02,
+        .type = SRC_CLK ,
+        .sync_clk = SYNC_CLKD (0, 0, 0),
+        .cru_ctrl = CRU_CTRL (0x8, 0x1fe, 9, 0x130, 0x44, 0x7, 1),
+        .def_max_rate = (F_40MHZ),
+        .init_state = INIT_STATE(F_1MHZ, 7, INIT_GATE_OFF),
+    },
+    [CLK_C08X4] = {
+        .name = "C8X4",
+        .clkd_id = CLK_C08X4,
+        .type = SRC_CLK,
+        .sync_clk = SYNC_CLKD (1, CLK_C08X1, 0),
+        .cru_ctrl = CRU_CTRL (0x10, 0x1fe, 9, 0x134, 0x48, 0x1, 2),
+        .def_max_rate = (F_40MHZ),
+        .init_state = INIT_STATE(F_2MHZ, 0x1, INIT_GATE_OFF),
+    },
+    [CLK_C11] = {
+        .name = "C11",
+        .clkd_id = CLK_C11,
+        .type = SRC_CLK,
+        .sync_clk = SYNC_CLKD (0, 0, 0),
+        .cru_ctrl = CRU_CTRL (0x14, 0x1fe, 9, 0x138, 0x54, 0x1, 3),
+        .flags = LOCK_KEY,
+        .def_max_rate = (F_12MHZ),
+        .init_state = INIT_STATE(F_2MHZ, 0, INIT_GATE_OFF),
+    },
+    [CLK_C16] = { // FPGA clk source 0
+        .name = "C16",
+        .clkd_id = CLK_C16,
+        .type = SRC_CLK,
+        .sync_clk = SYNC_CLKD (0, 0, 0),
+        .cru_ctrl = CRU_CTRL (0x20, 0x1fe, 9, 0x24, 0x64, 0x01, 5),
+        .def_max_rate = (F_24MHZ),
+        .init_state = INIT_STATE(F_10MHZ, 1, INIT_GATE_OFF),
+    },
+    [CLK_C30] = {
+        .name = "C30",
+        .clkd_id = CLK_C30,
+        .type = SRC_CLK,
+        .sync_clk = SYNC_CLKD (1, CLK_C31, 0xFF),
+        .cru_ctrl = CRU_CTRL (0x28, 0x1fe, 9, 0x144, 0x120, 0xF, 6),
+        .def_max_rate = (F_6MHZ),
+        .init_state = INIT_STATE(PDM2PCM_CLK_C30, 5, INIT_GATE_OFF),
+
+    },
+    [CLK_C19] = {
+        .name = "C19",
+        .clkd_id = CLK_C19,
+        .type = SRC_CLK,
+        .sync_clk = SYNC_CLKD (0, 0, 0),
+        .cru_ctrl = CRU_CTRL (0x2c, 0x1fe, 9, 0x13c, 0x6c, 0x1, 7),
+        .def_max_rate = (F_1MHZ),
+        .init_state = INIT_STATE(F_256KHZ/4, 1, INIT_GATE_OFF),
+    },
+    [CLK_C21] = {
+        .name = "C21",
+        .clkd_id = CLK_C21,
+        .type = SRC_CLK,
+        .sync_clk = SYNC_CLKD (0, 0, 0),
+        .cru_ctrl = CRU_CTRL (0x34, 0x1fe, 9, 0x38, 0x70, 0x1, 8),
+        .def_max_rate = (F_48MHZ),
+        .init_state = INIT_STATE(F_1MHZ, 1, INIT_GATE_OFF),
+    },
+    [CLK_C01] = {
+        .name = "C1",
+        .clkd_id = CLK_C01,
+        .type = SD_CLK,
+        .sync_clk = SRC_DOMAIN (CLK_C10),
+        .cru_ctrl = CRU_CTRL (0x110, 0xf, 4, 0, 0x40, 0x2ff, 4),
+        .def_max_rate = (F_10MHZ),
+        .init_state = INIT_STATE(F_10MHZ, 0x01, INIT_GATE_ON),
+    },
+    [CLK_C08X1] = {
+        .name = "C8x",
+        .clkd_id = CLK_C08X1,
+        .type = FD_CLK,
+        .div_val = 4,
+        .sync_clk = SRC_DOMAIN (CLK_C08X4),
+        .cru_ctrl = CRU_CTRL (0, 4, 0, 0, 0x4c, 0xd, 2),
+        .def_max_rate = (F_12MHZ),
+        .init_state = INIT_STATE(F_256KHZ, 8, INIT_GATE_OFF),
+    },
+    [CLK_C09] = {
+        .name = "C9",
+        .clkd_id = CLK_C09,
+        .type = SD_CLK,
+        .sync_clk = SRC_DOMAIN (CLK_C10),
+        .cru_ctrl = CRU_CTRL (0x114, 0xf, 4, 0, 0x11c, 0x7, 4),
+        .def_max_rate = (F_10MHZ),
+        .init_state = INIT_STATE(F_6MHZ, 1, INIT_GATE_ON),
+    },
+    [CLK_C31] = {
+        .name = "C31",
+        .clkd_id = CLK_C31,
+        .type = SD_CLK,
+        .sync_clk = SRC_DOMAIN (CLK_C30),
+        .cru_ctrl = CRU_CTRL (0x118, 0xf, 4, 0, 0x120, 0xF , 4),
+        .def_max_rate = (F_10MHZ),
+        .init_state = INIT_STATE(PDM2PCM_CLK_C31 , 8, INIT_GATE_OFF),
+    },
+};
+
+S3x_Pi S3Pi [] = {
+        [PI_A1] =  {
+            .name = "A1",
+            .pctrl = PI_CTRL(0xd0, 0xd4, 0x208 , 0x218, 1, 0x40, 0x40 ),
+            .ginfo = PI_GINFO(2, S3X_CFG_DMA_A1_CLK, S3X_A1_CLK, 0 , 0, 0),
+            .cfg_state = PI_SET_SHDN,
+        },
+        [PI_I2S] =  {
+            .name = "I2S_S",
+            .pctrl = PI_CTRL(0xe0, 0, 0x208, 0x218, 0x10, 0x20, 0x20),
+            .ginfo = PI_GINFO(1, S3X_I2S_A1_CLK, 0, 0 , 0, 0),
+            .cfg_state = PI_SET_SHDN,
+        },
+        [PI_EFUSE] =  {
+            .name = "EFUSE",
+            .pctrl = PI_CTRL(0xe0, 0, 0x208, 0x218, 0x4, 0x4, 0x4),
+            .ginfo = PI_GINFO(2, S3X_EFUSE_01_CLK, S3X_EFUSE_02_CLK, 0, 0, 0),
+            .cfg_state = PI_SET_SHDN,
+        },
+        [PI_FFE] =  {
+            .name = "FFE",
+            .pctrl = PI_CTRL(0x90, 0x94, 0x200, 0x210, 1, 1, 1),
+            .ginfo = PI_GINFO(3, S3X_FFE_X4_CLK, S3X_FFE_X1_CLK, S3X_FFE_CLK, 0, 0),
+            .cfg_state = PI_SET_SHDN,
+        },
+        [PI_PF] =  {
+            .name = "PF",
+            .pctrl = PI_CTRL(0xb0, 0xb4, 0x200, 0x210, 1, 4, 4),
+            .ginfo = PI_GINFO(2, S3X_PKT_FIFO_CLK, S3X_ASYNC_FIFO_0_CLK, 0, 0, 0),
+            .cfg_state = PI_SET_SHDN,
+        },
+        [PI_FB] =  {
+            .name = "FB",
+            .pctrl = PI_CTRL(0xa0, 0xa4, 0x200, 0x210, 1, 2, 2),
+            .ginfo = PI_GINFO(4, S3X_FB_02_CLK, S3X_FB_16_CLK, S3X_FB_21_CLK , S3X_CLKGATE_FB, 0),
+            .cfg_state = PI_NO_CFG,
+        },
+
+        [PI_AD0_ADMA] =  {
+            .name = "AD_DMA",
+            .pctrl = PI_CTRL(0xE4, 0, 0x20c, 0x21c, 0x1, 0x1, 0x1),
+            .ginfo = PI_GINFO(1, S3X_AUDIO_DMA_CLK, 0, 0, 0, 0),
+            .cfg_state = PI_SET_SHDN,
+         },
+         [PI_AD1_LEFT] =  {
+            .name = "AD_L",
+            .pctrl = PI_CTRL(0xE4, 0, 0x20c, 0x21c, 0x2, 0x2, 0xa),
+            .ginfo = PI_GINFO(1, S3X_PDM_LEFT, 0, 0, 0, 0),
+            .cfg_state = PI_SET_SHDN,
+        },
+         [PI_AD2_RIGHT] =  {
+            .name = "AD_R",
+            .pctrl = PI_CTRL(0xE4, 0, 0x20c, 0x21c, 0x4, 0x4, 0x4),
+            .ginfo = PI_GINFO(1, S3X_PDM_RIGHT, 0, 0, 0, 0),
+            .cfg_state = PI_SET_SHDN,
+        },
+        [PI_AD3_LPSD] =  {
+            .name = "AD_LPSD",
+            .pctrl = PI_CTRL(0xE4, 0, 0x20c, 0x21c, 0x8, 0x8, 0x8),
+            .ginfo = PI_GINFO(1, S3X_LPSD, 0, 0, 0, 0),
+            .cfg_state = PI_SET_SHDN,
+        },
+         [PI_AD4_I2SM] =  {
+            .name = "AD_I2SM",
+            .pctrl = PI_CTRL(0xE4, 0, 0x20c, 0x21c, 0x10, 0x10, 0x10),
+            .ginfo = PI_GINFO(1, S3X_I2S_MASTER, 0, 0, 0, 0),
+            .cfg_state = PI_SET_SHDN,
+        },
+        [PI_AD5_APB] =  {
+            .name = "AD_APB",
+            .pctrl = PI_CTRL(0xE4, 0, 0x20c, 0x21c, 0x20, 0x20, 0x20),
+            .ginfo = PI_GINFO(1, S3X_AUDIO_APB, 0, 0, 0, 0),
+            .cfg_state = PI_SET_SHDN,
+        },
+        [PI_SDMA] =  {
+            .name = "SDMA",
+            .pctrl = PI_CTRL(0x70, 0x74, 0x208, 0x218, 1, 1, 1),
+            .ginfo = PI_GINFO(2, S3X_SDMA_SRAM_CLK, S3X_SDMA_CLK, 0, 0, 0),
+            .cfg_state = PI_SET_SHDN,
+        },
+};
+
+uint8_t policyInitial = 1;
+
+S3x_Policy_Node dfs_node[]  = {
+/* 0th Policy is only for lpm not for run mode */
+    [0] = { // Sleep
+        .clk_domain = {CLK_C01, CLK_C09, CLK_C10, CLK_C08X4},
+        .rate = {F_256KHZ, F_256KHZ, F_48MHZ, F_256KHZ},
+        .step_width =  800,/* msec */
+        .cpuload_downthreshold = 0,
+        .cpuload_upthreshold = 98,
+        .policySleep = 0xFF,                   // Sleep policy: this is the sleep state, do nothing
+        .minHSOSC = F_48MHZ,
+    },
+
+    [1] = { // Minimum performance
+        .clk_domain = {CLK_C01, CLK_C09, CLK_C10, CLK_C08X4},
+        .rate = {F_3MHZ, F_3MHZ, F_48MHZ, F_256KHZ},
+        .step_width = 100,/* msec */
+        .cpuload_downthreshold = 0,             // Lowest active state, never go lower
+        .cpuload_upthreshold = 110,
+        .policySleep = 0,                       // When idle, go to deep sleep (node 0)
+        .minHSOSC = F_48MHZ,
+    },
+    [2] = {
+        .clk_domain = {CLK_C01, CLK_C09, CLK_C10, CLK_C08X4},
+        .rate = {C01_N2_CLK, C09_N2_CLK, C10_N2_CLK, C8X4_N2_CLK},
+        .step_width =  STEP_2,/* msec */
+        .cpuload_downthreshold = CPU_DOWN2,
+    },
+
+    [3] = {
+        .clk_domain = {CLK_C01, CLK_C09, CLK_C10, CLK_C08X4},
+        .rate = {C01_N3_CLK, C09_N3_CLK, C10_N3_CLK, C8X4_N3_CLK},
+        .step_width = STEP_3,/* msec */
+        .cpuload_downthreshold = CPU_DOWN3,
+    },
+
+    [4] = {
+        .clk_domain = {CLK_C01, CLK_C09, CLK_C10, CLK_C08X4},
+        .rate = {C01_N4_CLK, C09_N4_CLK, C10_N4_CLK, C8X4_N4_CLK},
+        .step_width = STEP_3,/* msec */
+        .cpuload_downthreshold = CPU_DOWN4,
+    },
+};
+
+void S3x_pwrcfg_init(void)
+{
+    S3clkd_size = SIZEOF_ARRAY(S3clk);
+    S3_dfs_max_index = (SIZEOF_ARRAY(dfs_node) - 1 );
+    DFS_Initialize();
+    S3x_Clk_Init();
+    S3x_pi_init();
+    DFS_StartTimer();
+}
+
+/* This value is determined from the icf and ld file.
+    ROM and RAM2 blocks can be put into light sleep */
+#define SRAM_IN_LPM_BLOCKS (0x7e3f)
+static int sram_lpm_blocks = SRAM_IN_LPM_BLOCKS;
+
+void s3x_sram_in_lpm(void)
+{
+    // Bit 0 is S0 (mem addr 0x0 to 0x00007fff) and so on
+    /* LPMF */
+    //PMU_WVAL(0x230, sram_lpm_blocks);
+    __ISB();
+    /* DS RAM, Leave 3 block of HWA Section,
+    * 1 for SHM
+    */
+    PMU_WVAL(0x100, sram_lpm_blocks);
+    __ISB();
+}
+
+/* This API is used to enable/disable sram in lpm
+ * 0 -> disables lpm for all blocks
+ * 1 -> enables lpm for ROM/RAM2 blocks.
+*/
+void set_sram_lpm_blocks(int state)
+{
+    if (state == 0)      /* Disable sram blocks going into lpm */
+    {
+        sram_lpm_blocks = 0x0;
+    }
+    else                /* Enable lpm blocks going into lpm */
+    {
+        sram_lpm_blocks = SRAM_IN_LPM_BLOCKS;
+    }
+}

--- a/litex_boards/targets/libeos/s3x_pwrcfg.h
+++ b/litex_boards/targets/libeos/s3x_pwrcfg.h
@@ -1,0 +1,196 @@
+/*==========================================================
+ * Copyright 2020 QuickLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *==========================================================*/
+
+#ifndef __S3X_PWRCFG_H
+#define __S3X_PWRCFG_H
+
+#define OSC_MINIMUM_FREQ                            (HSOSC_1MHZ)
+#define OSC_MAXIMMUM_FREQ                           (HSOSC_1MHZ * 80)
+
+#define HSOSC_DEF_RATE F_48MHZ
+#define HSOSC_QOS_VAL F_9MHZ
+
+#define FFE_MHZ (F_1MHZ * 80)
+/*Sensor Only*/
+#ifndef ENABLE_VOICE_SOLUTION
+
+#if (defined (PCG_ALGO_ON_M4_LIVE) || defined (DT_ALGO_ON_M4_LIVE))
+#define C01_N0_CLK  HSOSC_1MHZ
+#define C09_N0_CLK  HSOSC_1MHZ
+#define C10_N0_CLK  HSOSC_1MHZ
+#define C8X4_N0_CLK FFE_MHZ
+#else
+#define C01_N0_CLK  HSOSC_1MHZ
+#define C09_N0_CLK  HSOSC_1MHZ
+#define C10_N0_CLK  HSOSC_1MHZ
+#define C8X4_N0_CLK FFE_MHZ
+#endif
+
+
+#define C01_N1_CLK  HSOSC_1MHZ
+#define C09_N1_CLK  HSOSC_1MHZ
+#define C10_N1_CLK  HSOSC_12MHZ
+#define C8X4_N1_CLK FFE_MHZ
+#define STEP_1 500
+
+#define C01_N2_CLK  HSOSC_2MHZ
+#define C09_N2_CLK  HSOSC_2MHZ
+#define C10_N2_CLK  HSOSC_24MHZ
+#define C8X4_N2_CLK FFE_MHZ
+#define STEP_2 500
+
+#define C01_N3_CLK  HSOSC_3MHZ
+#define C09_N3_CLK  HSOSC_3MHZ
+#define C10_N3_CLK  HSOSC_48MHZ
+#define C8X4_N3_CLK FFE_MHZ
+#define STEP_3 500
+
+#define C01_N4_CLK  HSOSC_6MHZ
+#define C09_N4_CLK  HSOSC_6MHZ
+#define C10_N4_CLK  HSOSC_72MHZ
+#define C8X4_N4_CLK FFE_MHZ
+
+#else
+/* Only voice */
+#ifdef ONLY_VOICE_SOLUTION
+#ifdef COMPANION_VOICE
+#define C01_N0_CLK  HSOSC_3MHZ
+#define C09_N0_CLK  HSOSC_512KHZ
+#define C10_N0_CLK  HSOSC_3MHZ
+#define C8X4_N0_CLK HSOSC_1MHZ
+
+#define C01_N1_CLK  HSOSC_3MHZ
+#define C09_N1_CLK  HSOSC_1MHZ
+#define C10_N1_CLK  HSOSC_18MHZ
+#define C8X4_N1_CLK HSOSC_1MHZ
+#define STEP_1 500
+
+#define C01_N2_CLK  HSOSC_3MHZ
+#define C09_N2_CLK  HSOSC_2MHZ
+#define C10_N2_CLK  HSOSC_36MHZ
+#define C8X4_N2_CLK HSOSC_1MHZ
+#define STEP_2 500
+
+#define C01_N3_CLK  HSOSC_3MHZ
+#define C09_N3_CLK  HSOSC_3MHZ
+#define C10_N3_CLK  HSOSC_48MHZ
+#define C8X4_N3_CLK HSOSC_1MHZ
+#define STEP_3 500
+
+#define C01_N4_CLK  HSOSC_6MHZ
+#define C09_N4_CLK  HSOSC_6MHZ
+#define C10_N4_CLK  HSOSC_72MHZ
+#define C8X4_N4_CLK HSOSC_1MHZ
+
+#else
+
+#define C01_N0_CLK  HSOSC_512KHZ
+#define C09_N0_CLK  HSOSC_512KHZ
+#define C10_N0_CLK  HSOSC_512KHZ
+#define C8X4_N0_CLK HSOSC_1MHZ
+
+#define C01_N1_CLK  HSOSC_3MHZ
+#define C09_N1_CLK  HSOSC_1MHZ
+#define C10_N1_CLK  HSOSC_18MHZ
+#define C8X4_N1_CLK HSOSC_1MHZ
+#define STEP_1 500
+
+#define C01_N2_CLK  HSOSC_3MHZ
+#define C09_N2_CLK  HSOSC_2MHZ
+#define C10_N2_CLK  HSOSC_36MHZ
+#define C8X4_N2_CLK HSOSC_1MHZ
+#define STEP_2 500
+
+#define C01_N3_CLK  HSOSC_3MHZ
+#define C09_N3_CLK  HSOSC_3MHZ
+#define C10_N3_CLK  HSOSC_48MHZ
+#define C8X4_N3_CLK HSOSC_1MHZ
+#define STEP_3 500
+
+#define C01_N4_CLK  HSOSC_6MHZ
+#define C09_N4_CLK  HSOSC_6MHZ
+#define C10_N4_CLK  HSOSC_72MHZ
+#define C8X4_N4_CLK HSOSC_1MHZ
+#endif
+
+/* sensor + voice */
+#else
+
+#define C01_N0_CLK  HSOSC_2MHZ
+#define C09_N0_CLK  HSOSC_2MHZ
+#define C10_N0_CLK  HSOSC_36MHZ
+#define C8X4_N0_CLK FFE_MHZ
+
+#define C01_N1_CLK  HSOSC_2MHZ
+#define C09_N1_CLK  HSOSC_2MHZ
+#define C10_N1_CLK  HSOSC_36MHZ
+#define C8X4_N1_CLK FFE_MHZ
+#define STEP_1 500
+
+#define C01_N2_CLK  HSOSC_2MHZ
+#define C09_N2_CLK  HSOSC_2MHZ
+#define C10_N2_CLK  HSOSC_36MHZ
+#define C8X4_N2_CLK FFE_MHZ
+#define STEP_2 500
+#define CPU_DOWN2   10						
+
+#define C01_N3_CLK  HSOSC_4MHZ
+#define C09_N3_CLK  HSOSC_4MHZ
+#define C10_N3_CLK  HSOSC_36MHZ
+#define C8X4_N3_CLK FFE_MHZ
+#define STEP_3 500
+#define CPU_DOWN3   60						
+
+#define C01_N4_CLK  HSOSC_2MHZ
+#define C09_N4_CLK  HSOSC_2MHZ
+#define C10_N4_CLK  HSOSC_36MHZ
+#define C8X4_N4_CLK FFE_MHZ
+#define CPU_DOWN4   60
+#endif
+#endif
+
+
+#define HSOSC_STEP_WIDTH C10_N1_CLK
+
+#define C01_IDX   0
+#define C09_IDX   1
+#define C10_IDX   2
+#define C8X4_IDX  3
+
+#define INIT_GATE_ON 1
+#define INIT_GATE_OFF 0
+
+#define CRU_CTRL(d, m, en, so, go, gm, sds) { .div_off = d,\
+    .div_max = m, .div_en_shift = en, .src_sel_off = so,\
+    .gate_off = go, .gate_mask = gm, .src_div_shift = sds,}
+
+
+#define INIT_STATE(ir, im, men) { .irate = ir, .imask = im, .en = men }
+
+#define SYNC_CLKD(c,id0, id1) { .sd_clk.cnt = c,\
+    .sd_clk.sd_id[0] = id0, .sd_clk.sd_id[1] = id1, }
+
+#define SRC_DOMAIN(c) { .sclk.src_domain = c, .sclk.src_rate = 0,}
+
+#define PI_CTRL(so, co, to, wo, pm, tm, wm) { .st_off = so, .cfg_off = co,\
+                .trig_off = to, .swu_off = wo, .pmask = pm, .trig_mask = tm,\
+                .swu_mask = wm, }
+
+#define PI_GINFO(c, i0, i1, i2, i3, i4) { .gcnt = c, .gid[0] = i0,\
+                    .gid[1] = i1, .gid[2] = i2, .gid[3] = i3, .gid[4] = i4, }
+
+
+#endif      /* __S3X_PWRCFG_H  */

--- a/litex_boards/targets/libeos/sec_debug.c
+++ b/litex_boards/targets/libeos/sec_debug.c
@@ -1,0 +1,47 @@
+/*==========================================================
+ * Copyright 2020 QuickLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *==========================================================*/
+
+
+#include "Fw_global_config.h"
+#include <stdio.h>
+#include <string.h>
+#include "FreeRTOS.h"
+#include "task.h"
+#include "eoss3_dev.h"
+#include "sec_debug.h"
+#include "dbg_uart.h"
+
+
+void save_assert_info(char* file, int line)
+{
+	char assert_info[270];
+	dbg_str("****ASSERT****\n");
+	dbg_str_str("assert", file);
+	dbg_str_int("line", line);
+	sprintf(assert_info, "%s(%d)\0", strrchr(file, '\\') ? strrchr(file, '\\') + 1 : file, line);
+	strncpy((char*) 0x20000000, assert_info, strlen(assert_info));
+
+	REBOOT_STATUS_REG &= ~REBOOT_CAUSE;
+	REBOOT_STATUS_REG |= REBOOT_CAUSE_SOFTFAULT;	/* CHANGING THIS VALUE OR REGISTER REQUIRE CORRESPONDING CHANGE IN BOOTLOADER */
+}
+
+
+void invoke_soft_fault(void)
+{
+	dbg_fatal_error("SOFT FAULT\n");
+	{ taskDISABLE_INTERRUPTS(); for( ;; ); }
+}
+

--- a/litex_boards/targets/libeos/sec_debug.h
+++ b/litex_boards/targets/libeos/sec_debug.h
@@ -1,0 +1,32 @@
+/*==========================================================
+ * Copyright 2020 QuickLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *==========================================================*/
+
+
+#ifndef _SEC_DEBUG_H_
+#define _SEC_DEBUG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void save_assert_info(char* file, int line);
+void invoke_soft_fault(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SEC_DEBUG_H_ */


### PR DESCRIPTION
This enables LiteX BIOS run on EOS S3 ARM CPU.
The software library is adapted from QORC SDK examples for Quickfeather.
Because it's partially specific to Quickfeather (pin configuration etc) I propose to keep the library here in the boards repo for now.
Note that BIOS main() is started as a FreeRTOS thread - QORC SDK relies on FreeRTOS, maybe it could be decoupled later.
