### PR TITLE
qmtech_5cefa2: make serial pins consistent with other boards

### DIFF
--- a/litex_boards/platforms/qmtech_5cefa2.py
+++ b/litex_boards/platforms/qmtech_5cefa2.py
@@ -124,8 +124,8 @@ class Platform(AlteraPlatform):
     core_resources = [
         ("user_led", 0, Pins("D17"), IOStandard("3.3-V LVTTL")),
         ("serial", 0,
-            Subsignal("tx", Pins("J3:8"), IOStandard("3.3-V LVTTL")),
-            Subsignal("rx", Pins("J3:7"), IOStandard("3.3-V LVTTL"))
+            Subsignal("tx", Pins("J3:7"), IOStandard("3.3-V LVTTL")),
+            Subsignal("rx", Pins("J3:8"), IOStandard("3.3-V LVTTL"))
         ),
  ]
 


### PR DESCRIPTION
The pins on this one are inconsistent with the other qmtech boards.