### PR TITLE
adi_adrv2crr: Upgrade part to speedgrade 2

### DIFF
--- a/litex_boards/platforms/adi_adrv2crr_fmc.py
+++ b/litex_boards/platforms/adi_adrv2crr_fmc.py
@@ -476,7 +476,7 @@ class Platform(XilinxPlatform):
     default_clk_period = 1e9/122.88e6
 
     def __init__(self):
-        XilinxPlatform.__init__(self, "xczu11eg-ffvf1517-1-i", _io, _connectors, toolchain="vivado")
+        XilinxPlatform.__init__(self, "xczu11eg-ffvf1517-2-i", _io, _connectors, toolchain="vivado")
 
     def do_finalize(self, fragment):
         XilinxPlatform.do_finalize(self, fragment)


### PR DESCRIPTION
Even though the schematic and bom call for speedgrade 1, this was only for
the prototypes.

All productions units have been updated to speedgrade 2.

See this thread:
https://ez.analog.com/fpga/f/q-a/112356/adrv9009-zu11eg-speed-grade

And the official HDL project for the board:
https://github.com/analogdevicesinc/hdl/blob/master/projects/adrv9009zu11eg/adrv2crr_fmc/system_project.tcl#L16

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>