### PR TITLE
Delete additional "o" in "builder" object

### DIFF
--- a/litex_boards/targets/digilent_basys3.py
+++ b/litex_boards/targets/digilent_basys3.py
@@ -95,7 +95,7 @@ def main():
 
     if args.load:
         prog = soc.platform.create_programmer()
-        prog.load_bitstream(obuilder.get_bitstream_filename(mode="sram"))
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Delete an additional "o" in "builder" object. It makes not possible to program the Basys 3 out-of-the-box.