### PR TITLE
target: basys3: Remove redundant sdcard additions

### DIFF
--- a/litex_boards/targets/digilent_basys3.py
+++ b/litex_boards/targets/digilent_basys3.py
@@ -86,10 +86,6 @@ def main():
         soc.add_spi_sdcard()
     if args.with_sdcard:
         soc.add_sdcard()
-    if args.with_spi_sdcard:
-        soc.add_spi_sdcard()
-    if args.with_sdcard:
-        soc.add_sdcard()
     builder = Builder(soc, **builder_argdict(args))
     if args.build:
         builder.build()


### PR DESCRIPTION
This removes a redundancy that prevents a target to build with `--with-sdcard` and `--with-spi-sdcard` parameters.