### PR TITLE
Fix Zedboard software

### DIFF
--- a/litex_boards/targets/digilent_zedboard.py
+++ b/litex_boards/targets/digilent_zedboard.py
@@ -48,6 +48,8 @@ class _CRG(Module):
 
 
 class BaseSoC(SoCCore):
+    mem_map = {"csr": 0x43c0_0000}  # default GP0 address on Zynq
+
     def __init__(self, sys_clk_freq, with_led_chaser=True, **kwargs):
         platform = digilent_zedboard.Platform()
 
@@ -70,17 +72,16 @@ class BaseSoC(SoCCore):
             self.submodules += axi.AXI2Wishbone(
                 axi          = self.cpu.add_axi_gp_master(),
                 wishbone     = wb_gp0,
-                base_address = 0x43c0_0000)  # default GP0 address on Zynq
+                base_address = self.mem_map["csr"])
             self.add_wb_master(wb_gp0)
 
-            # FIXME: collection of hacks to enable BIOS compilation
             self.bus.add_region("sram", SoCRegion(
-                origin=128 * 1024 * 1024,
-                size=256 * 1024 * 1024)
+                origin=self.cpu.mem_map["sram"],
+                size=512 * 1024 * 1024 - self.cpu.mem_map["sram"])
             )
             self.bus.add_region("rom", SoCRegion(
-                origin=256 * 1024 * 1024,
-                size=8 * 1024 * 1024,
+                origin=self.cpu.mem_map["rom"],
+                size=256 * 1024 * 1024 // 8,
                 linker=True)
             )
             self.cpu.use_rom = True

--- a/litex_boards/targets/digilent_zedboard.py
+++ b/litex_boards/targets/digilent_zedboard.py
@@ -84,7 +84,6 @@ class BaseSoC(SoCCore):
                 size=256 * 1024 * 1024 // 8,
                 linker=True)
             )
-            self.cpu.use_rom = True
             self.constants['CONFIG_CLOCK_FREQUENCY'] = 666666687
 
             use_ps7_clk = True


### PR DESCRIPTION
This cleans up Zynq memory map and removes a hack that is not necessary anymore.