### PR TITLE
targets/digilent_arty_z7: add flash region

### DIFF
--- a/litex_boards/targets/digilent_arty_z7.py
+++ b/litex_boards/targets/digilent_arty_z7.py
@@ -84,6 +84,7 @@ class BaseSoC(SoCCore):
                 wishbone     = wb_gp0,
                 base_address = self.mem_map["csr"])
             self.bus.add_master(master=wb_gp0)
+            self.bus.add_region("flash",  SoCRegion(origin=0xFC00_0000, size=0x4_0000, mode="rwx"))
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:


### PR DESCRIPTION
As mentionned in issue #434 arty_z7 board fails to build when `--cpu-type zynq7000` is selected due a missing reset address.
This PR fix this issue by adding flash region.