### PR TITLE
add Gowin programmer support

### DIFF
--- a/litex_boards/platforms/sipeed_tang_nano_9k.py
+++ b/litex_boards/platforms/sipeed_tang_nano_9k.py
@@ -1,7 +1,6 @@
 #
 # This file is part of LiteX-Boards.
 #
-# Copyright (c) 2022 Franz Zhou <curliph@gmail.com>
 # Copyright (c) 2022 Icenowy Zheng <icenowy@aosc.io>
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/litex_boards/platforms/sipeed_tang_nano_9k.py
+++ b/litex_boards/platforms/sipeed_tang_nano_9k.py
@@ -1,6 +1,7 @@
 #
 # This file is part of LiteX-Boards.
 #
+# Copyright (c) 2022 Franz Zhou <curliph@gmail.com>
 # Copyright (c) 2022 Icenowy Zheng <icenowy@aosc.io>
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -8,7 +9,9 @@ from migen import *
 
 from litex.build.generic_platform import *
 from litex.build.gowin.platform import GowinPlatform
+from litex.build.gowin.programmer import GowinProgrammer
 from litex.build.openfpgaloader import OpenFPGALoader
+
 
 # IOs ----------------------------------------------------------------------------------------------
 
@@ -78,8 +81,11 @@ class Platform(GowinPlatform):
         GowinPlatform.__init__(self, "GW1NR-LV9QN88PC6/I5", _io, _connectors, toolchain=toolchain, devicename="GW1NR-9C")
         self.toolchain.options["use_mspi_as_gpio"] = 1
 
-    def create_programmer(self):
-        return OpenFPGALoader(cable="ft2232")
+    def create_programmer(self, kit="openfpgaloader"):
+        if kit == "gowin":
+            return GowinProgrammer(self.devicename)
+        else: 
+            return OpenFPGALoader(cable="ft2232")
 
     def do_finalize(self, fragment):
         GowinPlatform.do_finalize(self, fragment)

--- a/litex_boards/targets/sipeed_tang_nano_9k.py
+++ b/litex_boards/targets/sipeed_tang_nano_9k.py
@@ -3,7 +3,6 @@
 #
 # This file is part of LiteX-Boards.
 #
-# Copyright (c) 2022 Franz Zhou <curliph@gmail.com>
 # Copyright (c) 2022 Icenowy Zheng <icenowy@aosc.io>
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/litex_boards/targets/sipeed_tang_nano_9k.py
+++ b/litex_boards/targets/sipeed_tang_nano_9k.py
@@ -3,6 +3,7 @@
 #
 # This file is part of LiteX-Boards.
 #
+# Copyright (c) 2022 Franz Zhou <curliph@gmail.com>
 # Copyright (c) 2022 Icenowy Zheng <icenowy@aosc.io>
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -115,6 +116,7 @@ def main():
     parser.add_argument("--sys-clk-freq",default=27e6,        help="System clock frequency.")
     parser.add_argument("--bios-flash-offset", default="0x0", help="BIOS offset in SPI Flash.")
     parser.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support.")
+    parser.add_argument("--prog-kit", default="openfpgaloader", help="Programmer select from Gowin/openFPGALoader.")
     builder_args(parser)
     soc_core_args(parser)
     args = parser.parse_args()
@@ -132,13 +134,16 @@ def main():
     builder.build(run=args.build)
 
     if args.load:
-        prog = soc.platform.create_programmer()
+        prog = soc.platform.create_programmer(kit=args.prog_kit)
         prog.load_bitstream(os.path.join(builder.gateware_dir, "impl", "pnr", "project.fs"))
 
     if args.flash:
-        prog = soc.platform.create_programmer()
+        prog = soc.platform.create_programmer(kit=args.prog_kit)
         prog.flash(0, os.path.join(builder.gateware_dir, "impl", "pnr", "project.fs"))
-        prog.flash(int(args.bios_flash_offset, 0), "build/sipeed_tang_nano_9k/software/bios/bios.bin", external=True)
+        # external SPI programming not supported by gowin 'programmer_cli' now!
+        # if needed, use openFPGALoader or Gowin programmer GUI
+        if args.prog_kit == "openfpgaloader":
+            prog.flash(int(args.bios_flash_offset, 0), os.path.join(builder.software_dir, "bios", "bios.bin"), external=True)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
1. update only target for sipeed_tang_nano_9k platform and target
2. update LiteX to support PowerShell and WSL host for tang_nano_9k
3. add gowin programmer support, but with limitations:
    - there is no details info for external spi programming with programmer_cli, so it's support not working by now.
    - Verify got stuck, so it's also disabled by default.
    - programming interface is compatible with openFPGALoader

4. test with oss-cad-sute (from yosysHQ) under Powershell and also WSL(ubuntu 20.04)
    