### PR TITLE
MNT RKX7: update platform and target for D-2 release

### DIFF
--- a/litex_boards/platforms/mnt_rkx7.py
+++ b/litex_boards/platforms/mnt_rkx7.py
@@ -2,6 +2,7 @@
 # This file is part of LiteX-Boards.
 #
 # Copyright (c) 2021 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2022 Lukas F. Hartmann, MNT Research GmbH <lukas@mntre.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.build.generic_platform import *
@@ -18,6 +19,16 @@ _io = [
     ("serial", 0,
         Subsignal("tx", Pins("D15")),
         Subsignal("rx", Pins("C18")),
+        IOStandard("LVCMOS33")
+    ),
+    ("serial", 1,
+        Subsignal("tx", Pins("H16")),
+        Subsignal("rx", Pins("G16")),
+        IOStandard("LVCMOS33")
+    ),
+    ("litescope_serial", 0,
+        Subsignal("tx", Pins("C17")),
+        Subsignal("rx", Pins("C16")),
         IOStandard("LVCMOS33")
     ),
 
@@ -66,30 +77,51 @@ _io = [
 
     # I2C
     ("i2c", 0,
+        Subsignal("scl", Pins("Y26")),
+        Subsignal("sda", Pins("W26")),
+        IOStandard("LVCMOS18"),
+    ),
+    ("i2c", 1,
         Subsignal("scl", Pins("G12")),
         Subsignal("sda", Pins("A13")),
         IOStandard("LVCMOS18"),
+    ),
+    ("i2c", 2,
+        Subsignal("scl", Pins("H26")),
+        Subsignal("sda", Pins("G26")),
+        IOStandard("LVCMOS33"),
+    ),
+
+    # GPIO
+    ("resets", 0,
+        Pins("M21 M22 C13 C14"), # Backlight PWM, Backlight EN, hdmi_rst_n, edp_reset_n
+        IOStandard("LVCMOS18")
+    ),
+    ("gpio", 0,
+        Pins("D13 N19 M19"), # USB hub reset, Analogix reset, eDP HPD
+        IOStandard("LVCMOS18")
     ),
 
     # DDR3 SDRAM.
     ("ddram", 0,
         Subsignal("a",       Pins(
-            "AC8 AA7 AA8 AF7 AE7 AC11 V9 Y10",
-            "AB11 Y7  Y8 V11  V8  W11 Y11 V7 "),
+            "AC8 AA9 AA7 AD9 Y8 AA8 W11 Y10",
+            "Y11 Y7 AC11 V11 AB11 V7 V9 V8"),
             IOStandard("SSTL15")),
         Subsignal("ba",      Pins("AC7 AB7 AB9"), IOStandard("SSTL15")),
-        Subsignal("ras_n",   Pins("AA9"), IOStandard("SSTL15")),
-        Subsignal("cas_n",   Pins("AD8"), IOStandard("SSTL15")),
+        Subsignal("ras_n",   Pins("AF7"), IOStandard("SSTL15")),
+        Subsignal("cas_n",   Pins("AE7"), IOStandard("SSTL15")),
         Subsignal("we_n",    Pins("AC9"), IOStandard("SSTL15")),
-        Subsignal("cs_n",    Pins("AD9"), IOStandard("SSTL15")),
+        Subsignal("cs_n",    Pins("AD8"), IOStandard("SSTL15")),
         Subsignal("dm",      Pins(
             "U6 Y3 AB6 AD4"),
             IOStandard("SSTL15")),
         Subsignal("dq",      Pins(
-            " V4  W3  U5  U1  U7  U2  V6  V3",
+            " V4  W3  U5  U2  U7  U1  V6  V3",
             " Y2  Y1 AA3  V2 AC2  W1 AB2  V1",
-            "AA4 AB4 AC4 AC3 AC6  Y6  Y5 AD6",
-            "AD1 AE1 AE3 AE2 AE6 AE5 AF3 AF2"),
+            "AA4 AB4 AC4 AC3 AC6 Y6 Y5 AD6",
+            "AD1 AE1 AE3 AE2 AE6 AE5 AF3 AF2"
+            ),
             IOStandard("SSTL15_T_DCI")),
         Subsignal("dqs_p",   Pins("W6 AB1 AA5 AF5"),
             IOStandard("DIFF_SSTL15")),
@@ -102,6 +134,53 @@ _io = [
         Subsignal("reset_n", Pins("AA2"),  IOStandard("LVCMOS15")),
         Misc("SLEW=FAST"),
         Misc("VCCAUX_IO=HIGH")
+    ),
+
+    # HDMI (DISP1)
+    ("hdmi", 0,
+        Subsignal("clk",     Pins("C12")),
+        Subsignal("de",      Pins("D10")),
+        Subsignal("hsync_n", Pins("D11")),
+        Subsignal("vsync_n", Pins("E11")),
+        Subsignal("b", Pins("H13 G10 J13 H12 J10  H8  H9 J11")), # [16:23]
+        Subsignal("g", Pins("F14  C9 G14 F10 H14 G11 H11  G9")), # [8:15]
+        Subsignal("r", Pins("E10  D8  F9  F8  A9  A8  B9  D9")), # [0:7]
+        IOStandard("LVCMOS18")
+    ),
+
+    # RGB->eDP (DISP2)
+    ("edp", 0,
+        Subsignal("clk",     Pins("AC18")),
+        Subsignal("de",      Pins("AA15")),
+        Subsignal("hsync", Pins("AB15")), # hsync_n for negative
+        Subsignal("vsync", Pins("AB16")), # vsync_n for negative
+        Subsignal("b", Pins("AF14 AF15 AE15 AE16 AF17 AE17 AA14 AF18")), # [16:23]
+        Subsignal("g", Pins("AD15 AE18 AD16 AF19 AC16 AD14 AC17 AC14")), # [8:15]
+        Subsignal("r", Pins("AB14 Y15  AA17 AA18 Y16  AF20 AD20 AB17")), # [0:7]
+        IOStandard("LVCMOS18"), Misc("DRIVE=4"),
+    ),
+
+    ("edpoff", 0,
+       Pins("AD18"),
+       IOStandard("LVCMOS18")
+    ),
+
+    # Backlight via Motherboard (unused)
+    ("backlight", 0,
+        Subsignal("pwm", Pins("K16")),
+        Subsignal("en", Pins("B16")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # USB
+    ("usb", 0,
+        Subsignal("dp", Pins("D26")),
+        Subsignal("dm", Pins("C26")),
+        IOStandard("LVCMOS33"),
+    ),
+    ("usb_pull", 0,
+        Pins("F25"),
+        IOStandard("LVCMOS33")
     ),
 ]
 
@@ -117,6 +196,13 @@ class Platform(XilinxPlatform):
 
     def __init__(self, toolchain="vivado"):
         XilinxPlatform.__init__(self, "xc7k325t-ffg676-2", _io, _connectors, toolchain=toolchain)
+        # Enable bitstream compression, quad SPI and 50MHz rate for quick boot from SPI flash
+        # see https://github.com/timvideos/litex-buildenv/issues/79
+        self.toolchain.bitstream_commands = [
+            "set_property BITSTREAM.GENERAL.COMPRESS True [current_design]",
+            "set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]",
+            "set_property BITSTREAM.CONFIG.CONFIGRATE 50 [current_design]"
+        ]
 
     def create_programmer(self):
         return OpenOCD("openocd_xc7_ft2232.cfg", "bscan_spi_xc7a325t.bit")

--- a/litex_boards/targets/mnt_rkx7.py
+++ b/litex_boards/targets/mnt_rkx7.py
@@ -4,6 +4,7 @@
 # This file is part of LiteX-Boards.
 #
 # Copyright (c) 2021 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2022 Lukas F. Hartmann, MNT Research GmbH <lukas@mntre.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
@@ -12,8 +13,16 @@ from litex_boards.platforms import mnt_rkx7
 
 from litex.soc.cores.clock import *
 from litex.soc.integration.soc_core import *
+from litex.soc.integration.soc import SoCRegion
 from litex.soc.integration.builder import *
+from litex.soc.interconnect.csr import *
+from litex.soc.interconnect.axi import *
+from litex.soc.interconnect.wishbone import *
 from litex.soc.cores.bitbang import I2CMaster
+from litex.soc.cores.gpio import GPIOOut
+from litex.soc.cores.video import VideoDVIPHY
+from litex.soc.cores.usb_ohci import USBOHCI
+from migen.fhdl.specials import Tristate
 
 from litedram.modules import IS43TR16512B
 from litedram.phy import s7ddrphy
@@ -28,24 +37,44 @@ class _CRG(Module):
         self.clock_domains.cd_sys    = ClockDomain()
         self.clock_domains.cd_sys4x  = ClockDomain()
         self.clock_domains.cd_idelay = ClockDomain()
+        self.clock_domains.cd_dvi    = ClockDomain(reset_less=True)
+        self.clock_domains.cd_usb    = ClockDomain()
 
-        # # #
+        clkin = platform.request("clk100")
 
         self.submodules.pll = pll = S7MMCM(speedgrade=-2)
         self.comb += pll.reset.eq(self.rst)
-        pll.register_clkin(platform.request("clk100"), 100e6)
+        # Main clock input (100MHz)
+        pll.register_clkin(clkin, 100e6)
         pll.create_clkout(self.cd_sys,    sys_clk_freq)
         pll.create_clkout(self.cd_sys4x,  4*sys_clk_freq)
         pll.create_clkout(self.cd_idelay, 200e6)
-        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
+        # Ignore sys_clk to pll.clkin path created by SoC's rst.
+        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin)
+
+        # USB clock
+        pll.create_clkout(self.cd_usb, 48e6)
+
+        self.submodules.pll2 = pll2 = S7MMCM(speedgrade=-2)
+        self.comb += pll2.reset.eq(self.rst)
+        pll2.register_clkin(clkin, 100e6)
+        # DVI/HDMI pixel clock
+        pll2.create_clkout(self.cd_dvi, 80e6) # display wants 162e6, but we can underclock
+        platform.add_false_path_constraints(self.cd_sys.clk, pll2.clkin)
 
         self.submodules.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
 
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), with_ethernet=False, with_etherbone=False,
-        with_spi_flash=False, **kwargs):
+    mem_map = {**SoCCore.mem_map, **{
+        # FIXME: ends up as 0x7f000000 in linux
+        "video_framebuffer": 0x3f000000,
+        "usb_ohci":     0xc0000000,
+    }}
+
+    def __init__(self, sys_clk_freq=int(100e6), with_ethernet=True, with_etherbone=False,
+        with_spi_flash=True, **kwargs):
         platform = mnt_rkx7.Platform()
 
         # CRG --------------------------------------------------------------------------------------
@@ -64,7 +93,7 @@ class BaseSoC(SoCCore):
                 phy           = self.ddrphy,
                 module        = IS43TR16512B(sys_clk_freq, "1:4"),
                 size          = 0x40000000,
-                l2_cache_size = kwargs.get("l2_size", 8192),
+                l2_cache_size = kwargs.get("l2_size", 8192), # TBD: is L2 really necessary?
             )
 
         # SPI Flash --------------------------------------------------------------------------------
@@ -79,13 +108,74 @@ class BaseSoC(SoCCore):
                 clock_pads = self.platform.request("eth_clocks"),
                 pads       = self.platform.request("eth"))
             platform.add_platform_command("set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets {{main_ethphy_eth_rx_clk_ibuf}}]")
+            platform.add_platform_command("set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets {{soclinux_ethphy_eth_rx_clk_ibuf}}]")
             if with_ethernet:
-                self.add_ethernet(phy=self.ethphy)
+                self.add_ethernet(phy=self.ethphy, dynamic_ip=True, software_debug=False)
             if with_etherbone:
                 self.add_etherbone(phy=self.ethphy)
 
-        # I2C --------------------------------------------------------------------------------------
-        self.submodules.i2c = I2CMaster(platform.request("i2c"))
+        # GPIO -------------------------------------------------------------------------------------
+        # Controllable as faux "leds"
+        # These are reset pins of various chips
+        # We toggle them in LiteX BIOS
+        reset_signals = platform.request("resets")
+        self.comb += reset_signals.eq(Signal(6, reset=0b111111))
+
+        gpio_signals = platform.request("gpio")
+        self.submodules.leds = GPIOOut(gpio_signals)
+        self.add_csr("leds")
+
+        # Additional I2C Ports ---------------------------------------------------------------------
+        self.submodules.i2c0 = I2CMaster(platform.request("i2c", 0))
+        self.submodules.i2c1 = I2CMaster(platform.request("i2c", 1))
+        self.submodules.i2c2 = I2CMaster(platform.request("i2c", 2))
+
+        # JTAG -------------------------------------------------------------------------------------
+        #self.add_jtagbone()
+
+        # Backlight --------------------------------------------------------------------------------
+        # Motherboard display connector backlight, currently unused (the new backlight signals
+        # are on the 50pin RGB->eDP connector)
+        backlight = platform.request("backlight")
+        self.comb += backlight.en.eq(Signal(reset=1))
+        self.comb += backlight.pwm.eq(Signal(reset=1))
+
+        # eDP --------------------------------------------------------------------------------------
+        self.submodules.videophy = VideoDVIPHY(platform.request("edp"), clock_domain="dvi")
+        self.add_video_framebuffer(phy=self.videophy, timings="1920x1080@rkx7", clock_domain="dvi")
+
+        # HDMI -------------------------------------------------------------------------------------
+        # Untested: 2x VideoDVIPHYs and framebuffers in parallel
+        #self.submodules.videophy = VideoDVIPHY(platform.request("hdmi"), clock_domain="dvi")
+
+        # USB Host ---------------------------------------------------------------------------------
+        self.submodules.usb_ohci = USBOHCI(platform, platform.request("usb"))
+        self.bus.add_slave("usb_ohci_ctrl", self.usb_ohci.wb_ctrl, region=SoCRegion(origin=self.mem_map["usb_ohci"], size=0x100000, cached=False))
+        self.dma_bus.add_master("usb_ohci_dma", master=self.usb_ohci.wb_dma)
+        self.comb += self.cpu.interrupt[16].eq(self.usb_ohci.interrupt)
+
+        # LiteScope UART
+        self.add_uartbone(name="litescope_serial")
+        # LiteScope Analyzer (optional)
+        # analyzer_signals = [
+        #     ulpi_data.din,
+        #     utmi.linestate,
+        #     utmi.txvalid,
+        #     utmi.rxerror,
+        #     utmi.rxvalid,
+        #     usb_ulpi.dir,
+        #     usb_ulpi.stp,
+        #     usb_ulpi.nxt,
+        #     usbh_dbg_state,
+        #     ulpi_dbg_state,
+        #     usb_host_intr,
+        #     usb_host_dbg_intr,
+        #     ]
+        # from litescope import LiteScopeAnalyzer
+        # self.submodules.analyzer = LiteScopeAnalyzer(analyzer_signals,
+        #                                              depth        = 256,
+        #                                              clock_domain = "ulpi",
+        #                                              csr_csv      = "analyzer.csv")
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -96,12 +186,12 @@ def main():
     target_group.add_argument("--build",          action="store_true", help="Build design.")
     target_group.add_argument("--load",           action="store_true", help="Load bitstream.")
     target_group.add_argument("--sys-clk-freq",   default=100e6,       help="System clock frequency.")
-    target_group.add_argument("--with-spi-flash", action="store_true", help="Enable SPI Flash (MMAPed).")
+    target_group.add_argument("--with-spi-flash", default=True, action="store_true", help="Enable SPI Flash (MMAPed).")
     sdopts = target_group.add_mutually_exclusive_group()
     sdopts.add_argument("--with-spi-sdcard",     action="store_true", help="Enable SPI-mode SDCard support.")
-    sdopts.add_argument("--with-sdcard",         action="store_true", help="Enable SDCard support.")
+    sdopts.add_argument("--with-sdcard",         default=True, action="store_true", help="Enable SDCard support.")
     ethopts = target_group.add_mutually_exclusive_group()
-    ethopts.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support.")
+    ethopts.add_argument("--with-ethernet",  default=True, action="store_true", help="Enable Ethernet support.")
     ethopts.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support.")
     builder_args(parser)
     soc_core_args(parser)
@@ -118,6 +208,9 @@ def main():
         soc.add_spi_sdcard()
     if args.with_sdcard:
         soc.add_sdcard()
+
+    args.csr_csv="csr.csv"
+
     builder = Builder(soc, **builder_argdict(args))
     if args.build:
         builder.build()


### PR DESCRIPTION
This is an update for the MNT RKX7 files to make it compatible with the release version (tested in MNT Reform motherboard/carrier). Details: https://source.mnt.re/reform/reform-kintex-som

Hardware Changes from D-1:

- The DDR3 memory routing was completely redone for a less congested layout and avoiding crosstalk. This fixed some address bus errors of the first version.
- The TC358778XBG MIPI encoder was removed. Instead, 24-bit parallel RGB, clocks and extra GPIOs are routed out to a new 50 pin FPC header. This makes the module more flexibly usable.
- We designed a new adapter PCB featuring the Analogix ANX9807 RGB to eDP chip. We are able to successfully drive MNT Reform's eDP Full HD display.
- The TUSB1310ZAY USB3/2 PHY was removed as it is EOL, expensive and there was is no available XHCI host implementation that could drive it. Instead, USB1/2 pads are now driven directly by the FPGA. This works well with the SpinalHDL OHCI host controller which is supported by LiteX.
- 8 FPGA additional pads were broken out to an array of square test points.