### PR TITLE
add HPCStore STLV7325 with HDMI video

### DIFF
--- a/litex_boards/platforms/hpcstore_stlv7325.py
+++ b/litex_boards/platforms/hpcstore_stlv7325.py
@@ -294,7 +294,7 @@ class Platform(XilinxPlatform):
     default_clk_period = 1e9/200e6
 
     def __init__(self, toolchain="vivado"):
-        XilinxPlatform.__init__(self, "xc7k325t-ffg676-2", _io, _connectors, toolchain=toolchain)
+        XilinxPlatform.__init__(self, "xc7k325tffg676-2", _io, _connectors, toolchain=toolchain)
         self.add_platform_command("""
 set_property CFGBVS VCCO [current_design]
 set_property CONFIG_VOLTAGE 2.5 [current_design]

--- a/litex_boards/platforms/hpcstore_stlv7325.py
+++ b/litex_boards/platforms/hpcstore_stlv7325.py
@@ -19,7 +19,7 @@ _io = [
     # Clk / Rst
     ("cpu_reset_n", 0, Pins("AC16"), IOStandard("LVCMOS15")),
 
-    ("clk100",      0, Pins("F17"), IOStandard("LVCMOS15")),
+    ("clk100",      0, Pins("F17"), IOStandard("LVCMOS25")),
     ("clk200", 0,
         Subsignal("p", Pins("AB11"), IOStandard("DIFF_SSTL15")),
         Subsignal("n", Pins("AC11"), IOStandard("DIFF_SSTL15"))
@@ -148,14 +148,14 @@ _io = [
 
     # GMII Ethernet
     ("eth_clocks", 0,
-        Subsignal("tx",  Pins("E12"), IOStandard("LVCMOS15")),
-        Subsignal("gtx", Pins("F13"), IOStandard("LVCMOS15")),
-        Subsignal("rx",  Pins("C12"), IOStandard("LVCMOS15"))
+        Subsignal("tx",  Pins("E12"), IOStandard("LVCMOS25")),
+        Subsignal("gtx", Pins("F13"), IOStandard("LVCMOS25")),
+        Subsignal("rx",  Pins("C12"), IOStandard("LVCMOS25"))
     ),
     ("eth_clocks", 1,
-        Subsignal("tx",  Pins("C9"),  IOStandard("LVCMOS15")),
-        Subsignal("gtx", Pins("D8"),  IOStandard("LVCMOS15")),
-        Subsignal("rx",  Pins("E10"), IOStandard("LVCMOS15"))
+        Subsignal("tx",  Pins("C9"),  IOStandard("LVCMOS25")),
+        Subsignal("gtx", Pins("D8"),  IOStandard("LVCMOS25")),
+        Subsignal("rx",  Pins("E10"), IOStandard("LVCMOS25"))
     ),
     ("eth", 0,
         Subsignal("rst_n",   Pins("D11")),
@@ -167,7 +167,7 @@ _io = [
         Subsignal("tx_en",   Pins("F12")),
         Subsignal("tx_er",   Pins("E13")),
         Subsignal("tx_data", Pins("G12 E11 G11 C14 D14 C13 C11 D13")),
-        IOStandard("LVCMOS15")
+        IOStandard("LVCMOS25")
     ),
     ("eth", 1,
         Subsignal("rst_n",   Pins("J8")),
@@ -179,7 +179,7 @@ _io = [
         Subsignal("tx_en",   Pins("F8")),
         Subsignal("tx_er",   Pins("D9")),
         Subsignal("tx_data", Pins("H11 J11 H9 J10 H12 F10 G10 F9")),
-        IOStandard("LVCMOS15")
+        IOStandard("LVCMOS25")
     ),
 
     # HDMI out

--- a/litex_boards/platforms/hpcstore_stlv7325.py
+++ b/litex_boards/platforms/hpcstore_stlv7325.py
@@ -167,7 +167,6 @@ _io = [
         Subsignal("tx_en",   Pins("F12")),
         Subsignal("tx_er",   Pins("E13")),
         Subsignal("tx_data", Pins("G12 E11 G11 C14 D14 C13 C11 D13")),
-        Subsignal("crs",     Pins("R30")),
         IOStandard("LVCMOS15")
     ),
     ("eth", 1,
@@ -180,7 +179,6 @@ _io = [
         Subsignal("tx_en",   Pins("F8")),
         Subsignal("tx_er",   Pins("D9")),
         Subsignal("tx_data", Pins("H11 J11 H9 J10 H12 F10 G10 F9")),
-        Subsignal("crs",     Pins("R30")),
         IOStandard("LVCMOS15")
     ),
 

--- a/litex_boards/platforms/hpcstore_stlv7325.py
+++ b/litex_boards/platforms/hpcstore_stlv7325.py
@@ -293,8 +293,8 @@ class Platform(XilinxPlatform):
     default_clk_name   = "clk200"
     default_clk_period = 1e9/200e6
 
-    def __init__(self):
-        XilinxPlatform.__init__(self, "xc7k325t-ffg676-2", _io, _connectors, toolchain="vivado")
+    def __init__(self, toolchain="vivado"):
+        XilinxPlatform.__init__(self, "xc7k325t-ffg676-2", _io, _connectors, toolchain=toolchain)
         self.add_platform_command("""
 set_property CFGBVS VCCO [current_design]
 set_property CONFIG_VOLTAGE 2.5 [current_design]

--- a/litex_boards/platforms/hpcstore_stlv7325.py
+++ b/litex_boards/platforms/hpcstore_stlv7325.py
@@ -1,0 +1,319 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2022 Andrew Gillham <gillham@roadsign.com>
+# Copyright (c) 2022 Hans Baier <hansfbaier@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import XilinxPlatform
+from litex.build.openocd import OpenOCD
+
+# This is a variant of the aliexpress_stlv7325 board, with different IO voltages
+# available here:
+# https://www.aliexpress.com/item/1005001275162791.html
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("cpu_reset_n", 0, Pins("AC16"), IOStandard("LVCMOS15")),
+
+    ("clk100",      0, Pins("F17"), IOStandard("LVCMOS15")),
+    ("clk200", 0,
+        Subsignal("p", Pins("AB11"), IOStandard("DIFF_SSTL15")),
+        Subsignal("n", Pins("AC11"), IOStandard("DIFF_SSTL15"))
+    ),
+    ("clk156", 0, # TODO verify / test (in docs)
+        Subsignal("p", Pins("D6"), IOStandard("LVDS")),
+        Subsignal("n", Pins("D5"), IOStandard("LVDS")),
+    ),
+    ("clk150", 0, # TODO verify / test (in docs)
+        Subsignal("p", Pins("F6"), IOStandard("LVDS")),
+        Subsignal("n", Pins("F5"), IOStandard("LVDS")),
+    ),
+
+    # Leds
+    ("user_led_n", 0, Pins("AA2"),  IOStandard("LVCMOS15")),
+    ("user_led_n", 1, Pins("AD5"),  IOStandard("LVCMOS15")),
+    ("user_led_n", 2, Pins("W10"),  IOStandard("LVCMOS15")),
+    ("user_led_n", 3, Pins("Y10"),  IOStandard("LVCMOS15")),
+    ("user_led_n", 4, Pins("AE10"), IOStandard("LVCMOS15")),
+    ("user_led_n", 5, Pins("W11"),  IOStandard("LVCMOS15")),
+    ("user_led_n", 6, Pins("V11"),  IOStandard("LVCMOS15")),
+    ("user_led_n", 7, Pins("Y12"),  IOStandard("LVCMOS15")),
+
+    # Buttons
+    ("user_btn_n", 0, Pins("AC16"), IOStandard("LVCMOS15")),
+    ("user_btn_n", 0, Pins("C24"),  IOStandard("LVCMOS33")), # J4 jumper 2.5V or 3.3V
+
+    # I2C / AT24C04
+    ("i2c", 0,
+        Subsignal("scl", Pins("U19")),
+        Subsignal("sda", Pins("U20")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # Serial
+    ("serial", 0,
+        Subsignal("tx",  Pins("M25")),  # CH340_TX
+        Subsignal("rx",  Pins("L25")),  # CH340_RX
+        IOStandard("LVCMOS33")
+    ),
+
+    # DDR3 SDRAM
+    ("ddram", 0,
+        Subsignal("a",     Pins(
+            "AB7  AD11 AA8 AF10  AC7 AE11  AC8 AD8",
+            "AC13 AF12 AF9 AD10 AE13  AF7 AB12"),
+            IOStandard("SSTL15")),
+        Subsignal("ba",    Pins("AE8 AA7 AF13"), IOStandard("SSTL15")),
+        Subsignal("ras_n", Pins("Y7"),  IOStandard("SSTL15")),
+        Subsignal("cas_n", Pins("AE7"), IOStandard("SSTL15")),
+        Subsignal("we_n",  Pins("AF8"),  IOStandard("SSTL15")),
+        Subsignal("cs_n",  Pins("AA13"), IOStandard("SSTL15")),
+        Subsignal("dm",      Pins(
+            "AD16 AB16 AB19 V17 U1 AA3 AD6 AE1"),
+            IOStandard("SSTL15")),
+        Subsignal("dq",      Pins(
+            "AF17 AE17 AF15 AF14 AE15 AD15 AF20 AF19",
+            "AA15 AA14 AC14 AD14 AB14 AB15 AA18 AA17",
+            "AC18 AD18 AC17 AB17 AA20 AA19 AD19 AC19",
+            " W14  V14  V19  V18  V16  W15  W16  Y17",
+            "  V4   U6   U5   U2   V3   W3   U7   V6",
+            "  Y3   Y2   V2   V1   W1   Y1  AB2  AC2",
+            " AA4  AB4  AC4  AC3  AC6  AB6   Y6   Y5",
+            " AD4  AD1  AF2  AE2  AE6  AE5  AF3  AE3"),
+            IOStandard("SSTL15_T_DCI")),
+        Subsignal("dqs_p",   Pins("AE18 Y15 AD20 W18 W6 AB1 AA5 AF5"),
+            IOStandard("DIFF_SSTL15")),
+        Subsignal("dqs_n",   Pins("AF18 Y16 AE20 W19 W5 AC1 AB5 AF4"),
+            IOStandard("DIFF_SSTL15")),
+        Subsignal("clk_p",   Pins("AC9"),  IOStandard("DIFF_SSTL15")),
+        Subsignal("clk_n",   Pins("AD9"),  IOStandard("DIFF_SSTL15")),
+        Subsignal("cke",     Pins("AB9"),  IOStandard("SSTL15")),
+        #Subsignal("odt",     Pins("AA12"), IOStandard("SSTL15")),
+        Subsignal("reset_n", Pins("AB20"), IOStandard("LVCMOS15")),
+        Misc("SLEW=FAST"),
+        Misc("VCCAUX_IO=NORMAL")
+    ),
+    # 2 Rank Signals:
+    # Subsignal("cs_n",  Pins("AD13"), IOStandard("SSTL15")),
+    # Subsignal("clk_p", Pins("AA10"), IOStandard("DIFF_SSTL15")),
+    # Subsignal("clk_n", Pins("AB10"), IOStandard("DIFF_SSTL15")),
+    # Subsignal("cke",   Pins("AA9"), IOStandard("SSTL15")),
+    # Subsignal("odt",   Pins("Y13"),  IOStandard("SSTL15")),
+
+    ## TODO verify / test
+    # # SPIFlash
+    # ("spiflash", 0,
+    #     Subsignal("cs_n", Pins("C23")),
+    #     Subsignal("clk", Pins("C8")),
+    #     Subsignal("dq",   Pins("B24 A25 B22 A22")),
+    #     IOStandard("LVCMOS25")
+    # ),
+
+    # Sata
+    ("sata", 0,
+        Subsignal("rx_p", Pins("R4")),
+        Subsignal("rx_n", Pins("R3")),
+        Subsignal("tx_p", Pins("P2")),
+        Subsignal("tx_n", Pins("P1")),
+        IOStandard("LVCMOS33"),
+    ),
+    ("sata", 1,
+        Subsignal("rx_p", Pins("N4")),
+        Subsignal("rx_n", Pins("N3")),
+        Subsignal("tx_p", Pins("M2")),
+        Subsignal("tx_n", Pins("M1")),
+        IOStandard("LVCMOS33"),
+    ),
+
+    # SDCard
+    ("spisdcard", 0,
+        Subsignal("clk",  Pins("N21")),
+        Subsignal("cs_n", Pins("P19")),
+        Subsignal("mosi", Pins("U21"), Misc("PULLUP")),
+        Subsignal("miso", Pins("N16"), Misc("PULLUP")),
+        Misc("SLEW=FAST"),
+        IOStandard("LVCMOS33")
+    ),
+    ("sdcard", 0,
+        Subsignal("clk", Pins("N21")),
+        Subsignal("cmd", Pins("U21"), Misc("PULLUP True")),
+        Subsignal("data", Pins("N16 U16 N22 P19"), Misc("PULLUP True")),
+        Misc("SLEW=FAST"),
+        IOStandard("LVCMOS33")
+    ),
+
+    # GMII Ethernet
+    ("eth_clocks", 0,
+        Subsignal("tx",  Pins("E12"), IOStandard("LVCMOS15")),
+        Subsignal("gtx", Pins("F13"), IOStandard("LVCMOS15")),
+        Subsignal("rx",  Pins("C12"), IOStandard("LVCMOS15"))
+    ),
+    ("eth_clocks", 1,
+        Subsignal("tx",  Pins("C9"),  IOStandard("LVCMOS15")),
+        Subsignal("gtx", Pins("D8"),  IOStandard("LVCMOS15")),
+        Subsignal("rx",  Pins("E10"), IOStandard("LVCMOS15"))
+    ),
+    ("eth", 0,
+        Subsignal("rst_n",   Pins("D11")),
+        Subsignal("mdio",    Pins("K15")),
+        Subsignal("mdc",     Pins("M16")),
+        Subsignal("rx_dv",   Pins("G14")),
+        Subsignal("rx_er",   Pins("F14")),
+        Subsignal("rx_data", Pins("H14 J14 J13 H13 B15 A15 B14 A14")),
+        Subsignal("tx_en",   Pins("F12")),
+        Subsignal("tx_er",   Pins("E13")),
+        Subsignal("tx_data", Pins("G12 E11 G11 C14 D14 C13 C11 D13")),
+        Subsignal("crs",     Pins("R30")),
+        IOStandard("LVCMOS15")
+    ),
+    ("eth", 1,
+        Subsignal("rst_n",   Pins("J8")),
+        Subsignal("mdio",    Pins("G9")),
+        Subsignal("mdc",     Pins("H8")),
+        Subsignal("rx_dv",   Pins("A12")),
+        Subsignal("rx_er",   Pins("D10")),
+        Subsignal("rx_data", Pins("A13 B12 B11 A10 B10 A9 B9 A8")),
+        Subsignal("tx_en",   Pins("F8")),
+        Subsignal("tx_er",   Pins("D9")),
+        Subsignal("tx_data", Pins("H11 J11 H9 J10 H12 F10 G10 F9")),
+        Subsignal("crs",     Pins("R30")),
+        IOStandard("LVCMOS15")
+    ),
+
+    # HDMI out
+    ("hdmi_out", 0,
+     Subsignal("clk_p", Pins("R21"), IOStandard("TMDS_33")),
+     Subsignal("clk_n", Pins("P21"), IOStandard("TMDS_33")),
+     Subsignal("data0_p", Pins("N18"), IOStandard("TMDS_33")),
+     Subsignal("data0_n", Pins("M19"), IOStandard("TMDS_33")),
+     Subsignal("data1_p", Pins("M21"), IOStandard("TMDS_33")),
+     Subsignal("data1_n", Pins("M22"), IOStandard("TMDS_33")),
+     Subsignal("data2_p", Pins("K25"), IOStandard("TMDS_33")),
+     Subsignal("data2_n", Pins("K26"), IOStandard("TMDS_33")),
+     Subsignal("scl", Pins("K21"), IOStandard("LVCMOS33")),
+     Subsignal("sda", Pins("L23"), IOStandard("LVCMOS33")),
+     Subsignal("hdp", Pins("N26"), IOStandard("LVCMOS33")),
+     Subsignal("cec", Pins("M26"), IOStandard("LVCMOS33")),
+     ),
+
+    # PCIe
+    ("pcie_x1", 0,
+        Subsignal("rst_n", Pins("E17"), IOStandard("LVCMOS15")),
+        Subsignal("clk_p", Pins("H6")),
+        Subsignal("clk_n", Pins("H5")),
+        Subsignal("rx_p",  Pins("B6")),
+        Subsignal("rx_n",  Pins("B5")),
+        Subsignal("tx_p",  Pins("A4")),
+        Subsignal("tx_n",  Pins("A3"))
+    ),
+    ("pcie_x2", 0,
+        Subsignal("rst_n", Pins("E17"), IOStandard("LVCMOS15")),
+        Subsignal("clk_p", Pins("H6")),
+        Subsignal("clk_n", Pins("H5")),
+        Subsignal("rx_p",  Pins("B6 C4")),
+        Subsignal("rx_n",  Pins("B5 C3")),
+        Subsignal("tx_p",  Pins("A4 B2")),
+        Subsignal("tx_n",  Pins("A3 B1"))
+    ),
+    ("pcie_x4", 0,
+        Subsignal("rst_n", Pins("E17"), IOStandard("LVCMOS15")),
+        Subsignal("clk_p", Pins("H6")),
+        Subsignal("clk_n", Pins("H5")),
+        Subsignal("rx_p",  Pins("B6 C4 E4 G4")),
+        Subsignal("rx_n",  Pins("B5 C3 E3 G3")),
+        Subsignal("tx_p",  Pins("A4 B2 D2 F2")),
+        Subsignal("tx_n",  Pins("A3 B1 D1 F1"))
+    ),
+
+    # TODO find / test
+    # # SGMII Clk
+    # ("sgmii_clock", 0,
+    #     Subsignal("p", Pins("")),
+    #     Subsignal("n", Pins(""))
+    # ),
+
+    # SFP
+    ("sfp_a", 0,  # SFP A
+        Subsignal("txp", Pins("H2")),
+        Subsignal("txn", Pins("H1")),
+        Subsignal("rxp", Pins("J4")),
+        Subsignal("rxn", Pins("J3")),
+        Subsignal("sda", Pins("B21")),
+        Subsignal("scl", Pins("C21")),
+    ),
+    ("sfp_a_tx", 0,  # SFP A
+        Subsignal("p", Pins("H2")),
+        Subsignal("n", Pins("H1"))
+    ),
+    ("sfp_a_rx", 0,  # SFP A
+        Subsignal("p", Pins("J4")),
+        Subsignal("n", Pins("J3"))
+    ),
+    ("sfp_b", 0,  # SFP B
+        Subsignal("txp", Pins("K2")),
+        Subsignal("txn", Pins("K1")),
+        Subsignal("rxp", Pins("L4")),
+        Subsignal("rxn", Pins("L3")),
+        Subsignal("sda", Pins("D21")),
+        Subsignal("scl", Pins("C22")),
+     ),
+    ("sfp_b_tx", 0,  # SFP B
+        Subsignal("p", Pins("K2")),
+        Subsignal("n", Pins("K1"))
+    ),
+    ("sfp_b_rx", 0,  # SFP B
+        Subsignal("p", Pins("L4")),
+        Subsignal("n", Pins("L3"))
+    ),
+
+    # SI5338 (optional part per seller?)
+    ("si5338_i2c", 0,
+        Subsignal("sck", Pins("U19"), IOStandard("LVCMOS25")),
+        Subsignal("sda", Pins("U20"), IOStandard("LVCMOS25"))
+    ),
+    ("si5338_clkin", 0,  # CLK2A/B
+        Subsignal("p", Pins("K6"), IOStandard("LVDS_25")),
+        Subsignal("n", Pins("K5"), IOStandard("LVDS_25"))
+    ),
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = [
+    # TODO; add FMC / BTB
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(XilinxPlatform):
+    default_clk_name   = "clk200"
+    default_clk_period = 1e9/200e6
+
+    def __init__(self):
+        XilinxPlatform.__init__(self, "xc7k325t-ffg676-2", _io, _connectors, toolchain="vivado")
+        self.add_platform_command("""
+set_property CFGBVS VCCO [current_design]
+set_property CONFIG_VOLTAGE 2.5 [current_design]
+""")
+        self.toolchain.bitstream_commands = [
+            "set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]",
+            "set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]",
+            ]
+        self.toolchain.additional_commands = ["write_cfgmem -force -format bin -interface spix4 -size 16 -loadbit \"up 0x0 {build_name}.bit\" -file {build_name}.bin"]
+
+    def create_programmer(self):
+        return OpenOCD("openocd_xc7_ft232.cfg", "bscan_spi_xc7a325t.bit")
+
+    def do_finalize(self, fragment):
+        XilinxPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk100",        loose=True), 1e9/100e6)
+        self.add_period_constraint(self.lookup_request("clk200",        loose=True), 1e9/200e6)
+        self.add_period_constraint(self.lookup_request("eth_clocks:rx", 0, loose=True), 1e9/125e6)
+        self.add_period_constraint(self.lookup_request("eth_clocks:tx", 0, loose=True), 1e9/125e6)
+        self.add_period_constraint(self.lookup_request("eth_clocks:rx", 1, loose=True), 1e9/125e6)
+        self.add_period_constraint(self.lookup_request("eth_clocks:tx", 1, loose=True), 1e9/125e6)
+        self.add_platform_command("set_property DCI_CASCADE {{32 34}} [get_iobanks 33]")

--- a/litex_boards/targets/hpcstore_stlv7325.py
+++ b/litex_boards/targets/hpcstore_stlv7325.py
@@ -112,9 +112,9 @@ class BaseSoC(SoCCore):
                 pads       = self.platform.request("eth", 0),
                 clk_freq   = self.clk_freq)
             if with_ethernet:
-                self.add_ethernet(phy=self.ethphy)
+                self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip)
             if with_etherbone:
-                self.add_etherbone(phy=self.ethphy)
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
 
         # PCIe -------------------------------------------------------------------------------------
         if with_pcie:
@@ -209,10 +209,13 @@ def main():
         with_video_terminal    = args.with_video_terminal,
         **soc_core_argdict(args)
     )
+
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()
+
     if args.with_sdcard:
         soc.add_sdcard()
+
     builder = Builder(soc, **builder_argdict(args))
     if args.build:
         builder.build()

--- a/litex_boards/targets/hpcstore_stlv7325.py
+++ b/litex_boards/targets/hpcstore_stlv7325.py
@@ -73,7 +73,9 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6),
+    def __init__(self,
+        toolchain="vivado",
+        sys_clk_freq=int(100e6),
         with_ethernet   = False, with_etherbone=False, eth_ip="192.168.1.50", eth_dynamic_ip=False,
         with_led_chaser = True,
         with_pcie       = False,
@@ -82,7 +84,7 @@ class BaseSoC(SoCCore):
         with_video_framebuffer = False,
         with_video_terminal    = False,
         **kwargs):
-        platform = hpcstore_stlv7325.Platform()
+        platform = hpcstore_stlv7325.Platform(toolchain=toolchain)
 
         # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = _CRG(platform, sys_clk_freq)
@@ -168,6 +170,8 @@ class BaseSoC(SoCCore):
 def main():
     from litex.soc.integration.soc import LiteXSoCArgumentParser
     parser = LiteXSoCArgumentParser(description="LiteX SoC on HPC Store STLV7325")
+    parser.add_argument("--toolchain", default="vivado", help="FPGA toolchain (vivado, symbiflow or yosys+nextpnr).")
+
     target_group = parser.add_argument_group(title="Target options")
     target_group.add_argument("--build",         action="store_true", help="Build design.")
     target_group.add_argument("--load",          action="store_true", help="Load bitstream.")
@@ -192,6 +196,7 @@ def main():
     args = parser.parse_args()
 
     soc = BaseSoC(
+        toolchain      = args.toolchain,
         sys_clk_freq   = int(float(args.sys_clk_freq)),
         with_ethernet  = args.with_ethernet,
         with_etherbone = args.with_etherbone,

--- a/litex_boards/targets/hpcstore_stlv7325.py
+++ b/litex_boards/targets/hpcstore_stlv7325.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2022 Andrew Gillham <gillham@roadsign.com>
+# Copyright (c) 2014-2015 Sebastien Bourdeauducq <sb@m-labs.hk>
+# Copyright (c) 2014-2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2014-2015 Yann Sionneau <ys@m-labs.hk>
+# Copyright (c) 2022 Hans Baier <hansfbaier@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# This is a variant of the aliexpress_stlv7325 board, with different IO voltages
+# available here:
+# https://www.aliexpress.com/item/1005001275162791.html
+
+import os
+
+from migen import *
+
+from litex_boards.platforms import hpcstore_stlv7325
+
+from litex.soc.cores.clock import *
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+from litex.soc.cores.bitbang import I2CMaster
+from litex.soc.cores.video import VideoS6HDMIPHY
+
+from litedram.modules import MT8JTF12864
+from litedram.phy import s7ddrphy
+
+from liteeth.phy import LiteEthPHY
+
+from litepcie.phy.s7pciephy import S7PCIEPHY
+from litepcie.software import generate_litepcie_software
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst = Signal()
+        self.clock_domains.cd_sys    = ClockDomain()
+        self.clock_domains.cd_sys4x  = ClockDomain()
+        self.clock_domains.cd_idelay = ClockDomain()
+        self.clock_domains.cd_hdmi   = ClockDomain()
+        self.clock_domains.cd_hdmi5x = ClockDomain()
+
+        # # #
+
+        # Clk/Rst.
+        clk200 = platform.request("clk200")
+        clk100 = platform.request("clk100")
+        rst_n  = platform.request("cpu_reset_n")
+
+        # PLL.
+        self.submodules.pll = pll = S7MMCM(speedgrade=-2)
+        self.comb += pll.reset.eq(~rst_n | self.rst)
+        pll.register_clkin(clk200, 200e6)
+        pll.create_clkout(self.cd_sys,    sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x,  4*sys_clk_freq)
+        pll.create_clkout(self.cd_idelay, 200e6)
+        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
+
+        self.submodules.pll2 = pll2 = S7MMCM(speedgrade=-2)
+        self.comb += pll2.reset.eq(~rst_n | self.rst)
+        pll2.register_clkin(clk100, 100e6)
+        pll2.create_clkout(self.cd_hdmi,   25e6,  margin=0)
+        pll2.create_clkout(self.cd_hdmi5x, 125e6, margin=0)
+
+        self.submodules.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=int(100e6),
+        with_ethernet   = False, with_etherbone=False, eth_ip="192.168.1.50", eth_dynamic_ip=False,
+        with_led_chaser = True,
+        with_pcie       = False,
+        with_sata       = False,
+        with_video_colorbars   = False,
+        with_video_framebuffer = False,
+        with_video_terminal    = False,
+        **kwargs):
+        platform = hpcstore_stlv7325.Platform()
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on HPC Store STLV7325", **kwargs)
+
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.submodules.ddrphy = s7ddrphy.K7DDRPHY(platform.request("ddram"),
+                memtype      = "DDR3",
+                nphases      = 4,
+                sys_clk_freq = sys_clk_freq,
+            )
+            self.add_sdram("sdram",
+                phy           = self.ddrphy,
+                module        = MT8JTF12864(sys_clk_freq, "1:4"),
+                l2_cache_size = kwargs.get("l2_size", 8192),
+            )
+
+        # Ethernet / Etherbone ---------------------------------------------------------------------
+        if with_ethernet or with_etherbone:
+            self.submodules.ethphy = LiteEthPHY(
+                clock_pads = self.platform.request("eth_clocks", 0),
+                pads       = self.platform.request("eth", 0),
+                clk_freq   = self.clk_freq)
+            if with_ethernet:
+                self.add_ethernet(phy=self.ethphy)
+            if with_etherbone:
+                self.add_etherbone(phy=self.ethphy)
+
+        # PCIe -------------------------------------------------------------------------------------
+        if with_pcie:
+            self.submodules.pcie_phy = S7PCIEPHY(platform, platform.request("pcie_x4"),
+                data_width = 128,
+                bar0_size  = 0x20000)
+            self.add_pcie(phy=self.pcie_phy, ndmas=1)
+
+        # TODO verify / test
+        # SATA -------------------------------------------------------------------------------------
+        if with_sata:
+            from litex.build.generic_platform import Subsignal, Pins
+            from litesata.phy import LiteSATAPHY
+
+            # RefClk, Generate 150MHz from PLL.
+            self.clock_domains.cd_sata_refclk = ClockDomain()
+            self.crg.pll.create_clkout(self.cd_sata_refclk, 150e6)
+            sata_refclk = ClockSignal("sata_refclk")
+            platform.add_platform_command("set_property SEVERITY {{Warning}} [get_drc_checks REQP-52]")
+
+            # PHY
+            self.submodules.sata_phy = LiteSATAPHY(platform.device,
+                refclk     = sata_refclk,
+                pads       = platform.request("sata", 0),
+                gen        = "gen2",
+                clk_freq   = sys_clk_freq,
+                data_width = 16)
+
+            # Core
+            self.add_sata(phy=self.sata_phy, mode="read+write")
+
+        # HDMI Options -----------------------------------------------------------------------------
+        if (with_video_colorbars or with_video_framebuffer or with_video_terminal):
+            self.submodules.videophy = VideoS6HDMIPHY(platform.request("hdmi_out"), clock_domain="hdmi")
+            if with_video_colorbars:
+                self.add_video_colorbars(phy=self.videophy, timings="640x480@60Hz", clock_domain="hdmi")
+            if with_video_terminal:
+                self.add_video_terminal(phy=self.videophy, timings="640x480@60Hz", clock_domain="hdmi")
+            if with_video_framebuffer:
+                self.add_video_framebuffer(phy=self.videophy, timings="640x480@60Hz", clock_domain="hdmi")
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led_n"),
+                sys_clk_freq = sys_clk_freq)
+
+        # I2C --------------------------------------------------------------------------------------
+        self.submodules.i2c = I2CMaster(platform.request("i2c"))
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    from litex.soc.integration.soc import LiteXSoCArgumentParser
+    parser = LiteXSoCArgumentParser(description="LiteX SoC on HPC Store STLV7325")
+    target_group = parser.add_argument_group(title="Target options")
+    target_group.add_argument("--build",         action="store_true", help="Build design.")
+    target_group.add_argument("--load",          action="store_true", help="Load bitstream.")
+    target_group.add_argument("--sys-clk-freq",  default=100e6,       help="System clock frequency.")
+    ethopts = target_group.add_mutually_exclusive_group()
+    ethopts.add_argument("--with-ethernet",  action="store_true",              help="Enable Ethernet support.")
+    ethopts.add_argument("--with-etherbone", action="store_true",              help="Enable Etherbone support.")
+    target_group.add_argument("--eth-ip",          default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address.")
+    target_group.add_argument("--eth-dynamic-ip",  action="store_true",              help="Enable dynamic Ethernet IP addresses setting.")
+    target_group.add_argument("--with-pcie",       action="store_true", help="Enable PCIe support.")
+    target_group.add_argument("--driver",          action="store_true", help="Generate PCIe driver.")
+    target_group.add_argument("--with-sata",       action="store_true", help="Enable SATA support.")
+    sdopts = target_group.add_mutually_exclusive_group()
+    sdopts.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support.")
+    sdopts.add_argument("--with-sdcard",     action="store_true", help="Enable SDCard support.")
+    viopts = target_group.add_mutually_exclusive_group()
+    viopts.add_argument("--with-video-terminal",    action="store_true", help="Enable Video Terminal (HDMI).")
+    viopts.add_argument("--with-video-framebuffer", action="store_true", help="Enable Video Framebuffer (HDMI).")
+    viopts.add_argument("--with-video-colorbars",   action="store_true", help="Enable Video Colorbars (HDMI).")
+    builder_args(parser)
+    soc_core_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq   = int(float(args.sys_clk_freq)),
+        with_ethernet  = args.with_ethernet,
+        with_etherbone = args.with_etherbone,
+        eth_ip         = args.eth_ip,
+        eth_dynamic_ip = args.eth_dynamic_ip,
+        with_pcie      = args.with_pcie,
+        with_sata      = args.with_sata,
+        with_video_colorbars   = args.with_video_colorbars,
+        with_video_framebuffer = args.with_video_framebuffer,
+        with_video_terminal    = args.with_video_terminal,
+        **soc_core_argdict(args)
+    )
+    if args.with_spi_sdcard:
+        soc.add_spi_sdcard()
+    if args.with_sdcard:
+        soc.add_sdcard()
+    builder = Builder(soc, **builder_argdict(args))
+    if args.build:
+        builder.build()
+
+    if args.driver:
+        generate_litepcie_software(soc, os.path.join(builder.output_dir, "driver"))
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is a variant of the aliexpress_stl7325 board.
I added HDMI. This variant seems to have different IO
voltages, so I committed this as a new board.
All eight DDR3 chips worked beautifully on first try here.
HDMI works (terminal + framebuffer).
Is there a framebuffer demo somewhere?
Also tested booting from SDCARD.
Best regards,
Hans

```
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2022 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Jun 15 2022 16:41:49
 BIOS CRC passed (f969116e)

 LiteX git sha1: 1d20bbcd

--=============== SoC ==================--
CPU:		VexRiscv @ 100MHz
BUS:		WISHBONE 32-bit @ 4GiB
CSR:		32-bit data
ROM:		128KiB
SRAM:		8KiB
L2:		8KiB
SDRAM:		1048576KiB 64-bit @ 800MT/s (CL-6 CWL-5)

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Write leveling:
  tCK equivalent taps: 32
  Cmd/Clk scan (0-16)
  |0000000000000000| best: 11
  Setting Cmd/Clk delay to 11 taps.
  Data scan:
  m0: |111000000000000000001111| delay: -
  m1: |111000000000000000001111| delay: -
  m2: |111111111000000000000000| delay: 00
  m3: |000000000000000000111111| delay: 18
  m4: |000000111111111111111000| delay: 06
  m5: |111111111111100000000000| delay: 00
  m6: |001111111111111110000000| delay: 02
  m7: |111111111111111000000000| delay: 00
Write latency calibration:
m0:6 m1:6 m2:6 m3:0 m4:6 m5:6 m6:6 m7:6 
Write DQ-DQS training:
m0: |11110000000000000000000000000| delays: 03+-03
m1: |11110000000000000000000000000| delays: 03+-03
m2: |11100000000000000000000000000| delays: 03+-03
m3: |00000000001111111111000000000| delays: 16+-06
m4: |11111111110000000000000000000| delays: 06+-06
m5: |11110000000000000000000000000| delays: 03+-03
m6: |11111100000000000000000000000| delays: 04+-04
m7: |11111000000000000000000000000| delays: 04+-04
Read leveling:
  m0, b00: |00000000000000000000000000000000| delays: -
  m0, b01: |00000000000000000000000000000000| delays: -
  m0, b02: |11110100000000000000000000000000| delays: 02+-02
  m0, b03: |00000001111111111100000000000000| delays: 13+-07
  m0, b04: |00000000000000000000010111111111| delays: 27+-05
  m0, b05: |00000000000000000000000000000000| delays: -
  m0, b06: |00000000000000000000000000000000| delays: -
  m0, b07: |00000000000000000000000000000000| delays: -
  best: m0, b03 delays: 12+-05
  m1, b00: |00000000000000000000000000000000| delays: -
  m1, b01: |00000000000000000000000000000000| delays: -
  m1, b02: |11111110000000000000000000000000| delays: 03+-03
  m1, b03: |00000000001111111111111100000000| delays: 16+-07
  m1, b04: |00000000000000000000000000011111| delays: 29+-02
  m1, b05: |00000000000000000000000000000000| delays: -
  m1, b06: |00000000000000000000000000000000| delays: -
  m1, b07: |00000000000000000000000000000000| delays: -
  best: m1, b03 delays: 17+-06
  m2, b00: |00000000000000000000000000000000| delays: -
  m2, b01: |00000000000000000000000000000000| delays: -
  m2, b02: |11100000000000000000000000000000| delays: 02+-02
  m2, b03: |00000011111111111110000000000000| delays: 13+-06
  m2, b04: |00000000000000000000001011111111| delays: 27+-04
  m2, b05: |00000000000000000000000000000000| delays: -
  m2, b06: |00000000000000000000000000000000| delays: -
  m2, b07: |00000000000000000000000000000000| delays: -
  best: m2, b03 delays: 12+-06
  m3, b00: |00000000000000000000000000000000| delays: -
  m3, b01: |00000000000000000000000000000000| delays: -
  m3, b02: |01111111111110000000000000000000| delays: 05+-05
  m3, b03: |00000000000000110111111111111000| delays: 20+-07
  m3, b04: |00000000000000000000000000000001| delays: 01+-02
  m3, b05: |00000000000000000000000000000000| delays: -
  m3, b06: |00000000000000000000000000000000| delays: -
  m3, b07: |00000000000000000000000000000000| delays: -
  best: m3, b03 delays: 21+-06
  m4, b00: |00000000000000000000000000000000| delays: -
  m4, b01: |00000000000000000000000000000000| delays: -
  m4, b02: |00000000000000000000000000000000| delays: -
  m4, b03: |11111110000000000000000000000000| delays: 03+-03
  m4, b04: |00000000011111111111110000000000| delays: 15+-07
  m4, b05: |00000000000000000000000010011011| delays: 30+-02
  m4, b06: |00000000000000000000000000000000| delays: -
  m4, b07: |00000000000000000000000000000000| delays: -
  best: m4, b04 delays: 15+-06
  m5, b00: |00000000000000000000000000000000| delays: -
  m5, b01: |00000000000000000000000000000000| delays: -
  m5, b02: |00000000000000000000000000000000| delays: -
  m5, b03: |11111111111101000000000000000000| delays: 06+-06
  m5, b04: |00000000000000000111111111110000| delays: 22+-06
  m5, b05: |00000000000000000000000000000000| delays: -
  m5, b06: |00000000000000000000000000000000| delays: -
  m5, b07: |00000000000000000000000000000000| delays: -
  best: m5, b03 delays: 07+-07
  m6, b00: |00000000000000000000000000000000| delays: -
  m6, b01: |00000000000000000000000000000000| delays: -
  m6, b02: |00000000000000000000000000000000| delays: -
  m6, b03: |11111111100000000000000000000000| delays: 04+-04
  m6, b04: |00000000001011111111111100000000| delays: 18+-06
  m6, b05: |00000000000000000000000000001111| delays: 29+-02
  m6, b06: |00000000000000000000000000000000| delays: -
  m6, b07: |00000000000000000000000000000000| delays: -
  best: m6, b04 delays: 19+-07
  m7, b00: |00000000000000000000000000000000| delays: -
  m7, b01: |00000000000000000000000000000000| delays: -
  m7, b02: |00000000000000000000000000000000| delays: -
  m7, b03: |11111111100000000000000000000000| delays: 04+-04
  m7, b04: |00000000000101111111111110000000| delays: 18+-06
  m7, b05: |00000000000000000000000000100111| delays: 30+-02
  m7, b06: |00000000000000000000000000000000| delays: -
  m7, b07: |00000000000000000000000000000000| delays: -
  best: m7, b04 delays: 19+-07
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB     
   Read: 0x40000000-0x40200000 2.0MiB     
Memtest OK
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 89.3MiB/s
   Read speed: 74.1MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
             Timeout
Booting from SDCard in SD-Mode...
Booting from boot.json...
boot.json file not found.
Booting from boot.bin...
Copying boot.bin to 0x40000000 (6988 bytes)...
[########################################]
Executing booted program at 0x40000000

--============= Liftoff! ===============--

LiteX minimal demo app built Jun 15 2022 16:46:28

Available commands:
help               - Show this command
reboot             - Reboot CPU
led                - Led demo
donut              - Spinning Donut demo
helloc             - Hello C
litex-demo-app> 
```