### PR TITLE
targets/litex_acorn_baseboard: fix pn_swap

### DIFF
--- a/litex_boards/targets/litex_acorn_baseboard.py
+++ b/litex_boards/targets/litex_acorn_baseboard.py
@@ -94,7 +94,7 @@ class BaseSoC(SoCCore):
 
         # Video ------------------------------------------------------------------------------------
         if with_video_terminal:
-            self.submodules.videophy = VideoHDMIPHY(platform.request("hdmi"), clock_domain="hdmi", pn_swap=["g", "b"])
+            self.submodules.videophy = VideoHDMIPHY(platform.request("hdmi"), clock_domain="hdmi", pn_swap=["g", "r"])
             self.add_video_terminal(phy=self.videophy, timings="800x600@60Hz", clock_domain="hdmi")
 
         # LCD --------------------------------------------------------------------------------------


### PR DESCRIPTION
With this [PR](https://github.com/enjoy-digital/litex/pull/1442) focused on fixing this [issue](https://github.com/enjoy-digital/litex/issues/1439) blue and red colors are swapped. This fix as for consequence the need to update all targets where `pn_swap` is used.
Currently two targets uses this option `sipeed_tang_primer_20k` and `litex_acorn_baseboard`. Former has no needs to be updated since all channels must be swapper but latter has only channels 1 and 2 to permut -> this PR fix that by replacing **b** by **r** (aka channel 2).