### PR TITLE
antmicro_datacenter: fix i2c pads assignment

### DIFF
--- a/litex_boards/platforms/antmicro_datacenter_ddr4_test_board.py
+++ b/litex_boards/platforms/antmicro_datacenter_ddr4_test_board.py
@@ -119,8 +119,8 @@ _io = [
 
     # I2C
     ("i2c", 0,
-        Subsignal("scl", Pins("Y6")),
-        Subsignal("sda", Pins("Y5")),
+        Subsignal("scl", Pins("Y5")),
+        Subsignal("sda", Pins("Y6")),
         IOStandard("SSTL12_T_DCI"),
     ),
 ]


### PR DESCRIPTION
This fixes a typo in https://github.com/litex-hub/litex-boards/pull/359 for which the i2c pads were inverted

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>