### PR TITLE
platforms/alinx_axu2cga: adding missing psu_config at platform level

### DIFF
--- a/litex_boards/platforms/alinx_axu2cga.py
+++ b/litex_boards/platforms/alinx_axu2cga.py
@@ -167,6 +167,7 @@ class Platform(Xilinx7SeriesPlatform):
 
     def __init__(self, toolchain="vivado"):
         Xilinx7SeriesPlatform.__init__(self, "xczu2cg-sfvc784-1-e", _io, _connectors, toolchain=toolchain)
+        self.psu_config = psu_config
 
     def create_programmer(self, cable):
         return OpenFPGALoader("axu2cga", cable)


### PR DESCRIPTION
`alinx_axu2cga` build fails with:
```
AttributeError: 'Platform' object has no attribute 'psu_config'
```

This attribute has been added by commit 50654f1b7b43249c90dbd87d9a2ce66f7adeb949 at same time as `psu_config` but seems be lost lost at merge time (maybe a conflict with the commit b53b79821e757a92ed9b7f15d7ebe5ad7a0bbd44)
This PR re-add this attribute to fix build.