### PR TITLE
Update sipeed tang boards

### DIFF
--- a/litex_boards/platforms/sipeed_tang_primer_20k.py
+++ b/litex_boards/platforms/sipeed_tang_primer_20k.py
@@ -251,11 +251,12 @@ class Platform(GowinPlatform):
     default_clk_period = 1e9/27e6
 
     def __init__(self, dock="dock", toolchain="gowin"):
-        if dock == "lite":
-            _connectors.extend(_dock_lite_connectors)
 
         GowinPlatform.__init__(self, "GW2A-LV18PG256C8/I7", _io, _connectors, toolchain=toolchain, devicename="GW2A-18C")
         self.add_extension(_dock_io if dock == "dock" else _dock_lite_io)
+        if dock == "lite":
+            self.add_connector(_dock_lite_connectors)
+
         self.toolchain.options["use_mspi_as_gpio"]  = 1
         self.toolchain.options["use_sspi_as_gpio"]  = 1
         self.toolchain.options["use_ready_as_gpio"] = 1

--- a/litex_boards/targets/sipeed_tang_nano_4k.py
+++ b/litex_boards/targets/sipeed_tang_nano_4k.py
@@ -122,7 +122,7 @@ class BaseSoC(SoCCore):
 
         # Video ------------------------------------------------------------------------------------
         if with_video_terminal:
-            self.submodules.videophy = VideoHDMIPHY(platform.request("hdmi"), clock_domain="hdmi")
+            self.submodules.videophy = VideoGowinHDMIPHY(platform.request("hdmi"), clock_domain="hdmi")
             self.add_video_colorbars(phy=self.videophy, timings="640x480@75Hz", clock_domain="hdmi")
             #self.add_video_terminal(phy=self.videophy, timings="640x480@75Hz", clock_domain="hdmi") # FIXME: Free up BRAMs.
 
@@ -142,12 +142,14 @@ def main():
     target_group.add_argument("--load",        action="store_true", help="Load bitstream.")
     target_group.add_argument("--flash",       action="store_true", help="Flash Bitstream.")
     target_group.add_argument("--sys-clk-freq",default=27e6,        help="System clock frequency.")
+    target_group.add_argument("--with-video-terminal",action="store_true", help="System clock frequency.")
     builder_args(parser)
     soc_core_args(parser)
     args = parser.parse_args()
 
     soc = BaseSoC(
         sys_clk_freq=int(float(args.sys_clk_freq)),
+        with_video_terminal=args.with_video_terminal,
         **soc_core_argdict(args)
     )
 

--- a/litex_boards/targets/sipeed_tang_nano_9k.py
+++ b/litex_boards/targets/sipeed_tang_nano_9k.py
@@ -115,7 +115,7 @@ class BaseSoC(SoCCore):
 
         # Video ------------------------------------------------------------------------------------
         if with_video_terminal:
-            self.submodules.videophy = VideoHDMIPHY(platform.request("hdmi"), clock_domain="hdmi")
+            self.submodules.videophy = VideoGowinHDMIPHY(platform.request("hdmi"), clock_domain="hdmi")
             self.add_video_colorbars(phy=self.videophy, timings="640x480@60Hz", clock_domain="hdmi")
             #self.add_video_terminal(phy=self.videophy, timings="640x480@75Hz", clock_domain="hdmi") # FIXME: Free up BRAMs.
 


### PR DESCRIPTION
- First commit: update sipeed tang Nano 4k to replace the generic `VideoHDMIPHY` by `VideoGowinHDMIPHY`. This commit, also, adds `with-video-terminal` argument.
- Second: update sipeed tang Primer 20k platform to use new `add_connector`. The use of `VideoGowinHDMIPHY` is posponed until behaviour is checked with dock standard
- last: replace the generic `VideoHDMIPHY` by `VideoGowinHDMIPHY`