### PR TITLE
lpddr4_test_board: Fix button pin

### DIFF
--- a/litex_boards/platforms/antmicro_lpddr4_test_board.py
+++ b/litex_boards/platforms/antmicro_lpddr4_test_board.py
@@ -20,7 +20,7 @@ _io = [
     ("user_led", 4, Pins("F9"), IOStandard("LVCMOS33")),
 
     ("user_btn", 0, Pins("E8"), IOStandard("LVCMOS33")),
-    ("user_btn", 1, Pins("B9"), IOStandard("LVCMOS33")),
+    ("user_btn", 1, Pins("B8"), IOStandard("LVCMOS33")),
     ("user_btn", 2, Pins("C9"), IOStandard("LVCMOS33")),
     ("user_btn", 3, Pins("E9"), IOStandard("LVCMOS33")),
 


### PR DESCRIPTION
Currently if you use user button 1 in a design, Vivado will prompt a critical warning:
```
CRITICAL WARNING: [Common 17-69] Command failed: 'B9' is not a valid site or package pin name. [/build/antmicro_lpddr4_test_board/gateware/antmicro_lpddr4_test_board.xdc:211] 
```
This happens because there is an issue with pin name which I believe is a typo. Pin `B9` is a pin assigned to GND in `xc7k70tfbg484` part. When you look at LPDDR4 `.kicad_pcb` file you can see that this user button should be connected to `B8` pin:
```
    (pad B8 smd circle (at -3.5 -9.5 270) (size 0.51 0.51) (layers F.Cu F.Paste F.Mask)
      (net 456 USR_BTN2))
```

This resolves an issue with critical warning.