### PR TITLE
digilent_arty: make GPIOs interrupt-capable if SoC has IRQs enabled

### DIFF
--- a/litex_boards/targets/digilent_arty.py
+++ b/litex_boards/targets/digilent_arty.py
@@ -138,12 +138,16 @@ class BaseSoC(SoCCore):
 
         # Buttons ----------------------------------------------------------------------------------
         if with_buttons:
-            self.submodules.buttons = GPIOIn(pads=platform.request_all("user_btn"))
+            self.submodules.buttons = GPIOIn(
+                pads=platform.request_all("user_btn"),
+                with_irq=self.irq.enabled)
 
         # GPIOs ------------------------------------------------------------------------------------
         if with_pmod_gpio:
             platform.add_extension(digilent_arty.raw_pmod_io("pmoda"))
-            self.submodules.gpio = GPIOTristate(platform.request("pmoda"))
+            self.submodules.gpio = GPIOTristate(
+                platform.request("pmoda"),
+                with_irq=self.irq.enabled)
 
 # Build --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Enables interrupt requests for the exposed GPIOs if the SoC is capable of handling interrupts.