### PR TITLE
honours lattice toolchain args

### DIFF
--- a/litex_boards/targets/icebreaker.py
+++ b/litex_boards/targets/icebreaker.py
@@ -22,6 +22,7 @@ from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex_boards.platforms import icebreaker
 
+from litex.build.lattice.icestorm import icestorm_args, icestorm_argdict
 from litex.soc.cores.ram import Up5kSPRAM
 from litex.soc.cores.clock import iCE40PLL
 from litex.soc.integration.soc_core import *
@@ -141,6 +142,7 @@ def main():
     target_group.add_argument("--with-video-terminal", action="store_true", help="Enable Video Terminal (with DVI PMOD).")
     builder_args(parser)
     soc_core_args(parser)
+    icestorm_args(parser)
     args = parser.parse_args()
 
     soc = BaseSoC(
@@ -151,7 +153,7 @@ def main():
     )
     builder = Builder(soc, **builder_argdict(args))
     if args.build:
-        builder.build()
+        builder.build(**icestorm_argdict(args))
 
     if args.load:
         prog = soc.platform.create_programmer()

--- a/litex_boards/targets/icebreaker_bitsy.py
+++ b/litex_boards/targets/icebreaker_bitsy.py
@@ -21,6 +21,7 @@ from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex_boards.platforms import icebreaker_bitsy
 
+from litex.build.lattice.icestorm import icestorm_args, icestorm_argdict
 from litex.soc.cores.ram import Up5kSPRAM
 from litex.soc.cores.clock import iCE40PLL
 from litex.soc.integration.soc_core import *
@@ -115,6 +116,7 @@ def main():
     target_group.add_argument("--revision",            default="v1",        help="Board revision (v0 or v1).")
     builder_args(parser)
     soc_core_args(parser)
+    icestorm_args(parser)
     args = parser.parse_args()
 
     soc = BaseSoC(
@@ -125,7 +127,7 @@ def main():
     )
     builder = Builder(soc, **builder_argdict(args))
     if args.build:
-        builder.build()
+        builder.build(**icestorm_argdict(args))
 
     if args.flash:
         from litex.build.dfu import DFUProg

--- a/litex_boards/targets/kosagi_fomu.py
+++ b/litex_boards/targets/kosagi_fomu.py
@@ -16,6 +16,7 @@ from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex_boards.platforms import kosagi_fomu_pvt
 
+from litex.build.lattice.icestorm import icestorm_args, icestorm_argdict
 from litex.soc.cores.ram import Up5kSPRAM
 from litex.soc.cores.clock import iCE40PLL
 from litex.soc.integration.soc_core import *
@@ -164,6 +165,7 @@ def main():
     target_group.add_argument("--flash",             action="store_true", help="Flash Bitstream.")
     builder_args(parser)
     soc_core_args(parser)
+    icestorm_args(parser)
     args = parser.parse_args()
 
     dfu_flash_offset = 0x40000
@@ -175,7 +177,7 @@ def main():
     )
     builder = Builder(soc, **builder_argdict(args))
     if args.build:
-        builder.build()
+        builder.build(**icestorm_argdict(args))
 
     if args.flash:
         flash(builder.output_dir, soc.build_name, int(args.bios_flash_offset, 0))

--- a/litex_boards/targets/lattice_ecp5_evn.py
+++ b/litex_boards/targets/lattice_ecp5_evn.py
@@ -11,6 +11,8 @@ from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex_boards.platforms import lattice_ecp5_evn
 
+from litex.build.lattice.trellis import trellis_args, trellis_argdict
+
 from litex.soc.cores.clock import *
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
@@ -71,6 +73,7 @@ def main():
     target_group.add_argument("--x5-clk-freq",  type=int,            help="Use X5 oscillator as system clock at the specified frequency.")
     builder_args(parser)
     soc_core_args(parser)
+    trellis_args(parser)
     args = parser.parse_args()
 
     soc = BaseSoC(toolchain=args.toolchain,
@@ -78,8 +81,9 @@ def main():
         x5_clk_freq  = args.x5_clk_freq,
         **soc_core_argdict(args))
     builder = Builder(soc, **builder_argdict(args))
+    builder_kargs = trellis_argdict(args) if args.toolchain == "trellis" else {}
     if args.build:
-        builder.build()
+        builder.build(**builder_kargs)
 
     if args.load:
         prog = soc.platform.create_programmer()

--- a/litex_boards/targets/lattice_ecp5_vip.py
+++ b/litex_boards/targets/lattice_ecp5_vip.py
@@ -12,6 +12,8 @@ from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex_boards.platforms import lattice_ecp5_vip
 
+from litex.build.lattice.trellis import trellis_args, trellis_argdict
+
 from litex.soc.cores.clock import *
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
@@ -193,6 +195,7 @@ def main():
     target_group.add_argument("--sys-clk-freq", default=60e6,        help="System clock frequency (default: 60MHz)")
     builder_args(parser)
     soc_core_args(parser)
+    trellis_args(parser)
     args = parser.parse_args()
 
     soc = BaseSoC(
@@ -200,8 +203,9 @@ def main():
         sys_clk_freq = int(float(args.sys_clk_freq)),
         **soc_core_argdict(args))
     builder = Builder(soc, **builder_argdict(args))
+    builder_kargs = trellis_argdict(args) if args.toolchain == "trellis" else {}
     if args.build:
-        builder.build()
+        builder.build(**builder_kargs)
 
     if args.load:
         prog = soc.platform.create_programmer()

--- a/litex_boards/targets/lattice_ice40up5k_evn.py
+++ b/litex_boards/targets/lattice_ice40up5k_evn.py
@@ -14,6 +14,7 @@ from migen.genlib.resetsync import AsyncResetSynchronizer
 from litex_boards.platforms import lattice_ice40up5k_evn
 from litex.build.lattice.programmer import IceStormProgrammer
 
+from litex.build.lattice.icestorm import icestorm_args, icestorm_argdict
 from litex.soc.cores.ram import Up5kSPRAM
 from litex.soc.cores.clock import iCE40PLL
 from litex.soc.integration.soc_core import *
@@ -136,6 +137,7 @@ def main():
     target_group.add_argument("--flash",             action="store_true", help="Flash Bitstream.")
     builder_args(parser)
     soc_core_args(parser)
+    icestorm_args(parser)
     args = parser.parse_args()
 
     soc = BaseSoC(
@@ -145,7 +147,7 @@ def main():
     )
     builder = Builder(soc, **builder_argdict(args))
     if args.build:
-        builder.build()
+        builder.build(**icestorm_argdict(args))
 
     if args.flash:
         flash(args.bios_flash_offset)

--- a/litex_boards/targets/muselab_icesugar.py
+++ b/litex_boards/targets/muselab_icesugar.py
@@ -13,6 +13,7 @@ from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex_boards.platforms import muselab_icesugar
 
+from litex.build.lattice.icestorm import icestorm_args, icestorm_argdict
 from litex.soc.cores.ram import Up5kSPRAM
 from litex.soc.cores.clock import iCE40PLL
 from litex.soc.integration.soc_core import *
@@ -115,6 +116,7 @@ def main():
     target_group.add_argument("--bios-flash-offset",   default="0x40000",   help="BIOS offset in SPI Flash.")
     builder_args(parser)
     soc_core_args(parser)
+    icestorm_args(parser)
     args = parser.parse_args()
 
     soc = BaseSoC(
@@ -124,7 +126,7 @@ def main():
     )
     builder = Builder(soc, **builder_argdict(args))
     if args.build:
-        builder.build()
+        builder.build(**icestorm_argdict(args))
 
     if args.load:
         prog = soc.platform.create_programmer()

--- a/litex_boards/targets/qwertyembedded_beaglewire.py
+++ b/litex_boards/targets/qwertyembedded_beaglewire.py
@@ -15,6 +15,7 @@ from litex_boards.platforms import qwertyembedded_beaglewire
 
 from litex.build.io import DDROutput
 
+from litex.build.lattice.icestorm import icestorm_args, icestorm_argdict
 from litex.soc.cores.clock import iCE40PLL
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.soc import SoCRegion
@@ -114,6 +115,7 @@ def main():
     target_group.add_argument("--sys-clk-freq",      default=50e6,        help="System clock frequency.")
     builder_args(parser)
     soc_core_args(parser)
+    icestorm_args(parser)
     args = parser.parse_args()
 
     soc = BaseSoC(
@@ -123,7 +125,7 @@ def main():
     )
     builder = Builder(soc,  **builder_argdict(args))
     if args.build:
-        builder.build()
+        builder.build(**icestorm_argdict(args))
 
 if __name__ == "__main__":
     main()

--- a/litex_boards/targets/rcs_arctic_tern_bmc_card.py
+++ b/litex_boards/targets/rcs_arctic_tern_bmc_card.py
@@ -180,7 +180,7 @@ def main():
     builder = Builder(soc, **builder_argdict(args))
     builder_kargs = trellis_argdict(args) if args.toolchain == "trellis" else {}
     if args.build:
-        builder.build()
+        builder.build(**builder_kargs)
 
     if args.load:
         prog = soc.platform.create_programmer()

--- a/litex_boards/targets/tinyfpga_bx.py
+++ b/litex_boards/targets/tinyfpga_bx.py
@@ -12,6 +12,7 @@ from litex.build.io import CRG
 
 from litex_boards.platforms import tinyfpga_bx
 
+from litex.build.lattice.icestorm import icestorm_args, icestorm_argdict
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.soc import SoCRegion
 from litex.soc.integration.builder import *
@@ -64,6 +65,7 @@ def main():
     target_group.add_argument("--sys-clk-freq",      default=16e6,        help="System clock frequency.")
     builder_args(parser)
     soc_core_args(parser)
+    icestorm_args(parser)
     args = parser.parse_args()
 
     soc = BaseSoC(
@@ -73,7 +75,7 @@ def main():
     )
     builder = Builder(soc, **builder_argdict(args))
     if args.build:
-        builder.build()
+        builder.build(**icestorm_argdict(args))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
`LatticeIcestormToolchain` and `LatticeTrellisToolchain` provides addiitonal CLI arguments to modify/adapts `NextPnr behaviour. But at the target level these are never used.
This patch add required import, appends `args` with them and pass results to builder.builder method