### PR TITLE
Zybo: Fix for Zynq7000 and use ps7 as submodule for Soft-CPUs

### DIFF
--- a/litex_boards/platforms/digilent_zybo_z7.py
+++ b/litex_boards/platforms/digilent_zybo_z7.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.build.generic_platform import *
-from litex.build.xilinx import Xilinx7SeriesPlatform, VivadoProgrammer
+from litex.build.xilinx import Xilinx7SeriesPlatform, VivadoProgrammer, XilinxPlatform
 
 # IOs ----------------------------------------------------------------------------------------------
 
@@ -80,22 +80,45 @@ _usb_uart_pmod_io = [
 
 _connectors = [
     ("pmoda", "N15 L14 K16 K14 N16 L15 J16 J14"), # XADC
-    ("pmodb", "T20 U20 V20 W20 Y18 Y19 W18 W19"),
+    ("pmodb", "V8 W8 U7 V7 Y7 Y6 V6 W6"),
     ("pmodc", "V15 W15 T11 T10 W14 Y14 T12 U12"),
     ("pmodd", "T14 T15 P14 R14 U14 U15 V17 V18"),
     ("pmode", "V12 W16 J15 H15 V13 U17 T17 Y17"),
 ]
 
+ps7_config = {
+    "z7-20" : {
+        "PCW_UIPARAM_DDR_PARTNO " : "MT41K256M16 RE-125",
+        "PCW_FPGA_FCLK0_ENABLE " : "1",
+        "PCW_UART1_BAUD_RATE " :  "115200",
+        "PCW_EN_UART1 " :  "1",
+        "PCW_UART1_PERIPHERAL_ENABLE " :  "1",
+        "PCW_UART1_UART1_IO " :  "MIO 48 .. 49",
+        "PCW_PRESET_BANK1_VOLTAGE " : "LVCMOS 1.8V",
+        "PCW_USE_M_AXI_GP0 " : "1",
+        "PCW_USE_S_AXI_GP0 " : "1",
+        "PCW_USB0_PERIPHERAL_ENABLE " : "1",
+        "PCW_USB0_USB0_IO " : "MIO 28 .. 39", 
+        "PCW_USB0_RESET_ENABLE " : "1",
+        "PCW_USB0_RESET_IO " : "MIO 46",
+        "PCW_EN_USB0 " : "1"
+    }
+}
 # Platform -----------------------------------------------------------------------------------------
 
 class Platform(Xilinx7SeriesPlatform):
     default_clk_name   = "clk125"
     default_clk_period = 1e9/125e6
 
-    def __init__(self, toolchain="vivado"):
-        Xilinx7SeriesPlatform.__init__(self, "xc7z010-clg400-1", _io,  _connectors, toolchain=toolchain)
+    def __init__(self, variant="z7-20", toolchain="vivado"):
+        device = {
+            "z7-10": "xc7z010-clg400-1",
+            "z7-20": "xc7z020-clg400-1"
+        }[variant]
+        XilinxPlatform.__init__(self, device, _io,  _connectors, toolchain=toolchain)
         self.add_extension(_ps7_io)
         self.add_extension(_usb_uart_pmod_io)
+        self.ps7_config = ps7_config[variant]
 
     def create_programmer(self):
         return VivadoProgrammer()

--- a/litex_boards/platforms/digilent_zybo_z7.py
+++ b/litex_boards/platforms/digilent_zybo_z7.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.build.generic_platform import *
-from litex.build.xilinx import Xilinx7SeriesPlatform, VivadoProgrammer, XilinxPlatform
+from litex.build.xilinx import Xilinx7SeriesPlatform, VivadoProgrammer
 
 # IOs ----------------------------------------------------------------------------------------------
 
@@ -80,7 +80,7 @@ _usb_uart_pmod_io = [
 
 _connectors = [
     ("pmoda", "N15 L14 K16 K14 N16 L15 J16 J14"), # XADC
-    ("pmodb", "V8 W8 U7 V7 Y7 Y6 V6 W6"),
+    ("pmodb", "V8  W8  U7  V7  Y7  Y6  V6  W6"),
     ("pmodc", "V15 W15 T11 T10 W14 Y14 T12 U12"),
     ("pmodd", "T14 T15 P14 R14 U14 U15 V17 V18"),
     ("pmode", "V12 W16 J15 H15 V13 U17 T17 Y17"),
@@ -88,20 +88,20 @@ _connectors = [
 
 ps7_config = {
     "z7-20" : {
-        "PCW_UIPARAM_DDR_PARTNO " : "MT41K256M16 RE-125",
-        "PCW_FPGA_FCLK0_ENABLE " : "1",
-        "PCW_UART1_BAUD_RATE " :  "115200",
-        "PCW_EN_UART1 " :  "1",
-        "PCW_UART1_PERIPHERAL_ENABLE " :  "1",
-        "PCW_UART1_UART1_IO " :  "MIO 48 .. 49",
-        "PCW_PRESET_BANK1_VOLTAGE " : "LVCMOS 1.8V",
-        "PCW_USE_M_AXI_GP0 " : "1",
-        "PCW_USE_S_AXI_GP0 " : "1",
-        "PCW_USB0_PERIPHERAL_ENABLE " : "1",
-        "PCW_USB0_USB0_IO " : "MIO 28 .. 39", 
-        "PCW_USB0_RESET_ENABLE " : "1",
-        "PCW_USB0_RESET_IO " : "MIO 46",
-        "PCW_EN_USB0 " : "1"
+        "PCW_UIPARAM_DDR_PARTNO"        : "MT41K256M16 RE-125",
+        "PCW_FPGA_FCLK0_ENABLE"         : "1",
+        "PCW_UART1_BAUD_RATE"           : "115200",
+        "PCW_EN_UART1"                  : "1",
+        "PCW_UART1_PERIPHERAL_ENABLE"   : "1",
+        "PCW_UART1_UART1_IO"            : "MIO 48 .. 49",
+        "PCW_PRESET_BANK1_VOLTAGE"      : "LVCMOS 1.8V",
+        "PCW_USE_M_AXI_GP0"             : "1",
+        "PCW_USE_S_AXI_GP0"             : "1",
+        "PCW_USB0_PERIPHERAL_ENABLE"    : "1",
+        "PCW_USB0_USB0_IO"              : "MIO 28 .. 39",
+        "PCW_USB0_RESET_ENABLE"         : "1",
+        "PCW_USB0_RESET_IO"             : "MIO 46",
+        "PCW_EN_USB0"                   : "1"
     }
 }
 # Platform -----------------------------------------------------------------------------------------
@@ -115,7 +115,7 @@ class Platform(Xilinx7SeriesPlatform):
             "z7-10": "xc7z010-clg400-1",
             "z7-20": "xc7z020-clg400-1"
         }[variant]
-        XilinxPlatform.__init__(self, device, _io,  _connectors, toolchain=toolchain)
+        Xilinx7SeriesPlatform.__init__(self, device, _io,  _connectors, toolchain=toolchain)
         self.add_extension(_ps7_io)
         self.add_extension(_usb_uart_pmod_io)
         self.ps7_config = ps7_config[variant]

--- a/litex_boards/targets/xilinx_zybo_z7.py
+++ b/litex_boards/targets/xilinx_zybo_z7.py
@@ -170,15 +170,10 @@ class BaseSoC(SoCCore):
 
 def main():
     from litex.build.parser import LiteXArgumentParser
-    parser = LiteXArgumentParser(description="LiteX SoC on Zybo Z7")
-    target_group = parser.add_argument_group(title="Target options")
-    target_group.add_argument("--build",        action="store_true", help="Build design.")
-    target_group.add_argument("--load",         action="store_true", help="Load bitstream.")
-    target_group.add_argument("--sys-clk-freq", default=125e6,       help="System clock frequency.")
-    target_group.add_argument("--variant",      default="z7-10",     help="Board variant (z7-10 or z7-20).")
-    target_group.add_argument("--with-ps7",     action="store_true", help="Add the PS7 as slave for soft CPUs.")
-    builder_args(parser)
-    soc_core_args(parser)
+    parser = LiteXArgumentParser(platform=digilent_zybo_z7.Platform, description="LiteX SoC on Zybo Z7")
+    parser.add_target_argument("--sys-clk-freq",    default=125e6, type=float,  help="System clock frequency.")
+    parser.add_target_argument("--variant",         default="z7-10",            help="Board variant (z7-10 or z7-20).")
+    parser.add_target_argument("--with-ps7",        action="store_true",        help="Add the PS7 as slave for soft CPUs.")
     args = parser.parse_args()
 
     soc = BaseSoC(

--- a/litex_boards/targets/xilinx_zybo_z7.py
+++ b/litex_boards/targets/xilinx_zybo_z7.py
@@ -19,18 +19,16 @@ from litex.soc.cores.clock import *
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
 from litex.soc.cores.led import LedChaser
-
+from litex.soc.integration.soc import SoCRegion 
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(LiteXModule):
     def __init__(self, platform, sys_clk_freq, use_ps7_clk=False):
         self.rst    = Signal()
         self.cd_sys = ClockDomain()
-
         # # #
 
         if use_ps7_clk:
-            assert sys_clk_freq == 100e6
             self.comb += ClockSignal("sys").eq(ClockSignal("ps7"))
             self.comb += ResetSignal("sys").eq(ResetSignal("ps7") | self.rst)
         else:
@@ -43,55 +41,226 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=100e6, with_led_chaser=True, **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), variant="z7-10", with_ps7=False, with_led_chaser=True, **kwargs):
         platform = digilent_zybo_z7.Platform()
-
+        self.builder = None
         # CRG --------------------------------------------------------------------------------------
-        self.crg = _CRG(platform, sys_clk_freq)
+        use_ps7_clk = (kwargs.get("cpu_type", None) == "zynq7000")
+        self.crg = _CRG(platform, sys_clk_freq, use_ps7_clk)
 
         # SoCCore ----------------------------------------------------------------------------------
         if kwargs["uart_name"] == "serial":
             kwargs["uart_name"] = "usb_uart" # Use USB-UART Pmod on JB.
+        if kwargs.get("cpu_type", None) == "zynq7000":
+            kwargs["integrated_sram_size"] = 0x0
+            kwargs["with_uart"] = False
+            self.mem_map = {
+                'csr': 0x4000_0000,  # Zynq GP0 default
+            }
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Zybo Z7", **kwargs)
-
+        
         # Zynq7000 Integration ---------------------------------------------------------------------
         if kwargs.get("cpu_type", None) == "zynq7000":
-            # Get and set the pre-generated .xci FIXME: change location? add it to the repository?
-            os.system("wget https://github.com/litex-hub/litex-boards/files/8339591/zybo_z7_ps7.txt)")
-            os.makedirs("xci", exist_ok=True)
-            os.system("mv zybo_z7_ps7.txt xci/zybo_z7_ps7.xci")
-            self.cpu.set_ps7_xci("xci/zybo_z7_ps7.xci")
+            self.cpu.use_rom = True
+            
+            if variant == "z7-10":
+                # Get and set the pre-generated .xci FIXME: change location? add it to the repository? Make config
+                os.makedirs("xci", exist_ok=True)
+                os.system("wget https://github.com/litex-hub/litex-boards/files/8339591/zybo_z7_ps7.txt")
+                os.system("mv zybo_z7_ps7.txt xci/zybo_z7_ps7.xci")
+                self.cpu.set_ps7_xci("xci/zybo_z7_ps7.xci")
+            else: 
+                self.cpu.set_ps7(name="ps", config = platform.ps7_config)
 
-            # Connect AXI GP0 to the SoC with base address of 0x43c00000 (default one)
+            # Connect AXI GP0 to the SoC with base address of 0x40000000 (default one)
             wb_gp0  = wishbone.Interface()
             self.submodules += axi.AXI2Wishbone(
                 axi          = self.cpu.add_axi_gp_master(),
                 wishbone     = wb_gp0,
-                base_address = 0x43c00000)
+                base_address = 0x40000000)
             self.bus.add_master(master=wb_gp0)
-
+            #TODO memory size dependend on board variant
+            self.bus.add_region("sram", SoCRegion(
+                origin = self.cpu.mem_map["sram"],
+                size   = 512 * 1024 * 1024 - self.cpu.mem_map["sram"])
+            )
+            self.bus.add_region("rom", SoCRegion(
+                origin = self.cpu.mem_map["rom"],
+                size   = 256 * 1024 * 1024 // 8,
+                linker = True)
+            )
+            self.constants["CONFIG_CLOCK_FREQUENCY"] = 666666687
+            self.bus.add_region("flash",  SoCRegion(origin=0xFC00_0000, size=0x4_0000, mode="rwx"))
+        # PS7 as Slave Integration ---------------------------------------------------------------------
+        elif with_ps7:
+            #TODO: ps7_slave for each variant
+            if variant == "z7-20":
+                self.add_ps7()
+                self.add_axi_gp_slave()
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:
             self.leds = LedChaser(
                 pads         = platform.request_all("user_led"),
                 sys_clk_freq = sys_clk_freq)
 
+    def finalize(self, *args, **kwargs):
+        super(BaseSoC, self).finalize(*args, **kwargs)
+        if self.cpu_type != "zynq7000":
+            return
+        libxil_path = os.path.join(self.builder.software_dir, 'libxil')
+        os.makedirs(os.path.realpath(libxil_path), exist_ok=True)
+        lib = os.path.join(libxil_path, 'embeddedsw')
+        if not os.path.exists(lib):
+            os.system("git clone --depth 1 https://github.com/Xilinx/embeddedsw {}".format(lib))
+
+        os.makedirs(os.path.realpath(self.builder.include_dir), exist_ok=True)
+        for header in [
+            'XilinxProcessorIPLib/drivers/uartps/src/xuartps_hw.h',
+            'lib/bsp/standalone/src/common/xil_types.h',
+            'lib/bsp/standalone/src/common/xil_assert.h',
+            'lib/bsp/standalone/src/common/xil_io.h',
+            'lib/bsp/standalone/src/common/xil_printf.h',
+            'lib/bsp/standalone/src/common/xstatus.h',
+            'lib/bsp/standalone/src/common/xdebug.h',
+            'lib/bsp/standalone/src/arm/cortexa9/xpseudo_asm.h',
+            'lib/bsp/standalone/src/arm/cortexa9/xreg_cortexa9.h',
+            'lib/bsp/standalone/src/arm/cortexa9/xil_cache.h',
+            'lib/bsp/standalone/src/arm/cortexa9/xparameters_ps.h',
+            'lib/bsp/standalone/src/arm/cortexa9/xil_errata.h',
+            'lib/bsp/standalone/src/arm/cortexa9/xtime_l.h',
+            'lib/bsp/standalone/src/arm/common/xil_exception.h',
+            'lib/bsp/standalone/src/arm/common/gcc/xpseudo_asm_gcc.h',
+        ]:
+            shutil.copy(os.path.join(lib, header), self.builder.include_dir)
+        write_to_file(os.path.join(self.builder.include_dir, 'bspconfig.h'),
+                      '#define FPU_HARD_FLOAT_ABI_ENABLED 1')
+        write_to_file(os.path.join(self.builder.include_dir, 'xparameters.h'), '''
+#ifndef __XPARAMETERS_H
+#define __XPARAMETERS_H
+
+#include "xparameters_ps.h"
+
+#define STDOUT_BASEADDRESS            XPS_UART1_BASEADDR
+#define XPAR_PS7_DDR_0_S_AXI_BASEADDR 0x00100000
+#define XPAR_PS7_DDR_0_S_AXI_HIGHADDR 0x3FFFFFFF
+#endif
+''')
+
+
+    def add_ps7(self):
+        ps7_tcl = []
+        ps7_name = "processing_system"
+        ps7_tcl.append(f"set ps7 [create_ip -vendor xilinx.com -name processing_system7 -module_name {ps7_name}]")
+        ps7_tcl.append("set_property -dict [list \\")
+        for config, value in self.platform.ps7_config.items():
+            ps7_tcl.append("CONFIG.{} {} \\".format(config, '{{' + str(value) + '}}'))
+        ps7_tcl.append(f"] [get_ips {ps7_name}]")
+        ps7_tcl += [
+                f"upgrade_ip [get_ips {ps7_name}]",
+                f"generate_target all [get_ips {ps7_name}]",
+                f"synth_ip [get_ips {ps7_name}]"
+            ]
+        
+        self.platform.toolchain.pre_synthesis_commands += ps7_tcl
+
+    def add_axi_gp_slave(self):
+        axi_gpn = axi.AXIInterface(data_width=32, address_width=32, id_width=12)
+        
+        #TODO: better mapping/ Different Regions for IOP and DDR
+        aw_address = Signal(32)
+        ar_address = Signal(32)
+        #FIXME: define offsets with csr register?
+
+        self.comb += If(axi_gpn.aw.addr < 0x1ffbffff,
+            ## DDR
+            aw_address.eq(axi_gpn.aw.addr + 0x0008_0000)
+        ).Else(
+                ## IOP Register
+               aw_address.eq(axi_gpn.aw.addr  + 0xe000_0000))
+        self.comb += If(axi_gpn.ar.addr < 0x1ffbffff,
+            ## DDR
+            ar_address.eq(axi_gpn.ar.addr  + 0x0008_0000)
+        ).Else(
+                ## IOP Register
+               ar_address.eq(axi_gpn.ar.addr + 0xe000_0000))
+
+        # generate instance of ps7 with ports for axi_s_gp0
+        ps7_axi_s_gp0 = Instance("processing_system" ,
+            #o_S_AXI_GP0_ARESETN = axi_gpn.a.resetn,
+            o_S_AXI_GP0_ARREADY = axi_gpn.ar.ready,
+            o_S_AXI_GP0_AWREADY = axi_gpn.aw.ready,
+            o_S_AXI_GP0_BVALID = axi_gpn.b.valid,
+            o_S_AXI_GP0_RLAST = axi_gpn.r.last,
+            o_S_AXI_GP0_RVALID = axi_gpn.r.valid,
+            o_S_AXI_GP0_WREADY = axi_gpn.w.ready,  
+            o_S_AXI_GP0_BRESP = axi_gpn.b.resp,
+            o_S_AXI_GP0_RRESP = axi_gpn.r.resp,
+            o_S_AXI_GP0_RDATA = axi_gpn.r.data,
+            o_S_AXI_GP0_BID = axi_gpn.b.id,
+            o_S_AXI_GP0_RID = axi_gpn.r.id,
+            
+            i_S_AXI_GP0_ACLK = ClockSignal("sys"),
+            i_S_AXI_GP0_ARVALID = axi_gpn.ar.valid,
+            i_S_AXI_GP0_AWVALID = axi_gpn.aw.valid,
+            i_S_AXI_GP0_BREADY = axi_gpn.b.ready,
+            i_S_AXI_GP0_RREADY = axi_gpn.r.ready,
+            i_S_AXI_GP0_WLAST = axi_gpn.w.last,
+            i_S_AXI_GP0_WVALID = axi_gpn.w.valid,
+            i_S_AXI_GP0_ARBURST = axi_gpn.ar.burst,
+            i_S_AXI_GP0_ARLOCK = axi_gpn.ar.lock,
+            i_S_AXI_GP0_ARSIZE = axi_gpn.ar.size,
+            i_S_AXI_GP0_AWBURST = axi_gpn.aw.burst,
+            i_S_AXI_GP0_AWLOCK = axi_gpn.aw.lock,
+            i_S_AXI_GP0_AWSIZE = axi_gpn.aw.size,
+            i_S_AXI_GP0_ARPROT = axi_gpn.ar.prot,
+            i_S_AXI_GP0_AWPROT = axi_gpn.aw.prot,
+            i_S_AXI_GP0_ARADDR = ar_address,
+            i_S_AXI_GP0_AWADDR = aw_address,
+            i_S_AXI_GP0_WDATA = axi_gpn.w.data,
+            i_S_AXI_GP0_ARCACHE = axi_gpn.ar.cache,
+            i_S_AXI_GP0_ARLEN = axi_gpn.ar.len,
+            i_S_AXI_GP0_ARQOS = axi_gpn.ar.qos,
+            i_S_AXI_GP0_AWCACHE = axi_gpn.aw.cache,
+            i_S_AXI_GP0_AWLEN = axi_gpn.aw.len,
+            i_S_AXI_GP0_AWQOS = axi_gpn.aw.qos,
+            i_S_AXI_GP0_WSTRB = axi_gpn.w.strb,
+            i_S_AXI_GP0_ARID = axi_gpn.ar.id,
+            i_S_AXI_GP0_AWID = axi_gpn.aw.id,
+            i_S_AXI_GP0_WID = axi_gpn.w.id,
+        )
+
+        self.specials += ps7_axi_s_gp0
+        self.bus.add_slave(name="main_ram",slave=axi_gpn, region=SoCRegion(origin=0x4000_0000, size=0x2000_0000, mode="rwx"))
+
+
 # Build --------------------------------------------------------------------------------------------
 
 def main():
-    from litex.build.parser import LiteXArgumentParser
-    parser = LiteXArgumentParser(platform=digilent_zybo_z7.Platform, description="LiteX SoC on Zybo Z7.")
-    parser.add_target_argument("--sys-clk-freq", default=100e6, type=float, help="System clock frequency.")
+    from litex.soc.integration.soc import LiteXSoCArgumentParser
+    parser = LiteXSoCArgumentParser(description="LiteX SoC on Zybo Z7")
+    target_group = parser.add_argument_group(title="Target options")
+    target_group.add_argument("--build",        action="store_true", help="Build design.")
+    target_group.add_argument("--load",         action="store_true", help="Load bitstream.")
+    target_group.add_argument("--sys-clk-freq", default=125e6,       help="System clock frequency.")
+    target_group.add_argument("--variant",      default="z7-10",     help="Board variant (z7-10 or z7-20).")
+    target_group.add_argument("--with-ps7",     action="store_true", help="Add the PS as slave.")
+    builder_args(parser)
+    soc_core_args(parser)
     args = parser.parse_args()
 
     soc = BaseSoC(
-        sys_clk_freq = args.sys_clk_freq,
-        **parser.soc_argdict
+        sys_clk_freq = int(float(args.sys_clk_freq)),
+        variant = args.variant,
+        with_ps7 = args.with_ps7,
+        **soc_core_argdict(args)
     )
-    builder = Builder(soc, **parser.builder_argdict)
+    builder = Builder(soc, **builder_argdict(args))
+    if args.cpu_type == "zynq7000":
+        soc.builder = builder
+        builder.add_software_package('libxil')
+        builder.add_software_library('libxil')
     if args.build:
         builder.build(**parser.toolchain_argdict)
-
     if args.load:
         prog = soc.platform.create_programmer()
         prog.load_bitstream(builder.get_bitstream_filename(mode="sram"), device=1)

--- a/litex_boards/targets/xilinx_zybo_z7.py
+++ b/litex_boards/targets/xilinx_zybo_z7.py
@@ -19,7 +19,9 @@ from litex.soc.cores.clock import *
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
 from litex.soc.cores.led import LedChaser
-from litex.soc.integration.soc import SoCRegion 
+from litex.soc.integration.soc import SoCRegion
+
+from litex.soc.cores import cpu
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(LiteXModule):
@@ -29,11 +31,11 @@ class _CRG(LiteXModule):
         # # #
 
         if use_ps7_clk:
-            self.comb += ClockSignal("sys").eq(ClockSignal("ps7"))
-            self.comb += ResetSignal("sys").eq(ResetSignal("ps7") | self.rst)
+            self.comb   +=  ClockSignal("sys").eq(ClockSignal("ps7"))
+            self.comb   +=  ResetSignal("sys").eq(ResetSignal("ps7") | self.rst)
         else:
-            self.pll = pll = S7PLL(speedgrade=-1)
-            self.comb += pll.reset.eq(self.rst)
+            self.pll    =   pll = S7PLL(speedgrade=-1)
+            self.comb   +=  pll.reset.eq(self.rst)
             pll.register_clkin(platform.request("clk125"), 125e6)
             pll.create_clkout(self.cd_sys, sys_clk_freq)
             platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
@@ -41,12 +43,12 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=int(100e6), variant="z7-10", with_ps7=False, with_led_chaser=True, **kwargs):
+    def __init__(self, sys_clk_freq=100e6, variant="z7-10", with_ps7=False, with_led_chaser=True, **kwargs):
         platform = digilent_zybo_z7.Platform()
-        self.builder = None
+        self.builder    = None
         # CRG --------------------------------------------------------------------------------------
-        use_ps7_clk = (kwargs.get("cpu_type", None) == "zynq7000")
-        self.crg = _CRG(platform, sys_clk_freq, use_ps7_clk)
+        use_ps7_clk     = (kwargs.get("cpu_type", None) == "zynq7000")
+        self.crg        = _CRG(platform, sys_clk_freq, use_ps7_clk)
 
         # SoCCore ----------------------------------------------------------------------------------
         if kwargs["uart_name"] == "serial":
@@ -58,18 +60,17 @@ class BaseSoC(SoCCore):
                 'csr': 0x4000_0000,  # Zynq GP0 default
             }
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Zybo Z7", **kwargs)
-        
+
         # Zynq7000 Integration ---------------------------------------------------------------------
         if kwargs.get("cpu_type", None) == "zynq7000":
             self.cpu.use_rom = True
-            
             if variant == "z7-10":
                 # Get and set the pre-generated .xci FIXME: change location? add it to the repository? Make config
                 os.makedirs("xci", exist_ok=True)
                 os.system("wget https://github.com/litex-hub/litex-boards/files/8339591/zybo_z7_ps7.txt")
                 os.system("mv zybo_z7_ps7.txt xci/zybo_z7_ps7.xci")
                 self.cpu.set_ps7_xci("xci/zybo_z7_ps7.xci")
-            else: 
+            else:
                 self.cpu.set_ps7(name="ps", config = platform.ps7_config)
 
             # Connect AXI GP0 to the SoC with base address of 0x40000000 (default one)
@@ -90,13 +91,32 @@ class BaseSoC(SoCCore):
                 linker = True)
             )
             self.constants["CONFIG_CLOCK_FREQUENCY"] = 666666687
-            self.bus.add_region("flash",  SoCRegion(origin=0xFC00_0000, size=0x4_0000, mode="rwx"))
+            self.bus.add_region("flash", SoCRegion(
+                origin = 0xFC00_0000,
+                size = 0x4_0000,
+                mode = "rwx")
+            )
+
         # PS7 as Slave Integration ---------------------------------------------------------------------
         elif with_ps7:
-            #TODO: ps7_slave for each variant
             if variant == "z7-20":
-                self.add_ps7()
-                self.add_axi_gp_slave()
+                cpu_cls = cpu.CPUS["zynq7000"]
+                zynq    = cpu_cls(self.platform, "standard") # zynq7000 has no variants
+                zynq.set_ps7(name="ps", config = platform.ps7_config)
+                axi_gp_slave0   = zynq.add_axi_gp_slave(clock_domain = self.crg.cd_sys.name)
+                self.submodules += zynq
+                self.bus.add_slave(
+                    name="ps",slave=axi_gp_slave0,
+                    region=SoCRegion(
+                        origin=0x2000_0000,
+                        size=0x2000_0000,
+                        mode="rwx"
+                    )
+                )
+            else:
+                #TODO: make config for zybo-z7-10
+                raise NotImplementedError
+
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:
             self.leds = LedChaser(
@@ -146,110 +166,23 @@ class BaseSoC(SoCCore):
 #endif
 ''')
 
-
-    def add_ps7(self):
-        ps7_tcl = []
-        ps7_name = "processing_system"
-        ps7_tcl.append(f"set ps7 [create_ip -vendor xilinx.com -name processing_system7 -module_name {ps7_name}]")
-        ps7_tcl.append("set_property -dict [list \\")
-        for config, value in self.platform.ps7_config.items():
-            ps7_tcl.append("CONFIG.{} {} \\".format(config, '{{' + str(value) + '}}'))
-        ps7_tcl.append(f"] [get_ips {ps7_name}]")
-        ps7_tcl += [
-                f"upgrade_ip [get_ips {ps7_name}]",
-                f"generate_target all [get_ips {ps7_name}]",
-                f"synth_ip [get_ips {ps7_name}]"
-            ]
-        
-        self.platform.toolchain.pre_synthesis_commands += ps7_tcl
-
-    def add_axi_gp_slave(self):
-        axi_gpn = axi.AXIInterface(data_width=32, address_width=32, id_width=12)
-        
-        #TODO: better mapping/ Different Regions for IOP and DDR
-        aw_address = Signal(32)
-        ar_address = Signal(32)
-        #FIXME: define offsets with csr register?
-
-        self.comb += If(axi_gpn.aw.addr < 0x1ffbffff,
-            ## DDR
-            aw_address.eq(axi_gpn.aw.addr + 0x0008_0000)
-        ).Else(
-                ## IOP Register
-               aw_address.eq(axi_gpn.aw.addr  + 0xe000_0000))
-        self.comb += If(axi_gpn.ar.addr < 0x1ffbffff,
-            ## DDR
-            ar_address.eq(axi_gpn.ar.addr  + 0x0008_0000)
-        ).Else(
-                ## IOP Register
-               ar_address.eq(axi_gpn.ar.addr + 0xe000_0000))
-
-        # generate instance of ps7 with ports for axi_s_gp0
-        ps7_axi_s_gp0 = Instance("processing_system" ,
-            #o_S_AXI_GP0_ARESETN = axi_gpn.a.resetn,
-            o_S_AXI_GP0_ARREADY = axi_gpn.ar.ready,
-            o_S_AXI_GP0_AWREADY = axi_gpn.aw.ready,
-            o_S_AXI_GP0_BVALID = axi_gpn.b.valid,
-            o_S_AXI_GP0_RLAST = axi_gpn.r.last,
-            o_S_AXI_GP0_RVALID = axi_gpn.r.valid,
-            o_S_AXI_GP0_WREADY = axi_gpn.w.ready,  
-            o_S_AXI_GP0_BRESP = axi_gpn.b.resp,
-            o_S_AXI_GP0_RRESP = axi_gpn.r.resp,
-            o_S_AXI_GP0_RDATA = axi_gpn.r.data,
-            o_S_AXI_GP0_BID = axi_gpn.b.id,
-            o_S_AXI_GP0_RID = axi_gpn.r.id,
-            
-            i_S_AXI_GP0_ACLK = ClockSignal("sys"),
-            i_S_AXI_GP0_ARVALID = axi_gpn.ar.valid,
-            i_S_AXI_GP0_AWVALID = axi_gpn.aw.valid,
-            i_S_AXI_GP0_BREADY = axi_gpn.b.ready,
-            i_S_AXI_GP0_RREADY = axi_gpn.r.ready,
-            i_S_AXI_GP0_WLAST = axi_gpn.w.last,
-            i_S_AXI_GP0_WVALID = axi_gpn.w.valid,
-            i_S_AXI_GP0_ARBURST = axi_gpn.ar.burst,
-            i_S_AXI_GP0_ARLOCK = axi_gpn.ar.lock,
-            i_S_AXI_GP0_ARSIZE = axi_gpn.ar.size,
-            i_S_AXI_GP0_AWBURST = axi_gpn.aw.burst,
-            i_S_AXI_GP0_AWLOCK = axi_gpn.aw.lock,
-            i_S_AXI_GP0_AWSIZE = axi_gpn.aw.size,
-            i_S_AXI_GP0_ARPROT = axi_gpn.ar.prot,
-            i_S_AXI_GP0_AWPROT = axi_gpn.aw.prot,
-            i_S_AXI_GP0_ARADDR = ar_address,
-            i_S_AXI_GP0_AWADDR = aw_address,
-            i_S_AXI_GP0_WDATA = axi_gpn.w.data,
-            i_S_AXI_GP0_ARCACHE = axi_gpn.ar.cache,
-            i_S_AXI_GP0_ARLEN = axi_gpn.ar.len,
-            i_S_AXI_GP0_ARQOS = axi_gpn.ar.qos,
-            i_S_AXI_GP0_AWCACHE = axi_gpn.aw.cache,
-            i_S_AXI_GP0_AWLEN = axi_gpn.aw.len,
-            i_S_AXI_GP0_AWQOS = axi_gpn.aw.qos,
-            i_S_AXI_GP0_WSTRB = axi_gpn.w.strb,
-            i_S_AXI_GP0_ARID = axi_gpn.ar.id,
-            i_S_AXI_GP0_AWID = axi_gpn.aw.id,
-            i_S_AXI_GP0_WID = axi_gpn.w.id,
-        )
-
-        self.specials += ps7_axi_s_gp0
-        self.bus.add_slave(name="main_ram",slave=axi_gpn, region=SoCRegion(origin=0x4000_0000, size=0x2000_0000, mode="rwx"))
-
-
 # Build --------------------------------------------------------------------------------------------
 
 def main():
-    from litex.soc.integration.soc import LiteXSoCArgumentParser
-    parser = LiteXSoCArgumentParser(description="LiteX SoC on Zybo Z7")
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(description="LiteX SoC on Zybo Z7")
     target_group = parser.add_argument_group(title="Target options")
     target_group.add_argument("--build",        action="store_true", help="Build design.")
     target_group.add_argument("--load",         action="store_true", help="Load bitstream.")
     target_group.add_argument("--sys-clk-freq", default=125e6,       help="System clock frequency.")
     target_group.add_argument("--variant",      default="z7-10",     help="Board variant (z7-10 or z7-20).")
-    target_group.add_argument("--with-ps7",     action="store_true", help="Add the PS as slave.")
+    target_group.add_argument("--with-ps7",     action="store_true", help="Add the PS7 as slave for soft CPUs.")
     builder_args(parser)
     soc_core_args(parser)
     args = parser.parse_args()
 
     soc = BaseSoC(
-        sys_clk_freq = int(float(args.sys_clk_freq)),
+        sys_clk_freq = args.sys_clk_freq,
         variant = args.variant,
         with_ps7 = args.with_ps7,
         **soc_core_argdict(args)


### PR DESCRIPTION
(This pull-request is the second attempt of  https://github.com/litex-hub/litex-boards/pull/423)
As mentioned in the old pull-request the Zynq7000 could not be build on the Zybo-Z7-20.  To fix this I added two variants for the Zybo platform digilent_zybo_z7.py, so that the correct fpga device is selected. 
Furthermore I added a config for the ps7. As I don't have a zybo-z7-10, I only made a config for the z7-20 and the target is still using the downloaded .xci file for z7-10. 

For the target I fixed the Zynq7000 integration by introducing Memory Regions and a finalize-function like its done for the arty-z7. 

Additionally I added the "--with-ps7" option, which initializes the processing_system of the zybo board and connects it to a soft CPU via the S_GP0 AXI bus, so that all the Modules connected to this bus (UART, DDR, ...) can be accessed by the soft CPU.
Currently I only tested the DDR and added it as the main-ram, but in the future I want to use more of the Peripherals.

Issues:
-  test on zybo-z7-10
- currently all the slaves connected to the S_GP0 Bus are in the same SoC Region. It would be beneficial to have two regions for DDR and IO.
-  add software support for IO