### PR TITLE
targets/arduino_mkrvidor4000, avnet_aesku40, isx_im1283, machdyne_krote: Argparse -> LiteXArgumentParser

### DIFF
--- a/litex_boards/targets/arduino_mkrvidor4000.py
+++ b/litex_boards/targets/arduino_mkrvidor4000.py
@@ -7,7 +7,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
-import argparse
 
 from migen import *
 
@@ -72,7 +71,8 @@ class BaseSoC(SoCCore):
 # Build --------------------------------------------------------------------------------------------
 
 def main():
-    parser = argparse.ArgumentParser(description="LiteX SoC on MKR Vidor 4000")
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=arduino_mkrvidor4000.Platform, description="LiteX SoC on MKR Vidor 4000")
     parser.add_argument("--sys-clk-freq",  default=48e6,        help="System clock frequency.")
     args = parser.parse_args()
 

--- a/litex_boards/targets/avnet_aesku40.py
+++ b/litex_boards/targets/avnet_aesku40.py
@@ -7,7 +7,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
-import argparse
 
 from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer
@@ -104,7 +103,8 @@ class BaseSoC(SoCCore):
 # Build --------------------------------------------------------------------------------------------
 
 def main():
-    parser = argparse.ArgumentParser(description="LiteX SoC on AESKU40")
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=avnet_aesku40.Platform, description="LiteX SoC on AESKU40")
     parser.add_argument("--sys-clk-freq",  default=125e6,       help="System clock frequency (default: 125MHz)")
     args = parser.parse_args()
 

--- a/litex_boards/targets/isx_im1283.py
+++ b/litex_boards/targets/isx_im1283.py
@@ -8,7 +8,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
-import argparse
 
 from migen import *
 
@@ -82,7 +81,8 @@ class BaseSoC(SoCCore):
 # Build --------------------------------------------------------------------------------------------
 
 def main():
-    parser = argparse.ArgumentParser(description="LiteX SoC on iM1283")
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=isx_im1283.Platform, description="LiteX SoC on iM1283")
     parser.add_argument("--sys-clk-freq",    default=80e6,                     help="System clock frequency")
     sdopts = parser.add_mutually_exclusive_group()
     sdopts.add_argument("--with-spi-sdcard", action="store_true",              help="Enable SPI-mode SDCard support")

--- a/litex_boards/targets/machdyne_krote.py
+++ b/litex_boards/targets/machdyne_krote.py
@@ -19,7 +19,6 @@
 
 import os
 import sys
-import argparse
 
 from migen import *
 
@@ -109,7 +108,8 @@ class BaseSoC(SoCCore):
 # Build --------------------------------------------------------------------------------------------
 
 def main():
-    parser = argparse.ArgumentParser(description="LiteX SoC on Kr\xf6te")
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=machdyne_krote.Platform, description="LiteX SoC on Kr\xf6te")
     parser.add_argument("--bios-flash-offset", default="0x021000",  help="BIOS offset in SPI Flash (default: 0x21000)")
     parser.add_argument("--sys-clk-freq",      default=50e6,        help="System clock frequency (default: 50MHz)")
     parser.add_argument("--with-led-chaser", action="store_true", help="Enable LED Chaser.")


### PR DESCRIPTION
Some board still using argparse was partly moved to LiteXArgumentParser.
This PR fix this issue by updating these targets.