### PR TITLE
xilinx_zcu106: add DDR4 interface and fix reset error

### DIFF
--- a/litex_boards/platforms/xilinx_zcu106.py
+++ b/litex_boards/platforms/xilinx_zcu106.py
@@ -27,6 +27,13 @@ _io = [
     ("user_led", 6, Pins("AM10"), IOStandard("LVCMOS12")),
     ("user_led", 7, Pins("AM11"), IOStandard("LVCMOS12")),
 
+    # Buttons
+    ("user_btn_c", 0, Pins("AL11"), IOStandard("LVCMOS12")),
+    ("user_btn_n", 0, Pins("AG13"), IOStandard("LVCMOS12")),
+    ("user_btn_s", 0, Pins("AP20"), IOStandard("LVCMOS12")),
+    ("user_btn_w", 0, Pins("AK12"), IOStandard("LVCMOS12")),
+    ("user_btn_e", 0, Pins("AC14"), IOStandard("LVCMOS12")),
+
     # Serial
     ("serial", 0,
         Subsignal("cts", Pins("AP17")),
@@ -34,6 +41,50 @@ _io = [
         Subsignal("tx",  Pins("AL17")),
         Subsignal("rx",  Pins("AH17")),
         IOStandard("LVCMOS12")
+    ),
+
+    # DDR4 SDRAM
+    ("ddram", 0,
+        Subsignal("a",       Pins(
+            "AK9 AG11 AJ10 AL8 AK10 AH8 AJ9 AG8",
+            "AH9 AG10 AH13 AG9 AM13 AF8"),
+            IOStandard("SSTL12_DCI")),
+        Subsignal("ba",      Pins("AK8 AL12"), IOStandard("SSTL12_DCI")),
+        Subsignal("bg",      Pins("AE14"), IOStandard("SSTL12_DCI")),
+        Subsignal("ras_n",   Pins("AF11"), IOStandard("SSTL12_DCI")), # A16
+        Subsignal("cas_n",   Pins("AE12"), IOStandard("SSTL12_DCI")), # A15
+        Subsignal("we_n",    Pins("AC12"), IOStandard("SSTL12_DCI")), # A14
+        Subsignal("cs_n",    Pins("AD12"), IOStandard("SSTL12_DCI")),
+        Subsignal("act_n",   Pins("AD14"), IOStandard("SSTL12_DCI")),
+        # Subsignal("par",     Pins("AC13"), IOStandard("SSTL12_DCI")),
+        Subsignal("dm",      Pins("AH18 AD15 AM16 AP18 AE18 AH22 AL20 AP19"),
+            IOStandard("POD12_DCI")),
+        Subsignal("dq",      Pins(
+                "AF16 AF18 AG15 AF17 AF15 AG18 AG14 AE17",
+                "AA14 AC16 AB15 AD16 AB16 AC17 AB14 AD17",
+                "AJ16 AJ17 AL15 AK17 AJ15 AK18 AL16 AL18",
+                "AP13 AP16 AP15 AN16 AN13 AM18 AN17 AN18",
+                "AB19 AD19 AC18 AC19 AA20 AE20 AA19 AD20",
+                "AF22 AH21 AG19 AG21 AE24 AG20 AE23 AF21",
+                "AL22 AJ22 AL23 AJ21 AK20 AJ19 AK19 AJ20",
+                "AP22 AN22 AP21 AP23 AM19 AM23 AN19 AN23"),
+            IOStandard("POD12_DCI"),
+            Misc("PRE_EMPHASIS=RDRV_240"),
+            Misc("EQUALIZATION=EQ_LEVEL2")),
+        Subsignal("dqs_p",   Pins("AH14 AA16 AK15 AM14 AA18 AF23 AK22 AM21"),
+            IOStandard("DIFF_POD12_DCI"),
+            Misc("PRE_EMPHASIS=RDRV_240"),
+            Misc("EQUALIZATION=EQ_LEVEL2")),
+        Subsignal("dqs_n",   Pins("AJ14 AA15 AK14 AN14 AB18 AG23 AK23 AN21"),
+            IOStandard("DIFF_POD12_DCI"),
+            Misc("PRE_EMPHASIS=RDRV_240"),
+            Misc("EQUALIZATION=EQ_LEVEL2")),
+        Subsignal("clk_p",   Pins("AH11"), IOStandard("DIFF_SSTL12_DCI")),
+        Subsignal("clk_n",   Pins("AJ11"), IOStandard("DIFF_SSTL12_DCI")),
+        Subsignal("cke",     Pins("AB13"), IOStandard("SSTL12_DCI")),
+        Subsignal("odt",     Pins("AF10"), IOStandard("SSTL12_DCI")),
+        Subsignal("reset_n", Pins("AF12"), IOStandard("LVCMOS12")),
+        Misc("SLEW=FAST"),
     ),
 ]
 
@@ -53,3 +104,6 @@ class Platform(XilinxPlatform):
     def do_finalize(self, fragment):
         XilinxPlatform.do_finalize(self, fragment)
         self.add_period_constraint(self.lookup_request("clk125", loose=True), 1e9/125e6)
+        self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 64]")
+        self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 65]")
+        self.add_platform_command("set_property INTERNAL_VREF 0.84 [get_iobanks 66]")

--- a/litex_boards/targets/xilinx_zcu106.py
+++ b/litex_boards/targets/xilinx_zcu106.py
@@ -19,12 +19,18 @@ from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
 from litex.soc.cores.led import LedChaser
 
+from litedram.modules import MT40A256M16
+from litedram.phy import usddrphy
+
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(Module):
     def __init__(self, platform, sys_clk_freq):
         self.rst = Signal()
-        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sys    = ClockDomain()
+        self.clock_domains.cd_sys4x  = ClockDomain(reset_less=True)
+        self.clock_domains.cd_pll4x  = ClockDomain(reset_less=True)
+        self.clock_domains.cd_idelay = ClockDomain()
 
         # # #
 
@@ -32,10 +38,21 @@ class _CRG(Module):
         rst    = platform.request("rst")
 
         self.submodules.pll = pll = USMMCM(speedgrade=-2)
-        self.comb += pll.reset.eq(self.rst | ~rst)
+        self.comb += pll.reset.eq(self.rst | rst)
         pll.register_clkin(clk125, 125e6)
-        pll.create_clkout(self.cd_sys, sys_clk_freq)
+        pll.create_clkout(self.cd_pll4x, sys_clk_freq*4, buf=None, with_reset=False)
+        pll.create_clkout(self.cd_idelay, 500e6)
         platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
+
+        self.specials += [
+            Instance("BUFGCE_DIV", name="main_bufgce_div",
+                p_BUFGCE_DIVIDE=4,
+                i_CE=1, i_I=self.cd_pll4x.clk, o_O=self.cd_sys.clk),
+            Instance("BUFGCE", name="main_bufgce",
+                i_CE=1, i_I=self.cd_pll4x.clk, o_O=self.cd_sys4x.clk),
+        ]
+
+        self.submodules.idelayctrl = USIDELAYCTRL(cd_ref=self.cd_idelay, cd_sys=self.cd_sys)
 
 # BaseSoC ------------------------------------------------------------------------------------------
 
@@ -50,6 +67,19 @@ class BaseSoC(SoCCore):
 
         # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = _CRG(platform, sys_clk_freq)
+
+        # DDR4 SDRAM -------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.submodules.ddrphy = usddrphy.USPDDRPHY(platform.request("ddram"),
+                memtype          = "DDR4",
+                sys_clk_freq     = sys_clk_freq,
+                iodelay_clk_freq = 500e6)
+            self.add_sdram("sdram",
+                phy           = self.ddrphy,
+                module        = MT40A256M16(sys_clk_freq, "1:4"),
+                size          = 0x20000000,
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:


### PR DESCRIPTION
1. Add ZCU106 PL DDR4 PHY IOs. Then we can upload firmware to board for CFU playground framework.
2. According to the schematic diagram, it can be confirmed that the rst pin is active at high level.

DDR, reset pin and CFU tested pass.