### PR TITLE
xilinx_zybo_z7: Fix typo

### DIFF
--- a/litex_boards/targets/xilinx_zybo_z7.py
+++ b/litex_boards/targets/xilinx_zybo_z7.py
@@ -57,7 +57,7 @@ class BaseSoC(SoCCore):
         # Zynq7000 Integration ---------------------------------------------------------------------
         if kwargs.get("cpu_type", None) == "zynq7000":
             # Get and set the pre-generated .xci FIXME: change location? add it to the repository?
-            os.system("wget https://github.com/litex-hub/litex-boards/files/8339591/zybo_z7_ps7.txt)")
+            os.system("wget https://github.com/litex-hub/litex-boards/files/8339591/zybo_z7_ps7.txt")
             os.makedirs("xci", exist_ok=True)
             os.system("mv zybo_z7_ps7.txt xci/zybo_z7_ps7.xci")
             self.cpu.set_ps7_xci("xci/zybo_z7_ps7.xci")


### PR DESCRIPTION
Sadly, setting the cpu_type to zynq7000 doesn't work.

The zynq7000 CPU doesn't have a CSR region in the mem_map therefore the SoC finalize code errors here:
https://github.com/enjoy-digital/litex/blob/89bb688500e24625a749bd36c47e1a894adf85ca/litex/soc/integration/soc.py#L1118

The last mem_map configuration commit (for the zynq7000 CPU) explicitly removed the CSR region.

Additionally, https://github.com/enjoy-digital/litex/blob/23f529a313797d2e866990f3c3d113ac88490089/litex/soc/integration/soc_core.py#L166 removes the ROM. Therefore, https://github.com/enjoy-digital/litex/blob/a7cc1af41640f505bacafceb87019dbbe7bdee3a/litex/soc/integration/soc.py#L1237 errors with `CPU needs reset address 0xfc000000 to be in a defined Region`.

I'm not sure what the intended SoC configuration is for this target.
Should the CPU add a CSR region or should the SoC finalization method only do CSR stuff if there is a region for it? I think in the past, the CSR adding code checked for the existing of a wishbone bus.
Same for the ROM, is the idea that the CPU boots from something on the PS side?
Thanks in advance for any hints.