### PR TITLE
Adding DFU Support to the Butterstick Platform

### DIFF
--- a/litex_boards/platforms/gsd_butterstick.py
+++ b/litex_boards/platforms/gsd_butterstick.py
@@ -195,13 +195,13 @@ class Platform(LatticePlatform):
         connectors = {"1.0": _connectors_r1_0}[revision]
         LatticePlatform.__init__(self, f"LFE5UM5G-{device}-8BG381C", io, connectors, toolchain=toolchain, **kwargs)
 
-    def create_programmer(self, load):
-        if load == "jtag":
+    def create_programmer(self, programmer):
+        if programmer == "jtag":
             return OpenOCDJTAGProgrammer("openocd_butterstick.cfg")
-        elif load == "dfu":
+        elif programmer == "dfu":
             return DFUProg(vid="1209", pid="5af1", alt=0)
         else:
-            print("Could not program board. " + load + " is not a valid argument. Please use 'jtag' or 'dfu'.")
+            print("Could not program board. " + programmer + " is not a valid argument. Please use 'jtag' or 'dfu'.")
 
     def do_finalize(self, fragment):
         LatticePlatform.do_finalize(self, fragment)

--- a/litex_boards/platforms/gsd_butterstick.py
+++ b/litex_boards/platforms/gsd_butterstick.py
@@ -201,7 +201,7 @@ class Platform(LatticePlatform):
         elif load == "dfu":
             return DFUProg(vid="1209", pid="5af1", alt=0)
         else:
-            print("Could not program board. "+load+" is not a valid argument. Please use 'jtag' or 'dfu'.")
+            print("Could not program board. " + load + " is not a valid argument. Please use 'jtag' or 'dfu'.")
 
     def do_finalize(self, fragment):
         LatticePlatform.do_finalize(self, fragment)

--- a/litex_boards/platforms/gsd_butterstick.py
+++ b/litex_boards/platforms/gsd_butterstick.py
@@ -4,10 +4,11 @@
 # Copyright (c) 2021 Greg Davill <greg.davill@gmail.com>
 # Copyright (c) 2021 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
-
+ 
 from litex.build.generic_platform import *
 from litex.build.lattice import LatticePlatform
 from litex.build.lattice.programmer import OpenOCDJTAGProgrammer
+from litex.build.dfu import DFUProg
 
 # IOs ----------------------------------------------------------------------------------------------
 
@@ -194,8 +195,13 @@ class Platform(LatticePlatform):
         connectors = {"1.0": _connectors_r1_0}[revision]
         LatticePlatform.__init__(self, f"LFE5UM5G-{device}-8BG381C", io, connectors, toolchain=toolchain, **kwargs)
 
-    def create_programmer(self):
-        return OpenOCDJTAGProgrammer("openocd_butterstick.cfg")
+    def create_programmer(self, load):
+        if load == "jtag":
+            return OpenOCDJTAGProgrammer("openocd_butterstick.cfg")
+        elif load == "dfu":
+            return DFUProg(vid="1209", pid="5af1", alt=0)
+        else:
+            print("Could not program board. "+load+" is not a valid argument. Please use 'jtag' or 'dfu'.")
 
     def do_finalize(self, fragment):
         LatticePlatform.do_finalize(self, fragment)

--- a/litex_boards/targets/gsd_butterstick.py
+++ b/litex_boards/targets/gsd_butterstick.py
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 # Build/Use:
-# ./gsd_butterstick.py --uart-name=crossover --with-etherbone --csr-csv=csr.csv --build --load
+# ./gsd_butterstick.py --uart-name=crossover --with-etherbone --csr-csv=csr.csv --build --load (jtag / dfu)
 # litex_server --udp
 # litex_term crossover
 

--- a/litex_boards/targets/gsd_butterstick.py
+++ b/litex_boards/targets/gsd_butterstick.py
@@ -155,7 +155,7 @@ def main():
     parser = LiteXSoCArgumentParser(description="LiteX SoC on ButterStick")
     target_group = parser.add_argument_group(title="Target options")
     target_group.add_argument("--build",           action="store_true",    help="Build design.")
-    target_group.add_argument("--load",            action="store_true",    help="Load bitstream.")
+    target_group.add_argument("--load",            default="jtag",         help="Load bitstream (jtag or dfu).")
     target_group.add_argument("--toolchain",       default="trellis",      help="FPGA toolchain (trellis or diamond).")
     target_group.add_argument("--sys-clk-freq",    default=75e6,           help="System clock frequency.")
     target_group.add_argument("--revision",        default="1.0",          help="Board Revision (1.0).")
@@ -201,7 +201,7 @@ def main():
         builder.build(**builder_kargs)
 
     if args.load:
-        prog = soc.platform.create_programmer()
+        prog = soc.platform.create_programmer(args.load)
         prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
 
 if __name__ == "__main__":

--- a/litex_boards/targets/gsd_butterstick.py
+++ b/litex_boards/targets/gsd_butterstick.py
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 # Build/Use:
-# ./gsd_butterstick.py --uart-name=crossover --with-etherbone --csr-csv=csr.csv --build --load (jtag / dfu)
+# ./gsd_butterstick.py --uart-name=crossover --with-etherbone --csr-csv=csr.csv --build --load --programmer (jtag / dfu)
 # litex_server --udp
 # litex_term crossover
 
@@ -155,7 +155,8 @@ def main():
     parser = LiteXSoCArgumentParser(description="LiteX SoC on ButterStick")
     target_group = parser.add_argument_group(title="Target options")
     target_group.add_argument("--build",           action="store_true",    help="Build design.")
-    target_group.add_argument("--load",            default="jtag",         help="Load bitstream (jtag or dfu).")
+    target_group.add_argument("--load",            action="store_true",    help="Load bitstream.")
+    target_group.add_argument("--programmer",      default="jtag",         help="Programming interface (jtag or dfu).")
     target_group.add_argument("--toolchain",       default="trellis",      help="FPGA toolchain (trellis or diamond).")
     target_group.add_argument("--sys-clk-freq",    default=75e6,           help="System clock frequency.")
     target_group.add_argument("--revision",        default="1.0",          help="Board Revision (1.0).")
@@ -201,7 +202,7 @@ def main():
         builder.build(**builder_kargs)
 
     if args.load:
-        prog = soc.platform.create_programmer(args.load)
+        prog = soc.platform.create_programmer(args.programmer)
         prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
 
 if __name__ == "__main__":


### PR DESCRIPTION
I ran into an issue while trying to get LiteX running on my Butterstick, it was pointed out to me that the example expects a JTAG adapter for programming the board, rather than the onboard USB. I added the option to select between "jtag" and "dfu" while programming so that the board can be programmed without an additional adapter. If no programmer option is specified, it defaults to a JTAG programmer, to maintain compatibility with existing code. 