### PR TITLE
Use Arrow-USB-Blaster for trenz c10lprefkit

### DIFF
--- a/litex_boards/platforms/trenz_c10lprefkit.py
+++ b/litex_boards/platforms/trenz_c10lprefkit.py
@@ -130,7 +130,7 @@ class Platform(AlteraPlatform):
         AlteraPlatform.__init__(self, "10CL055YU484A7G", _io)
 
     def create_programmer(self):
-        return USBBlaster()
+        return USBBlaster(cable_name="Arrow-USB-Blaster")
 
     def do_finalize(self, fragment):
         AlteraPlatform.do_finalize(self, fragment)


### PR DESCRIPTION
The trenz Cyclone 10 lp RefKit (c10lprefkit) has an integrated arrow usb blaster, which needs to be added to quartus before usage (as described [here](https://wiki.trenz-electronic.de/display/PD/Arrow+USB+Programmer)). This patch uses that programmer for loading the bitstream.

Before:
```console
> ./trenz_c10lprefkit.py --load

[...]

Error (213013): Programming hardware cable not detected
Traceback (most recent call last):
  File "./trenz_c10lprefkit.py", line 125, in <module>
    main()
  File "./trenz_c10lprefkit.py", line 122, in main
    prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".sof"))
  File "/home/wilbrandt/litex/litex/litex/build/altera/programmer.py", line 19, in load_bitstream
    self.call(["quartus_pgm",
  File "/home/wilbrandt/litex/litex/litex/build/generic_programmer.py", line 100, in call
    raise OSError(msg)
OSError: Error occured during USBBlaster's call, please check:
- USBBlaster installation.
- access permissions.
- hardware and cable.
```

With this patch:
```console
> ./trenz_c10lprefkit.py --load

[...]

Info: *******************************************************************
Info: Running Quartus Prime Programmer
    Info: Version 21.1.0 Build 842 10/21/2021 SJ Lite Edition
    Info: Copyright (C) 2021  Intel Corporation. All rights reserved.
    Info: Your use of Intel Corporation's design tools, logic functions 
    Info: and other software and tools, and any partner logic 
    Info: functions, and any output files from any of the foregoing 
    Info: (including device programming or simulation files), and any 
    Info: associated documentation or information are expressly subject 
    Info: to the terms and conditions of the Intel Program License 
    Info: Subscription Agreement, the Intel Quartus Prime License Agreement,
    Info: the Intel FPGA IP License Agreement, or other applicable license
    Info: agreement, including, without limitation, that your use is for
    Info: the sole purpose of programming logic devices manufactured by
    Info: Intel and sold by Intel or its authorized distributors.  Please
    Info: refer to the applicable agreement for further details, at
    Info: https://fpgasoftware.intel.com/eula.
    Info: Processing started: Sun Jan 16 18:12:57 2022
Info: Command: quartus_pgm -m jtag -c Arrow-USB-Blaster -o p;/home/wilbrandt/litex/litex-boards/litex_boards/targets/build/trenz_c10lprefkit/gateware/trenz_c10lprefkit.sof@1
Info (213045): Using programming cable "Arrow-USB-Blaster [AR3M3WMU]"
Info (213011): Using programming file /home/wilbrandt/litex/litex-boards/litex_boards/targets/build/trenz_c10lprefkit/gateware/trenz_c10lprefkit.sof with checksum 0x008975AF for device 10CL055YU484@1
Info (209060): Started Programmer operation at Sun Jan 16 18:12:57 2022
Info (209016): Configuring device index 1
Info (209017): Device 1 contains JTAG ID code 0x020F50DD
Info (209007): Configuration succeeded -- 1 device(s) configured
Info (209011): Successfully performed operation(s)
Info (209061): Ended Programmer operation at Sun Jan 16 18:13:01 2022
Info: Quartus Prime Programmer was successful. 0 errors, 0 warnings
    Info: Peak virtual memory: 329 megabytes
    Info: Processing ended: Sun Jan 16 18:13:01 2022
    Info: Elapsed time: 00:00:04
    Info: Total CPU time (on all processors): 00:00:00
```