### PR TITLE
Digilent CMOD A7: add flash support.

### DIFF
--- a/litex_boards/platforms/digilent_cmod_a7.py
+++ b/litex_boards/platforms/digilent_cmod_a7.py
@@ -51,6 +51,24 @@ _io = [
         Subsignal("cen", Pins("N19"), IOStandard("LVCMOS33")),
         Misc("SLEW=FAST"),
     ),
+
+    # SPIFlash
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("K19")),
+        Subsignal("clk",  Pins("E19")),
+        Subsignal("mosi", Pins("D18")),
+        Subsignal("miso", Pins("D19")),
+        Subsignal("wp",   Pins("G18")),
+        Subsignal("hold", Pins("F18")),
+        IOStandard("LVCMOS33"),
+    ),
+    ("spiflash4x", 0,
+        Subsignal("cs_n", Pins("K19")),
+        Subsignal("clk",  Pins("E19")),
+        Subsignal("dq",   Pins("D18 D19 G18 F18")),
+        IOStandard("LVCMOS33")
+    ),
+
 ]
 
 # Connectors ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Add both "--flash" and "--with-spi-flash"; tested on board.
4MB flash mapped at 0x00400000.

Signed-off-by: Tim Callahan <tcal@google.com>