### PR TITLE
fix: Basys3 V_sync is pin R19

### DIFF
--- a/litex_boards/platforms/digilent_basys3.py
+++ b/litex_boards/platforms/digilent_basys3.py
@@ -67,7 +67,7 @@ _io = [
     # VGA
      ("vga", 0,
         Subsignal("hsync_n", Pins("P19")),
-        Subsignal("vsync_n", Pins("R18")),
+        Subsignal("vsync_n", Pins("R19")),
         Subsignal("r", Pins("G19 H19 J19 N19")),
         Subsignal("g", Pins("J17 H17 G17 D17")),
         Subsignal("b", Pins("N18 L18 K18 J18")),


### PR DESCRIPTION
I was running VGA on my Basys 3 board and it wasn't working
Debugging I realized that the Vsync pin was wrong and changing it worked

We can see the correct pin [on contrains](https://github.com/Digilent/digilent-xdc/blob/master/Basys-3-Master.xdc#LL129C34-L129C37) or in [page 11 of docs](https://digilent.com/reference/_media/basys3:basys3_rm.pdf)
![image](https://user-images.githubusercontent.com/32439070/203547323-98d35e02-b33c-43d4-bd50-306dac6ec8e2.png)
