### PR TITLE
Alveo U280 with HBM now working for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ ENV/
 
 # support library for EOS-S3 (downloaded when needed)
 litex_boards/targets/libeos/
+
+# ip files used during build
+litex_boards/targets/ip/

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ PCIe accelerators boards that you could use to accelerate your applications, Lit
 | ForestKitten33 | Xilinx Ultrascale+  | XCVU33P       | 125MHz   | PCIe | 2 x 1024-bit 4GB HBM2*|  Gen3 X16     |     ?       |
 | BCU1525        | Xilinx Ultrascale+  | XCVU9P        | 125MHz   | PCIe | 4 x 64-bit DDR4 DIMM  |  Gen3 X16     |     ?       |
 | AlveoU250      | Xilinx Ultrascale+  | XCU250        | 125MHz   | PCIe | 4 x 64-bit DDR4 DIMM  |  Gen2 X16     |     ?       |
-| AlveoU280      | Xilinx Ultrascale+  | XCU280-ES1    | 150MHz   | PCIe* | 2 x 64-bit DDR4 DIMM <BR> 2 x 1024-bit 4GB HBM2* |  Gen2 X16     |     ?       |
+| AlveoU280      | Xilinx Ultrascale+  | XCU280-ES1    | 150MHz   | PCIe* | 2 x 64-bit 16GB DDR4 DIMM* <BR> 2 x 1024-bit 4GB HBM2 |  Gen2 X16     |     ?       |
 
 \* Present on the board but not yet supported or validated with LiteX.
 

--- a/litex_boards/targets/terasic_de0nano.py
+++ b/litex_boards/targets/terasic_de0nano.py
@@ -6,6 +6,10 @@
 # Copyright (c) 2015-2020 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+# Build/Use:
+# ./terasic_de0nano.py --uart-name=jtag_uart --build --load
+# litex_term --jtag-config ../prog/openocd_max10_blaster.cfg jtag
+
 import os
 import argparse
 

--- a/litex_boards/targets/xilinx_alveo_u280.py
+++ b/litex_boards/targets/xilinx_alveo_u280.py
@@ -9,6 +9,9 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
+# To interface via the serial port use:
+#     lxterm /dev/ttyUSBx --speed=115200
+
 import argparse, os
 
 from migen import *

--- a/litex_boards/targets/xilinx_alveo_u280.py
+++ b/litex_boards/targets/xilinx_alveo_u280.py
@@ -220,6 +220,9 @@ class BaseSoC(SoCCore):
                 axi_lite_hbm = AXILiteInterface(data_width=256, address_width=33)
                 self.submodules += AXILite2AXI(axi_lite_hbm, axi_hbm)
                 self.bus.add_slave(f"hbm{i}", axi_lite_hbm, SoCRegion(origin=0x4000_0000 + 0x1000_0000*i, size=0x1000_0000)) # 256MB.
+            # Link HBM2 channel 0 as main RAM
+            self.bus.add_region("main_ram", SoCRegion(origin=0x4000_0000, size=0x1000_0000, linker=True)) # 256MB.
+
         else:
             # DDR4 SDRAM -------------------------------------------------------------------------------
             if not self.integrated_main_ram_size:


### PR DESCRIPTION
Summary of changes:
- added `targets/ip/` to .gitignore
- updated the README.md description for Alveo board
- added line that links the HBM channel 0 to be used as main RAM

I tested this alone (targets ./xilinx_alveo_u280.py) and the bitstream is generated, boots into LiteX BIOS, and will create the linux-litex-vexriscv PR next.