### PR TITLE
enclustra_mercury_kx2: add clk100, leds, base board serial, DDR3 termination

### DIFF
--- a/litex_boards/platforms/enclustra_mercury_kx2.py
+++ b/litex_boards/platforms/enclustra_mercury_kx2.py
@@ -12,7 +12,6 @@ from litex.build.openocd import OpenOCD
 
 _io = [
     # Clk / Rst
-    ("clk100", 0, Pins("AD24"), IOStandard("LVCMOS18")),
     ("clk200", 0,
         Subsignal("p", Pins("AB11"), IOStandard("LVDS")),
         Subsignal("n", Pins("AC11"), IOStandard("LVDS"))
@@ -115,4 +114,3 @@ class Platform(XilinxPlatform):
     def do_finalize(self, fragment):
         XilinxPlatform.do_finalize(self, fragment)
         self.add_period_constraint(self.lookup_request("clk200", loose=True), 1e9/200e6)
-        self.add_period_constraint(self.lookup_request("clk100", loose=True), 1e9/100e6)

--- a/litex_boards/platforms/enclustra_mercury_kx2.py
+++ b/litex_boards/platforms/enclustra_mercury_kx2.py
@@ -12,6 +12,7 @@ from litex.build.openocd import OpenOCD
 
 _io = [
     # Clk / Rst
+    ("clk100", 0, Pins("AD24"), IOStandard("LVCMOS18")),
     ("clk200", 0,
         Subsignal("p", Pins("AB11"), IOStandard("LVDS")),
         Subsignal("n", Pins("AC11"), IOStandard("LVDS"))
@@ -19,16 +20,24 @@ _io = [
     ("cpu_reset_n", 0, Pins("G9"), IOStandard("LVCMOS25")),
 
     # Leds
-    ("user_led", 0, Pins("U9"),  IOStandard("LVCMOS15")),
-    ("user_led", 1, Pins("V12"), IOStandard("LVCMOS15")),
-    #("user_led", 2, Pins("V13"), IOStandard("LVCMOS15")),
-    #("user_led", 3, Pins("W13"), IOStandard("LVCMOS15")),
+    ("user_led", 0, Pins("U9"),  IOStandard("LVCMOS15"), Misc("SLEW=SLOW")),
+    ("user_led", 1, Pins("V12"), IOStandard("LVCMOS15"), Misc("SLEW=SLOW")),
+    ("user_led", 2, Pins("V13"), IOStandard("LVCMOS15"), Misc("SLEW=SLOW")),
+    ("user_led", 3, Pins("W13"), IOStandard("LVCMOS15"), Misc("SLEW=SLOW")),
 
-    # Serial
+    # The Serial which connects to the second UART
+    # of the FTDI on the base board (first FTDI port is JTAG)
     ("serial", 0,
+        Subsignal("tx", Pins("A20")),
+        Subsignal("rx", Pins("B20")),
+        IOStandard("LVCMOS15")
+     ),
+
+    # Serial This one is multiplexed with the I2C bus
+    ("serial", 1,
         Subsignal("tx", Pins("W11")),
         Subsignal("rx", Pins("AB16")),
-        IOStandard("LVCMOS15")  # FIXME: LVCMOS15 or LVCMOS33?
+        IOStandard("LVCMOS15")
      ),
 
     # DDR3 SDRAM
@@ -56,17 +65,21 @@ _io = [
             "W15   W16  W14   V16 V19  V17  V18  Y17"),
             IOStandard("SSTL15_T_DCI")),
         Subsignal("dqs_p", Pins("AB1 W6 AF5 AA5 AE18 Y15 AD20 W18"),
-            IOStandard("DIFF_SSTL15")),
+            IOStandard("DIFF_SSTL15_T_DCI")),
         Subsignal("dqs_n", Pins("AC1 W5 AF4 AB5 AF18 Y16 AE20 W19"),
-            IOStandard("DIFF_SSTL15")),
+            IOStandard("DIFF_SSTL15_T_DCI")),
         Subsignal("clk_p", Pins("AB12"), IOStandard("DIFF_SSTL15")),
         Subsignal("clk_n", Pins("AC12"), IOStandard("DIFF_SSTL15")),
         Subsignal("cke",   Pins("AA13"), IOStandard("SSTL15")),
         Subsignal("odt",   Pins("AD13"), IOStandard("SSTL15")),
-        Subsignal("reset_n", Pins("AB7"), IOStandard("LVCMOS15")),
+        Subsignal("reset_n", Pins("AB7"), IOStandard("SSTL15"), Misc("SLEW=SLOW")),
         Misc("SLEW=FAST"),
-        Misc("VCCAUX_IO=HIGH")
+        Misc("VCCAUX_IO=HIGH"),
     ),
+
+    # Don't use, this is for documentation only.
+    # This pin sets DDR3 voltage. LOW = 1.3V, HI-Z = 1.5V, HIGH = illegal
+    ("ddram_vsel", 0, Pins('AA3'), IOStandard("SSTL15"), Misc("SLEW=SLOW")),
 ]
 
 # Platform -----------------------------------------------------------------------------------------
@@ -76,7 +89,25 @@ class Platform(XilinxPlatform):
     default_clk_period = 1e9/200e6
 
     def __init__(self, toolchain="vivado"):
-        XilinxPlatform.__init__(self, " xc7k160tffg676-2", _io, toolchain=toolchain)
+        XilinxPlatform.__init__(self, "xc7k160tffg676-2", _io, toolchain=toolchain)
+        self.add_platform_command("set_property CONFIG_VOLTAGE 1.8 [current_design]")
+        self.add_platform_command("set_property CFGBVS GND [current_design]")
+        # DDR3 is connected to banks 32, 33 and 34
+        self.add_platform_command("set_property INTERNAL_VREF 0.750 [get_iobanks 32]")
+        self.add_platform_command("set_property INTERNAL_VREF 0.750 [get_iobanks 33]")
+        self.add_platform_command("set_property INTERNAL_VREF 0.750 [get_iobanks 34]")
+        # The VRP/VRN resistors are connected to bank 34.
+        # Banks 32 and 33 have LEDs in the places, so we have to use the reference from bank 34
+        # Bank 33 has no _T_DCI signals connected
+        self.add_platform_command("set_property DCI_CASCADE {{32}} [get_iobanks 34]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.CONFIGRATE 22 [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.OVERTEMPPOWERDOWN ENABLE [current_design]")
+
+        # Important! Do not remove this constraint!
+        # This property ensures that all unused pins are set to high impedance.
+        # If the constraint is removed, all unused pins have to be set to HiZ in the top level file
+        # This causes DDR3 to use 1.5V by default
+        self.add_platform_command("set_property BITSTREAM.CONFIG.UNUSEDPIN PULLNONE [current_design]")
 
     def create_programmer(self):
         return OpenOCD("openocd_xc7_ft232.cfg", "bscan_spi_xc7k160t.bit")
@@ -84,3 +115,4 @@ class Platform(XilinxPlatform):
     def do_finalize(self, fragment):
         XilinxPlatform.do_finalize(self, fragment)
         self.add_period_constraint(self.lookup_request("clk200", loose=True), 1e9/200e6)
+        self.add_period_constraint(self.lookup_request("clk100", loose=True), 1e9/100e6)


### PR DESCRIPTION
Since start this board has a very strange issue:
As long as the DDR RAM is activated, the board goes completely dead
(LED chaser not working, all LEDs dark, no output on serial.)
In this pull request I already added all the properties from the Enclustra reference
design.
But nevertheless, the issue persists.
I use Vivado 2020.2.
Do you have any idea why the presence of the DDR PHY causes the whole design to go dead?
