### PR TITLE
Enable LiteX BIOS on ARM core on Tang nano 4K

### DIFF
--- a/litex_boards/platforms/sipeed_tang_nano_4k.py
+++ b/litex_boards/platforms/sipeed_tang_nano_4k.py
@@ -83,8 +83,8 @@ _connectors = [
 # Platform -----------------------------------------------------------------------------------------
 
 class Platform(GowinPlatform):
-    default_clk_name   = "clk27"
-    default_clk_period = 1e9/27e6
+    default_clk_name = "clk27"
+    default_clk_freq = 27e6
 
     def __init__(self):
         GowinPlatform.__init__(self, "GW1NSR-LV4CQN48PC7/I6", _io, _connectors, toolchain="gowin", devicename="GW1NSR-4C")
@@ -97,4 +97,4 @@ class Platform(GowinPlatform):
 
     def do_finalize(self, fragment):
         GowinPlatform.do_finalize(self, fragment)
-        self.add_period_constraint(self.lookup_request("clk27", loose=True), 1e9/27e6)
+        self.add_period_constraint(self.lookup_request("clk27", loose=True), 1e9 / self.default_clk_freq)

--- a/litex_boards/targets/sipeed_tang_nano_4k.py
+++ b/litex_boards/targets/sipeed_tang_nano_4k.py
@@ -93,6 +93,15 @@ class BaseSoC(SoCCore):
 
         if self.cpu_type == "gowin_emcu":
             self.cpu.connect_uart(platform.request("serial"))
+            self.bus.add_region("sram", SoCRegion(
+                origin=self.cpu.mem_map["sram"],
+                size=16 * 1024)
+            )
+            self.bus.add_region("rom", SoCRegion(
+                origin=self.cpu.mem_map["rom"],
+                size=32 * 1024,
+                linker=True)
+            )
         else:
             # Add ROM linker region --------------------------------------------------------------------
             self.bus.add_region("rom", SoCRegion(
@@ -140,11 +149,8 @@ def main():
     parser.add_argument("--sys-clk-freq",default=27e6,        help="System clock frequency.")
     builder_args(parser)
     soc_core_args(parser)
+    parser.set_defaults(cpu_type="gowin_emcu")
     args = parser.parse_args()
-
-    if args.cpu_type == 'gowin_emcu':
-        # FIXME: ARM software not supported yet
-        args.no_compile_software = True
 
     soc = BaseSoC(
         sys_clk_freq=int(float(args.sys_clk_freq)),
@@ -162,6 +168,7 @@ def main():
         prog = soc.platform.create_programmer()
         prog.flash(0, os.path.join(builder.gateware_dir, "impl", "pnr", "project.fs"))
         prog.flash(0, "build/sipeed_tang_nano_4k/software/bios/bios.bin", external=True)
+
 
 if __name__ == "__main__":
     main()

--- a/litex_boards/targets/sipeed_tang_nano_4k.py
+++ b/litex_boards/targets/sipeed_tang_nano_4k.py
@@ -23,8 +23,11 @@ from litex_boards.platforms import tang_nano_4k
 
 from litehyperbus.core.hyperbus import HyperRAM
 
+from litespi.modules import W25Q32
+from litespi.opcodes import SpiNorFlashOpCodes as Codes
+
 kB = 1024
-mB = 1024*kB
+MB = 1024 * kB
 
 # CRG ----------------------------------------------------------------------------------------------
 
@@ -36,13 +39,13 @@ class _CRG(Module):
         # # #
 
         # Clk / Rst
-        clk27 = platform.request("clk27")
+        default_clk = platform.request(platform.default_clk_name)
         rst_n = platform.request("user_btn", 0)
 
         # PLL
         self.submodules.pll = pll = GW1NPLL(devicename=platform.devicename, device=platform.device)
         self.comb += pll.reset.eq(~rst_n)
-        pll.register_clkin(clk27, 27e6)
+        pll.register_clkin(default_clk, platform.default_clk_freq)
         pll.create_clkout(self.cd_sys, sys_clk_freq)
 
 
@@ -50,7 +53,7 @@ class _CRG(Module):
         if with_video_pll:
             self.submodules.video_pll = video_pll = GW1NPLL(devicename=platform.devicename, device=platform.device)
             self.comb += video_pll.reset.eq(~rst_n)
-            video_pll.register_clkin(clk27, 27e6)
+            video_pll.register_clkin(default_clk, platform.default_clk_freq)
             self.clock_domains.cd_hdmi   = ClockDomain()
             self.clock_domains.cd_hdmi5x = ClockDomain()
             video_pll.create_clkout(self.cd_hdmi5x, 125e6)
@@ -64,7 +67,7 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(27e6), with_hyperram=False, with_led_chaser=True, with_video_terminal=True, **kwargs):
+    def __init__(self, sys_clk_freq, with_hyperram=False, with_led_chaser=True, with_video_terminal=True, **kwargs):
         platform = tang_nano_4k.Platform()
 
         if "cpu_type" in kwargs and kwargs["cpu_type"] == "gowin_emcu":
@@ -86,23 +89,20 @@ class BaseSoC(SoCCore):
         # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = _CRG(platform, sys_clk_freq, with_video_pll=with_video_terminal)
 
-        # SPI Flash --------------------------------------------------------------------------------
-        from litespi.modules import W25Q32
-        from litespi.opcodes import SpiNorFlashOpCodes as Codes
-        self.add_spi_flash(mode="1x", module=W25Q32(Codes.READ_1_1_1), with_master=False)
-
         if self.cpu_type == "gowin_emcu":
             self.cpu.connect_uart(platform.request("serial"))
             self.bus.add_region("sram", SoCRegion(
                 origin=self.cpu.mem_map["sram"],
-                size=16 * 1024)
+                size=16 * kB)
             )
             self.bus.add_region("rom", SoCRegion(
                 origin=self.cpu.mem_map["rom"],
-                size=32 * 1024,
+                size=32 * kB,
                 linker=True)
             )
         else:
+            # SPI Flash --------------------------------------------------------------------------------
+            self.add_spi_flash(mode="1x", module=W25Q32(Codes.READ_1_1_1), with_master=False)
             # Add ROM linker region --------------------------------------------------------------------
             self.bus.add_region("rom", SoCRegion(
                 origin = self.bus.regions["spiflash"].origin,
@@ -167,7 +167,7 @@ def main():
     if args.flash:
         prog = soc.platform.create_programmer()
         prog.flash(0, os.path.join(builder.gateware_dir, "impl", "pnr", "project.fs"))
-        prog.flash(0, "build/sipeed_tang_nano_4k/software/bios/bios.bin", external=True)
+        prog.flash(0, os.path.join(builder.software_dir, "bios", "bios.bin"), external=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Has to be programmed with Gowin programmer (which for me sadly on works on Windows) in MCU mode using project.fs and bios.bin.

Also tested at "--sys-clk-freq=78e6" and "--sys-clk-freq=54e6".
