### PR TITLE
targets/sipeed_tang_primer_20k: don't force run when build argument is true

### DIFF
--- a/litex_boards/targets/sipeed_tang_primer_20k.py
+++ b/litex_boards/targets/sipeed_tang_primer_20k.py
@@ -80,7 +80,8 @@ def main():
     )
 
     builder = Builder(soc, **builder_argdict(args))
-    builder.build(run=args.build)
+    if args.build:
+        builder.build()
 
     if args.load:
         prog = soc.platform.create_programmer()


### PR DESCRIPTION
With sipeed_tang_primer_20k `builder.build()` `run` argument is set to true when `--build` is true too.
Usually, for all others boards, the rule is to let Builder deciding when  `run` must be true according `--no-compile` or `--no-compile-gateware` are set / unset.