### PR TITLE
targets/sipeed_tang_primer_20k: fix CLKDIV (disable reset and calibration)

### DIFF
--- a/litex_boards/targets/sipeed_tang_primer_20k.py
+++ b/litex_boards/targets/sipeed_tang_primer_20k.py
@@ -62,6 +62,8 @@ class _CRG(Module):
             video_pll.create_clkout(self.cd_hdmi5x, 125e6)
             self.specials += Instance("CLKDIV",
                 p_DIV_MODE= "5",
+                i_RESETN = 1, # disable reset signal
+                i_CALIB  = 0, # no calibration
                 i_HCLKIN = self.cd_hdmi5x.clk,
                 o_CLKOUT = self.cd_hdmi.clk
             )


### PR DESCRIPTION
`CLKDIV` primitive must have `RESETN` and `CALIB` set to an explicit value. Without that nothing is produce on output.
By fixing that issue HDMI is now working.
Tested with **lite** dock, a @machdyne [DDMI PMOD](https://machdyne.com/product/ddmi-pmod/) and with colorbars and terminal.