### PR TITLE
butterstick: set ethernet rx_delay to 0ns

### DIFF
--- a/litex_boards/targets/gsd_butterstick.py
+++ b/litex_boards/targets/gsd_butterstick.py
@@ -129,7 +129,9 @@ class BaseSoC(SoCCore):
         if with_ethernet or with_etherbone:
             self.submodules.ethphy = LiteEthPHYRGMII(
                 clock_pads = self.platform.request("eth_clocks"),
-                pads       = self.platform.request("eth"))
+                pads       = self.platform.request("eth"),
+                rx_delay   = 0e-9, # KSZ9031RNX phy adds a 1.2ns RX delay
+                )
             if with_ethernet:
                 self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip)
             if with_etherbone:


### PR DESCRIPTION
The Microchip KSZ9031RNX PHY on the Butterstick has a default 1.2ns
internal RX delay so we shouldn't add the default 2ns MAC delay.

In testing with Linux on vexriscv I haven't seen any difference either
way, but with liteeth in Microwatt I have seen 30%+ packet loss when
receiving from certain ethernet devices (RTL8153 and AX88179 usb-gige
adapters, a GS105 switch didn't show the problem). Setting RX delay=0
resolves the problem. A TX delay is still required by the PHY.

Adding @gregdavill for any thoughts.