### PR TITLE
sipeed_tang_primer_20k: adding dock lite support

### DIFF
--- a/litex_boards/platforms/sipeed_tang_primer_20k.py
+++ b/litex_boards/platforms/sipeed_tang_primer_20k.py
@@ -19,6 +19,13 @@ _io = [
     # Clk / Rst.
     ("clk27",  0, Pins("H11"), IOStandard("LVCMOS33")),
 
+    # Serial.
+    ("serial", 0,
+        Subsignal("rx", Pins("T13")), # CARD1:1
+        Subsignal("tx", Pins("M11")), # CARD1:11
+        IOStandard("LVCMOS33")
+    ),
+
     # SPIFlash.
     ("spiflash", 0,
         Subsignal("cs_n", Pins("M9"),  IOStandard("LVCMOS33")),
@@ -59,8 +66,8 @@ _connectors = [
         " --- --- --- --- --- ---  T6 R16  P6 P15",
         # GND GND                 GND GND           (31-40).
         " --- ---  T7 P16  R8 N15 --- ---  T8  N16",
-        #                             GND GND       (41-50).
-        "  M6 N14 GND L16  T9 L14  P9 --- --- K15",
+        #         GND                 GND GND       (41-50).
+        "  M6 N14 --- L16  T9 L14  P9 --- --- K15",
         #             GND GND                 GND   (51-60).
         " P11 K14 T11 --- --- K16 R11 J15 T12 ---",
         # GND                 GND                   (61-70).
@@ -73,8 +80,8 @@ _connectors = [
         " M15 L13 M14 K11 F13 K12 G12 K13 T15 ---",
         #                  NC  NC                   (83-92).
         " J16 H13 J14 J12 --- --- G14 H12 G15 G11",
-        #  NC  NC                  NC  NC E15  NC  (93-102).
-        " --- --- F14 B10 F16 A13 --- --- --- ---",
+        #  NC  NC                  NC  NC      NC  (93-102).
+        " --- --- F14 B10 F16 A13 --- --- E15 ---",
         #      NC  NC  NC      NC      NC  NC  NC  (103-112).
         " D15 --- --- --- A15 --- B14 --- --- ---",
         #      NC      NC  NC  NC      NC      NC  (113-122).
@@ -120,13 +127,6 @@ _dock_io = [
     ("btn_n", 2,  Pins("CARD1:163"), IOStandard("LVCMOS15")),
     ("btn_n", 3,  Pins("CARD1:159"), IOStandard("LVCMOS15")),
     ("btn_n", 4,  Pins("CARD1:157"), IOStandard("LVCMOS15")),
-
-    # Serial.
-    ("serial", 0,
-        Subsignal("rx", Pins( "CARD1:1")),
-        Subsignal("tx", Pins("CARD1:11")),
-        IOStandard("LVCMOS33")
-    ),
 
     # HDMI.
     ("hdmi", 0,
@@ -184,15 +184,78 @@ _dock_io = [
      ),
 ]
 
+# Dock Lite IOs ------------------------------------------------------------------------------------
+
+_dock_lite_io = [
+    # Buttons.
+    ("btn_n",   0, Pins("CARD1:15"),  IOStandard("LVCMOS33")),
+    ("btn_n",   1, Pins("CARD1:163"), IOStandard("LVCMOS15")),
+
+    # Switches
+    ("user_sw", 0, Pins("CARD1:159"), IOStandard("LVCMOS15")),
+    ("user_sw", 1, Pins("CARD1:157"), IOStandard("LVCMOS15")),
+]
+
+_dock_lite_connectors = [
+    # Pmod
+    ("j2", "F15 D16 C9  L12 E15 E14 A9  J11"),
+    ("j6", "L8  P7  E10 D11 M6  R7  D10 F10"),
+    ("j7", "T6  T7  T8  T9  P6  R8  M6  P9"),
+    ("j8", "R16 P16 N16 L16 P15 N15 N14 L14"),
+
+    ("j1", {
+         7: "T5",
+         9: "T3",  10: "T5",
+        13: "E9",  14: "E8",
+        15: "T15", 16: "C13",
+        17: "T13", 18: "M11",
+        19: "B10", 20: "A13",
+        21: "H12", 22: "G11",
+        23: "H13", 24: "J12",
+        25: "K12", 26: "K13",
+        27: "L13", 28: "K11",
+        29: "R11", 30: "T12",
+        31: "P11", 32: "T11",
+        33: "G16", 34: "H15",
+        35: "H16", 36: "H14",
+        37: "K16", 38: "J15",
+        39: "K15", 40: "K14",
+    }),
+    ("j3", {
+         3: "N6",   4: "N7",
+         5: "B11",  6: "A12",
+         7: "L9",   8: "N8",
+         9: "R9",  10: "N9",
+        11: "A6",  12: "A7",
+        13: "C6",  14: "B8",
+        15: "C10",
+        17: "A11", 18: "C11",
+        19: "B12", 20: "C12",
+        21: "B13", 22: "A14",
+        23: "B14", 24: "A15",
+        25: "D15", 26: "E15",
+        27: "F16", 28: "F14",
+        29: "G15", 30: "G14",
+        31: "J14", 32: "J16",
+        33: "G12", 34: "F13",
+        35: "M14", 36: "M15",
+        37: "T14", 38: "R13",
+        39: "P13", 40: "R12",
+    })
+]
+
 # Platform -----------------------------------------------------------------------------------------
 
 class Platform(GowinPlatform):
     default_clk_name   = "clk27"
     default_clk_period = 1e9/27e6
 
-    def __init__(self, toolchain="gowin"):
+    def __init__(self, dock="dock", toolchain="gowin"):
+        if dock == "lite":
+            _connectors.extend(_dock_lite_connectors)
+
         GowinPlatform.__init__(self, "GW2A-LV18PG256C8/I7", _io, _connectors, toolchain=toolchain, devicename="GW2A-18C")
-        self.add_extension(_dock_io)
+        self.add_extension(_dock_io if dock == "dock" else _dock_lite_io)
         self.toolchain.options["use_mspi_as_gpio"]  = 1
         self.toolchain.options["use_sspi_as_gpio"]  = 1
         self.toolchain.options["use_ready_as_gpio"] = 1

--- a/litex_boards/targets/sipeed_tang_primer_20k.py
+++ b/litex_boards/targets/sipeed_tang_primer_20k.py
@@ -79,8 +79,15 @@ class BaseSoC(SoCCore):
         with_etherbone      = False,
         eth_ip              = "192.168.1.50",
         eth_dynamic_ip      = False,
+        dock                = "dock",
         **kwargs):
-        platform = sipeed_tang_primer_20k.Platform()
+
+        assert dock in ["dock", "lite"]
+
+        platform = sipeed_tang_primer_20k.Platform(dock, toolchain="gowin")
+
+        if dock == "lite":
+            with_led_chaser = False # no leds on core board nor on dock lite
 
         # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = _CRG(platform, sys_clk_freq, with_video_pll=with_video_terminal)
@@ -145,6 +152,7 @@ def main():
     from litex.soc.integration.soc import LiteXSoCArgumentParser
     parser = LiteXSoCArgumentParser(description="LiteX SoC on Tang Primer 20K")
     target_group = parser.add_argument_group(title="Target options")
+    target_group.add_argument("--dock",         default="dock",        help="Dock version (dock (default) or lite.")
     target_group.add_argument("--build",        action="store_true",   help="Build bitstream.")
     target_group.add_argument("--load",         action="store_true",   help="Load bitstream.")
     target_group.add_argument("--flash",        action="store_true",   help="Flash Bitstream.")
@@ -171,6 +179,7 @@ def main():
         with_etherbone      = args.with_etherbone,
         eth_ip              = args.eth_ip,
         eth_dynamic_ip      = args.eth_dynamic_ip,
+        dock                = args.dock,
         **soc_core_argdict(args)
     )
     if args.with_spi_sdcard:


### PR DESCRIPTION
@sipeed provides two docks for tang primer 20k core board: one called simply **dock** (expected for october) and **lite** version with:
- 2 buttons
- 2 switches
- 4 PMODs
- 2 2 x 20 headers

This PR adds the definition for *io* and *connectors* and an argument to select between docks version. Default dock is left unchanged, user has to explicitly set `--dock lite`.
It also move serial node at core level: **lite** has no onboard serial adapter (*rx* and *tx* are available only on core board **J1** connector), it disable inconditionnaly **led_chaser** because there is no leds at all.

Also toolchain is explicitly set at target level and it fix *CARD1* typos.