### PR TITLE
targets: ecp5 & nexus: add toolchain argument

### DIFF
--- a/litex_boards/targets/fpc_iii.py
+++ b/litex_boards/targets/fpc_iii.py
@@ -143,6 +143,7 @@ def main():
 
     soc = BaseSoC(
         sys_clk_freq   = int(float(args.sys_clk_freq)),
+        toolchain      = args.toolchain,
         with_ethernet  = args.with_ethernet,
         with_etherbone = args.with_etherbone,
         **soc_core_argdict(args))

--- a/litex_boards/targets/trellisboard.py
+++ b/litex_boards/targets/trellisboard.py
@@ -198,6 +198,7 @@ def main():
 
     soc = BaseSoC(
         sys_clk_freq           = int(float(args.sys_clk_freq)),
+        toolchain              = args.toolchain,
         with_ethernet          = args.with_ethernet,
         with_video_terminal    = args.with_video_terminal,
         with_video_framebuffer = args.with_video_framebuffer,


### PR DESCRIPTION
Lattice ECP5 and Nexus may be build using vendor's tool (diamond or radiant) or using Open source tools (yosys/nextpnr and prjtrellis or prjoxide). This selection is allowed for all at platforms level but not always at targets level.
This PR adds a `--toolchain` argument to allows user to select between tools.