### PR TITLE
Add JTAGbone support to Terasic DECA

### DIFF
--- a/litex_boards/prog/openocd_max10_blaster.cfg
+++ b/litex_boards/prog/openocd_max10_blaster.cfg
@@ -1,0 +1,22 @@
+source [find interface/altera-usb-blaster.cfg]
+
+if { [info exists CHIPNAME] } {
+	set _CHIPNAME $CHIPNAME
+} else {
+	set _CHIPNAME 10m50
+}
+
+# user-defined chains are 0xC (12) or 0xE (14)
+# they are the same, single, scan-chain disgtinguished by the usr1user bit
+
+jtag newtap $_CHIPNAME tap -irlen 10 -expected-id 0x31810dd -expected-id 0x318a0dd \
+	-expected-id 0x31820dd -expected-id 0x31830dd -expected-id 0x31840dd \
+	-expected-id 0x318d0dd -expected-id 0x31850dd -expected-id 0x31010dd \
+	-expected-id 0x310a0dd -expected-id 0x31020dd -expected-id 0x31030dd \
+	-expected-id 0x31040dd -expected-id 0x310d0dd -expected-id 0x31050dd
+
+# unneeded
+# suppresses warning
+gdb_port disabled
+tcl_port disabled
+telnet_port disabled

--- a/litex_boards/prog/openocd_max10_blaster2.cfg
+++ b/litex_boards/prog/openocd_max10_blaster2.cfg
@@ -1,0 +1,22 @@
+source [find interface/altera-usb-blaster2.cfg]
+
+if { [info exists CHIPNAME] } {
+	set _CHIPNAME $CHIPNAME
+} else {
+	set _CHIPNAME 10m50
+}
+
+# user-defined chains are 0xC (12) or 0xE (14)
+# they are the same, single, scan-chain disgtinguished by the usr1user bit
+
+jtag newtap $_CHIPNAME tap -irlen 10 -expected-id 0x31810dd -expected-id 0x318a0dd \
+	-expected-id 0x31820dd -expected-id 0x31830dd -expected-id 0x31840dd \
+	-expected-id 0x318d0dd -expected-id 0x31850dd -expected-id 0x31010dd \
+	-expected-id 0x310a0dd -expected-id 0x31020dd -expected-id 0x31030dd \
+	-expected-id 0x31040dd -expected-id 0x310d0dd -expected-id 0x31050dd
+
+# unneeded
+# suppresses warning
+gdb_port disabled
+tcl_port disabled
+telnet_port disabled

--- a/litex_boards/targets/terasic_deca.py
+++ b/litex_boards/targets/terasic_deca.py
@@ -17,7 +17,6 @@ from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
 from litex.soc.cores.video import VideoDVIPHY
 from litex.soc.cores.led import LedChaser
-from litex.soc.cores.bitbang import I2CMaster
 
 # CRG ----------------------------------------------------------------------------------------------
 
@@ -52,13 +51,20 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(50e6), with_led_chaser=True, with_video_terminal=False,
+    def __init__(self, sys_clk_freq=int(50e6), with_led_chaser=True, with_uartbone=False, with_jtagbone=False,
+                 with_video_terminal=False,
                  **kwargs):
         self.platform = platform = deca.Platform()
 
         # Defaults to JTAG-UART since no hardware UART.
-        if kwargs["uart_name"] == "serial":
-            kwargs["uart_name"] = "jtag_atlantic"
+        real_uart_name = kwargs["uart_name"]
+        if real_uart_name == "serial":
+            if with_jtagbone:
+                kwargs["uart_name"] = "crossover"
+            else:
+                kwargs["uart_name"] = "jtag_atlantic"
+        if with_uartbone:
+            kwargs["uart_name"] = "crossover"
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq,
@@ -67,6 +73,14 @@ class BaseSoC(SoCCore):
 
         # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = self.crg = _CRG(platform, sys_clk_freq, with_usb_pll=False)
+
+        # UARTbone ---------------------------------------------------------------------------------
+        if with_uartbone:
+            self.add_uartbone(name=real_uart_name, baudrate=kwargs["uart_baudrate"])
+
+        # JTAGbone ---------------------------------------------------------------------------------
+        if with_jtagbone:
+            self.add_jtagbone()
 
         # Video ------------------------------------------------------------------------------------
         if with_video_terminal:
@@ -86,6 +100,8 @@ def main():
     parser.add_argument("--build",               action="store_true", help="Build bitstream.")
     parser.add_argument("--load",                action="store_true", help="Load bitstream.")
     parser.add_argument("--sys-clk-freq",        default=50e6,        help="System clock frequency.")
+    parser.add_argument("--with-uartbone",       action="store_true", help="Enable UARTbone support.")
+    parser.add_argument("--with-jtagbone",       action="store_true", help="Enable JTAGbone support.")
     parser.add_argument("--with-video-terminal", action="store_true", help="Enable Video Terminal (VGA).")
     builder_args(parser)
     soc_core_args(parser)
@@ -93,6 +109,8 @@ def main():
 
     soc = BaseSoC(
         sys_clk_freq             = int(float(args.sys_clk_freq)),
+        with_uartbone            = args.with_uartbone,
+        with_jtagbone            = args.with_jtagbone,
         with_video_terminal      = args.with_video_terminal,
         **soc_core_argdict(args)
     )


### PR DESCRIPTION
Along the way I added UARTbone support to DECA as well for debugging.

Examples:

./terasic_deca.py --csr-csv csr.csv --with-jtagbone --build --load
litex_server --jtag --jtag-config ../prog/openocd_max10_blaster2.cfg
litex_term crossover

./terasic_deca.py --csr-csv csr.csv --uart-name jtag_uart --build --load
litex_term --jtag-config ../prog/openocd_max10_blaster2.cfg jtag