### PR TITLE
antmicro datacenter: fix pins and increase freq

### DIFF
--- a/litex_boards/platforms/antmicro_datacenter_ddr4_test_board.py
+++ b/litex_boards/platforms/antmicro_datacenter_ddr4_test_board.py
@@ -63,12 +63,12 @@ _io = [
                 "AA18 AB19 V16  W15  AB17 AA17 V19  V17"),
             IOStandard("SSTL12_T_DCI")),
         Subsignal("dqs_p",   Pins(
-                "W10 W6  AB1 AA5 AD20 AE18 W18 Y15 AF5",
-                "B17 D19 L19 J15 T24  P19  R16 M25 AC8"),
+                "W10  B17 W6   D19 AB1 L19 AA5 J15",
+                "AD20 T24 AE18 P19 W18 R16 Y15 M25"),
             IOStandard("DIFF_HSUL_12")),
         Subsignal("dqs_n",   Pins(
-                "W9  W5  AC1 AB5 AE20 AF18 W19 Y16 AF4",
-                "A17 D20 L20 J16 T25  P20  R17 L25 AD8"),
+                "W9   A17 W5   D20 AC1 L20 AB5 J16",
+                "AE20 T25 AF18 P20 W19 R17 Y16 L25"),
             IOStandard("DIFF_HSUL_12")),
         Subsignal("clk_p",   Pins("AE12 AB12"), IOStandard("DIFF_SSTL12_DCI")),
         Subsignal("clk_n",   Pins("AF12 AC12"), IOStandard("DIFF_SSTL12_DCI")),

--- a/litex_boards/platforms/antmicro_datacenter_ddr4_test_board.py
+++ b/litex_boards/platforms/antmicro_datacenter_ddr4_test_board.py
@@ -61,7 +61,7 @@ _io = [
                 "AF17 AE17 AF20 AD19 AE15 AE16 AF19 AD18",
                 "Y18  Y17  W14  V14  AA20 AA15 V18  W16",
                 "AA18 AB19 V16  W15  AB17 AA17 V19  V17"),
-            IOStandard("SSTL12")),
+            IOStandard("SSTL12_T_DCI")),
         Subsignal("dqs_p",   Pins(
                 "W10 W6  AB1 AA5 AD20 AE18 W18 Y15 AF5",
                 "B17 D19 L19 J15 T24  P19  R16 M25 AC8"),
@@ -134,6 +134,7 @@ class Platform(XilinxPlatform):
         self.add_platform_command("set_property INTERNAL_VREF 0.6 [get_iobanks 32]")
         self.add_platform_command("set_property INTERNAL_VREF 0.6 [get_iobanks 33]")
         self.add_platform_command("set_property INTERNAL_VREF 0.6 [get_iobanks 34]")
+        self.add_platform_command("set_property DCI_CASCADE {{32 34}} [get_iobanks 33]")
 
     def create_programmer(self):
         return OpenOCD("openocd_xc7_ft4232.cfg", "bscan_spi_xc7k100t.bit")

--- a/litex_boards/platforms/antmicro_datacenter_ddr4_test_board.py
+++ b/litex_boards/platforms/antmicro_datacenter_ddr4_test_board.py
@@ -116,6 +116,13 @@ _io = [
         Misc("SLEW=FAST"),
         IOStandard("LVCMOS33"),
     ),
+
+    # I2C
+    ("i2c", 0,
+        Subsignal("scl", Pins("Y6")),
+        Subsignal("sda", Pins("Y5")),
+        IOStandard("SSTL12_T_DCI"),
+    ),
 ]
 
 # Platform -----------------------------------------------------------------------------------------

--- a/litex_boards/platforms/antmicro_datacenter_ddr4_test_board.py
+++ b/litex_boards/platforms/antmicro_datacenter_ddr4_test_board.py
@@ -46,7 +46,7 @@ _io = [
         Subsignal("ras_n",   Pins("AA12"), IOStandard("SSTL12_DCI")), # A16
         Subsignal("cas_n",   Pins("AF13"), IOStandard("SSTL12_DCI")), # A15
         Subsignal("we_n",    Pins("AA13"), IOStandard("SSTL12_DCI")), # A14
-        Subsignal("cs_n",    Pins("W13 AA14 AC14 AF15"), IOStandard("SSTL12_DCI")),
+        Subsignal("cs_n",    Pins("W13"), IOStandard("SSTL12_DCI")),
         Subsignal("act_n",   Pins("Y8"), IOStandard("SSTL12_DCI")),
         Subsignal("alert_n", Pins("AE10"), IOStandard("SSTL12_DCI")),
         Subsignal("par",     Pins("AE13"), IOStandard("SSTL12_DCI")),
@@ -70,10 +70,10 @@ _io = [
                 "W9   A17 W5   D20 AC1 L20 AB5 J16",
                 "AE20 T25 AF18 P20 W19 R17 Y16 L25"),
             IOStandard("DIFF_HSUL_12")),
-        Subsignal("clk_p",   Pins("AE12 AB12"), IOStandard("DIFF_SSTL12_DCI")),
-        Subsignal("clk_n",   Pins("AF12 AC12"), IOStandard("DIFF_SSTL12_DCI")),
-        Subsignal("cke",     Pins("AA8 AA7"), IOStandard("SSTL12_DCI")), # also AM15 for larger SODIMMs
-        Subsignal("odt",     Pins("Y13 AB14"), IOStandard("SSTL12_DCI")), # also AM16 for larger SODIMMs
+        Subsignal("clk_p",   Pins("AE12"), IOStandard("DIFF_SSTL12_DCI")),
+        Subsignal("clk_n",   Pins("AF12"), IOStandard("DIFF_SSTL12_DCI")),
+        Subsignal("cke",     Pins("AA8"), IOStandard("SSTL12_DCI")), # also AM15 for larger SODIMMs
+        Subsignal("odt",     Pins("Y13"), IOStandard("SSTL12_DCI")), # also AM16 for larger SODIMMs
         Subsignal("reset_n", Pins("AB6"), IOStandard("SSTL12")),
         Misc("SLEW=FAST"),
     ),

--- a/litex_boards/targets/antmicro_datacenter_ddr4_test_board.py
+++ b/litex_boards/targets/antmicro_datacenter_ddr4_test_board.py
@@ -75,6 +75,7 @@ class BaseSoC(SoCCore):
                 memtype         = "DDR4",
                 iodelay_clk_freq = iodelay_clk_freq,
                 sys_clk_freq     = sys_clk_freq,
+                cmd_latency      = 1,
                 is_rdimm         = True,
             )
             self.add_sdram("sdram",

--- a/litex_boards/targets/antmicro_datacenter_ddr4_test_board.py
+++ b/litex_boards/targets/antmicro_datacenter_ddr4_test_board.py
@@ -21,7 +21,7 @@ from litex.soc.integration.builder import *
 from litex.soc.cores.led import LedChaser
 
 from litedram.modules import MTA18ASF2G72PZ
-from litedram.phy.s7ddrphy import K7DDRPHY
+from litedram.phy.s7ddrphy import A7DDRPHY
 
 from liteeth.phy import LiteEthS7PHYRGMII
 from litex.soc.cores.hyperbus import HyperRAM
@@ -30,19 +30,21 @@ from litex.soc.cores.hyperbus import HyperRAM
 
 class _CRG(Module):
     def __init__(self, platform, sys_clk_freq, iodelay_clk_freq):
-        self.clock_domains.cd_sys    = ClockDomain()
-        self.clock_domains.cd_sys2x  = ClockDomain(reset_less=True)
-        self.clock_domains.cd_sys4x  = ClockDomain(reset_less=True)
-        self.clock_domains.cd_idelay = ClockDomain()
+        self.clock_domains.cd_sys       = ClockDomain()
+        self.clock_domains.cd_sys2x     = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys4x     = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
+        self.clock_domains.cd_idelay    = ClockDomain()
 
         # # #
 
         self.submodules.pll = pll = S7PLL(speedgrade=-1)
         pll.register_clkin(platform.request("clk100"), 100e6)
-        pll.create_clkout(self.cd_sys,    sys_clk_freq)
-        pll.create_clkout(self.cd_sys2x,  2 * sys_clk_freq)
-        pll.create_clkout(self.cd_sys4x,  4 * sys_clk_freq)
-        pll.create_clkout(self.cd_idelay, iodelay_clk_freq)
+        pll.create_clkout(self.cd_sys,       sys_clk_freq)
+        pll.create_clkout(self.cd_sys2x,     2 * sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x,     4 * sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x_dqs, 4 * sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_idelay,    iodelay_clk_freq)
 
         self.submodules.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
 
@@ -65,7 +67,7 @@ class BaseSoC(SoCCore):
 
         # DDR4 SDRAM RDIMM -------------------------------------------------------------------------
         if not self.integrated_main_ram_size:
-            self.submodules.ddrphy = K7DDRPHY(platform.request("ddr4"),
+            self.submodules.ddrphy = A7DDRPHY(platform.request("ddr4"),
                 memtype         = "DDR4",
                 iodelay_clk_freq = iodelay_clk_freq,
                 sys_clk_freq     = sys_clk_freq,

--- a/litex_boards/targets/antmicro_datacenter_ddr4_test_board.py
+++ b/litex_boards/targets/antmicro_datacenter_ddr4_test_board.py
@@ -20,6 +20,7 @@ from litex.soc.integration.soc_core import *
 from litex.soc.integration.soc import SoCRegion
 from litex.soc.integration.builder import *
 from litex.soc.cores.led import LedChaser
+from litex.soc.cores.bitbang import I2CMaster
 
 from litedram.modules import MTA18ASF2G72PZ
 from litedram.phy.s7ddrphy import A7DDRPHY
@@ -75,7 +76,6 @@ class BaseSoC(SoCCore):
                 memtype         = "DDR4",
                 iodelay_clk_freq = iodelay_clk_freq,
                 sys_clk_freq     = sys_clk_freq,
-                cmd_latency      = 1,
                 is_rdimm         = True,
             )
             self.add_sdram("sdram",
@@ -121,6 +121,10 @@ class BaseSoC(SoCCore):
                 pads         = platform.request_all("user_led"),
                 sys_clk_freq = sys_clk_freq)
 
+        # System I2C (behing multiplexer) ----------------------------------------------------------
+        i2c_pads = platform.request('i2c')
+        self.submodules.i2c = I2CMaster(i2c_pads)
+
     def generate_sdram_phy_py_header(self, output_file):
         os.makedirs(os.path.dirname(output_file), exist_ok=True)
         f = open(output_file, "w")
@@ -150,7 +154,7 @@ def main():
     target.add_argument("--build",            action="store_true",    help="Build bitstream.")
     target.add_argument("--load",             action="store_true",    help="Load bitstream.")
     target.add_argument("--flash",            action="store_true",    help="Flash bitstream.")
-    target.add_argument("--sys-clk-freq",     default=50e6,           help="System clock frequency.")
+    target.add_argument("--sys-clk-freq",     default=100e6,           help="System clock frequency.")
     target.add_argument("--iodelay-clk-freq", default=200e6,          help="IODELAYCTRL frequency.")
     ethopts = target.add_mutually_exclusive_group()
     ethopts.add_argument("--with-ethernet",   action="store_true",    help="Add Ethernet.")


### PR DESCRIPTION
This PR fixes the antmicro datacenter board definition:

 - adjusted pins corresponding to the RDIMM datacenter board
 - increased clk frequency to 100 MHz to reach 800 MT/s
 - use A7DDRPHY (without odelays)
 - add i2c