### PR TITLE
Added Tang Nano 4k Support for GoWin Educational IDE v1.9.8.03

### DIFF
--- a/litex_boards/platforms/sipeed_tang_nano_4k.py
+++ b/litex_boards/platforms/sipeed_tang_nano_4k.py
@@ -87,7 +87,10 @@ class Platform(GowinPlatform):
     default_clk_period = 1e9/27e6
 
     def __init__(self, toolchain="gowin"):
-        GowinPlatform.__init__(self, "GW1NSR-LV4CQN48PC7/I6", _io, _connectors, toolchain=toolchain, devicename="GW1NSR-4C")
+        # Educational GoWin IDE v. 1.9.8.03
+    	GowinPlatform.__init__(self, "GW1NSR-LV4CQN48PC6/I5", _io, _connectors, toolchain=toolchain, devicename="GW1NSR-4C")
+    	# Licensed GoWin IDE v. 1.9.7.06 Beta
+        # GowinPlatform.__init__(self, "GW1NSR-LV4CQN48PC7/I6", _io, _connectors, toolchain=toolchain, devicename="GW1NSR-4C")
         self.toolchain.options["use_mode_as_gpio"] = 1
         self.toolchain.options["use_mspi_as_gpio"] = 1
         self.toolchain.options["use_done_as_gpio"] = 1


### PR DESCRIPTION
According to Issue #411, I have added Tang Nano 4k support for GoWin Educational IDE v1.9.8.03