### PR TITLE
muselab icesugar pro: add ethernet/etherbone support

### DIFF
--- a/litex_boards/platforms/muselab_icesugar_pro.py
+++ b/litex_boards/platforms/muselab_icesugar_pro.py
@@ -97,6 +97,22 @@ _io = [
         Subsignal("data2_p", Pins("L1"), IOStandard("LVCMOS33"), Misc("DRIVE=4")),
         Subsignal("data2_n", Pins("K2"), IOStandard("LVCMOS33"), Misc("DRIVE=4")),
     ),
+
+    # RMII Ethernet PHY (WaveShare Board)
+    # Assumed to be modified to be PMOD-compatible (TX1 tied to MDIO)
+    # Position is P4 header "top half" (toward the GPDI connector)
+    ("eth_clocks", 0,
+        Subsignal("ref_clk", Pins("D5")),
+        IOStandard("LVCMOS33"),
+    ),
+    ("eth", 0,
+        Subsignal("rx_data", Pins("D4 C3")),
+        Subsignal("crs_dv",  Pins("C4")),
+        Subsignal("tx_en",   Pins("E4")),
+        Subsignal("tx_data", Pins("E3 R7")),
+        IOStandard("LVCMOS33"),
+    ),
+
 ]
 
 # from colorlight_i5.py adapted to icesugar pro


### PR DESCRIPTION
- use P4 header for a waveshare ethernet phy module
- add --with-ethernet, --with-etherbone, --eth-ip, and --eth-dynamic-ip
  target configuration options