### PR TITLE
radiona_ulx3s: add buttons

### DIFF
--- a/litex_boards/platforms/radiona_ulx3s.py
+++ b/litex_boards/platforms/radiona_ulx3s.py
@@ -15,6 +15,15 @@ _io_common = [
     ("clk25", 0, Pins("G2"), IOStandard("LVCMOS33")),
     ("rst",   0, Pins("R1"), IOStandard("LVCMOS33")),
 
+    # Buttons
+    ("user_button", 0, Pins("D6"), IOStandard("LVCMOS33"), Misc("PULLMODE=UP")), # PWR
+    ("user_button", 1, Pins("R1"), IOStandard("LVCMOS33"), Misc("PULLMODE=DOWN")), # F1
+    ("user_button", 2, Pins("T1"), IOStandard("LVCMOS33"), Misc("PULLMODE=DOWN")), # F2
+    ("user_button", 3, Pins("R18"), IOStandard("LVCMOS33"), Misc("PULLMODE=DOWN")), # UP
+    ("user_button", 4, Pins("V1"), IOStandard("LVCMOS33"), Misc("PULLMODE=DOWN")), # DOWN
+    ("user_button", 5, Pins("U1"), IOStandard("LVCMOS33"), Misc("PULLMODE=DOWN")), # LEFT
+    ("user_button", 6, Pins("H16"), IOStandard("LVCMOS33"), Misc("PULLMODE=DOWN")), # RIGHT
+
     # Leds
     ("user_led", 0, Pins("B2"), IOStandard("LVCMOS33")),
     ("user_led", 1, Pins("C2"), IOStandard("LVCMOS33")),


### PR DESCRIPTION
Tested on LFE5U-85F:

```
from litex.build.generic_platform import *
from litex_boards.platforms import radiona_ulx3s

import design

platform = radiona_ulx3s.Platform(device="LFE5U-85F")

# Design

in1 = platform.request("user_button", 1)
in2 = platform.request("user_button", 2)
sum_led1 = platform.request("user_led")
sum_led2 = platform.request("user_led", 1)
status_led = platform.request("user_led", 3)

module = design.adder()
module.comb += module.in1.eq(in1)
module.comb += module.in2.eq(in2)
module.comb += sum_led1.eq(module.sum[0])
module.comb += sum_led2.eq(module.sum[1])
module.comb += status_led.eq(1)

# Build

platform.build(module)

# Load

prog = platform.create_programmer()
prog.load_bitstream("build/top.bit")
```