### PR TITLE
add option to use ecpprog for crosslink-nx eval board

### DIFF
--- a/litex_boards/platforms/lattice_crosslink_nx_evn.py
+++ b/litex_boards/platforms/lattice_crosslink_nx_evn.py
@@ -8,6 +8,7 @@
 from litex.build.generic_platform import *
 from litex.build.lattice import LatticePlatform
 from litex.build.lattice.programmer import LatticeProgrammer
+from litex.build.lattice.programmer import EcpprogProgrammer
 
 # IOs ----------------------------------------------------------------------------------------------
 
@@ -258,8 +259,13 @@ class Platform(LatticePlatform):
         assert device in ["LIFCL-40-9BG400C", "LIFCL-40-8BG400CES"]
         LatticePlatform.__init__(self, device, _io, _connectors, toolchain=toolchain, **kwargs)
 
-    def create_programmer(self, mode = "direct"):
+    def create_programmer(self, mode = "direct", prog="radiant"):
         assert mode in ["direct","flash"]
+        assert prog in ["radiant","ecpprog"]
+
+        if prog == "ecpprog":
+            return EcpprogProgrammer()
+
 
         xcf_template_direct = """<?xml version='1.0' encoding='utf-8' ?>
 <!DOCTYPE		ispXCF	SYSTEM	"IspXCF.dtd" >

--- a/litex_boards/targets/lattice_crosslink_nx_evn.py
+++ b/litex_boards/targets/lattice_crosslink_nx_evn.py
@@ -97,9 +97,11 @@ def main():
     target_group.add_argument("--build",         action="store_true",        help="Build design.")
     target_group.add_argument("--load",          action="store_true",        help="Load bitstream.")
     target_group.add_argument("--toolchain",     default="radiant",          help="FPGA toolchain (radiant or prjoxide).")
-    target_group.add_argument("--device",        default="LIFCL-40-9BG400C", help="FPGA device (LIFCL-40-9BG400C or LIFCL-40-8BG400CES).")
+    target_group.add_argument("--device",        default="LIFCL-40-9BG400C", help="FPGA device (LIFCL-40-9BG400C, LIFCL-40-8BG400CES, or LIFCL-40-8BG400CES2).")
     target_group.add_argument("--sys-clk-freq",  default=75e6,               help="System clock frequency.")
     target_group.add_argument("--serial",        default="serial",           help="UART Pins (serial (requires R15 and R17 to be soldered) or serial_pmod[0-2]).")
+    target_group.add_argument("--programmer",    default="radiant",          help="Programmer (radiant or ecpprog).")
+    target_group.add_argument("--address",       default=0x0,                help="Flash address to program bitstream at.")
     target_group.add_argument("--prog-target",   default="direct",           help="Programming Target (direct or flash).")
     builder_args(parser)
     soc_core_args(parser)
@@ -118,8 +120,11 @@ def main():
         builder.build(**builder_kargs)
 
     if args.load:
-        prog = soc.platform.create_programmer(args.prog_target)
-        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+        prog = soc.platform.create_programmer(args.prog_target, args.programmer)
+        if args.programmer == "ecpprog" and args.prog_target == "flash":
+            prog.flash(address=args.address, bitstream=builder.get_bitstream_filename(mode="sram"))
+        else:
+            prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
e.g. the following was tested:
```
python3 lattice_crosslink_nx_evn.py --build --toolchain oxide --programmer ecpprog --load
```
with output:
```
Info: Program finished normally.
init..
reset..
programming..
Bye.
IDCODE: 0x110f1043 (LIFCL-40)
NX Status Register: 0x0000150100400100
NX Status Register: 0x0000150100400e50
NX Status Register: 0x0000150100400100
```