### PR TITLE
Reintroduce original Zybo + HDMI addition

### DIFF
--- a/litex_boards/platforms/digilent_zybo_z7.py
+++ b/litex_boards/platforms/digilent_zybo_z7.py
@@ -1,7 +1,7 @@
 #
 # This file is part of LiteX-Boards.
 #
-# Copyright (c) 2019-2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2019-2020 Florent Kermarrec <florent@enjoy-digital.fr>, Oliver Szabo <16oliver16@gmail.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.build.generic_platform import *
@@ -9,9 +9,55 @@ from litex.build.xilinx import Xilinx7SeriesPlatform, VivadoProgrammer
 
 # IOs ----------------------------------------------------------------------------------------------
 
-_io = [
+_io_z7 = [
     # Clk / Rst
     ("clk125", 0, Pins("K17"), IOStandard("LVCMOS33")),
+
+    # Leds
+    ("user_led", 0, Pins("M14"), IOStandard("LVCMOS33")),
+    ("user_led", 1, Pins("M15"), IOStandard("LVCMOS33")),
+    ("user_led", 2, Pins("G14"), IOStandard("LVCMOS33")),
+    ("user_led", 3, Pins("D18"), IOStandard("LVCMOS33")),
+
+    # Switches
+    ("user_sw", 0, Pins("G15"), IOStandard("LVCMOS33")),
+    ("user_sw", 1, Pins("P15"), IOStandard("LVCMOS33")),
+    ("user_sw", 2, Pins("W13"), IOStandard("LVCMOS33")),
+    ("user_sw", 3, Pins("T16"), IOStandard("LVCMOS33")),
+
+    # Buttons
+    ("user_btn", 0, Pins("K18"), IOStandard("LVCMOS33")),
+    ("user_btn", 1, Pins("P16"), IOStandard("LVCMOS33")),
+    ("user_btn", 2, Pins("K19"), IOStandard("LVCMOS33")),
+    ("user_btn", 3, Pins("Y16"), IOStandard("LVCMOS33")),
+
+    # HDMI Out
+    ("hdmi_out", 0,
+        Subsignal("clk_p",   Pins("H16"), IOStandard("TMDS_33")),
+        Subsignal("clk_n",   Pins("H17"), IOStandard("TMDS_33")),
+        Subsignal("data0_p", Pins("D19"), IOStandard("TMDS_33")),
+        Subsignal("data0_n", Pins("D20"), IOStandard("TMDS_33")),
+        Subsignal("data1_p", Pins("C20"), IOStandard("TMDS_33")),
+        Subsignal("data1_n", Pins("B20"), IOStandard("TMDS_33")),
+        Subsignal("data2_p", Pins("B19"), IOStandard("TMDS_33")),
+        Subsignal("data2_n", Pins("A20"), IOStandard("TMDS_33")),
+        Subsignal("scl",     Pins("G17"), IOStandard("LVCMOS33")),
+        Subsignal("sda",     Pins("G18"), IOStandard("LVCMOS33")),
+        Subsignal("cec",     Pins("E19"), IOStandard("LVCMOS33")),
+        Subsignal("hdp",     Pins("E18"), IOStandard("LVCMOS33")),
+    ),    
+    
+    # Serial
+    ("serial", 0,
+        Subsignal("tx", Pins("T17")),
+        Subsignal("rx", Pins("Y17")),
+        IOStandard("LVCMOS33")
+    ),
+]
+
+_io_original = [
+    # Clk / Rst
+    ("clk125", 0, Pins("L16"), IOStandard("LVCMOS33")),
 
     # Leds
     ("user_led", 0, Pins("M14"), IOStandard("LVCMOS33")),
@@ -30,6 +76,22 @@ _io = [
     ("user_btn", 1, Pins("P16"), IOStandard("LVCMOS33")),
     ("user_btn", 2, Pins("V16"), IOStandard("LVCMOS33")),
     ("user_btn", 3, Pins("Y16"), IOStandard("LVCMOS33")),
+
+    # HDMI Out
+    ("hdmi_out", 0,
+        Subsignal("clk_p",   Pins("H16"), IOStandard("TMDS_33")),
+        Subsignal("clk_n",   Pins("H17"), IOStandard("TMDS_33")),
+        Subsignal("data0_p", Pins("D19"), IOStandard("TMDS_33")),
+        Subsignal("data0_n", Pins("D20"), IOStandard("TMDS_33")),
+        Subsignal("data1_p", Pins("C20"), IOStandard("TMDS_33")),
+        Subsignal("data1_n", Pins("B20"), IOStandard("TMDS_33")),
+        Subsignal("data2_p", Pins("B19"), IOStandard("TMDS_33")),
+        Subsignal("data2_n", Pins("A20"), IOStandard("TMDS_33")),
+        Subsignal("scl",     Pins("G17"), IOStandard("LVCMOS33")),
+        Subsignal("sda",     Pins("G18"), IOStandard("LVCMOS33")),
+        Subsignal("cec",     Pins("E19"), IOStandard("LVCMOS33")),
+        Subsignal("hdp",     Pins("E18"), IOStandard("LVCMOS33")),
+    ),
 
     # Serial
     ("serial", 0,
@@ -78,9 +140,17 @@ _usb_uart_pmod_io = [
 
 # Connectors ---------------------------------------------------------------------------------------
 
-_connectors = [
+_connectors_z7 = [
     ("pmoda", "N15 L14 K16 K14 N16 L15 J16 J14"), # XADC
     ("pmodb", "V8  W8  U7  V7  Y7  Y6  V6  W6"),
+    ("pmodc", "V15 W15 T11 T10 W14 Y14 T12 U12"),
+    ("pmodd", "T14 T15 P14 R14 U14 U15 V17 V18"),
+    ("pmode", "V12 W16 J15 H15 V13 U17 T17 Y17"),
+]
+
+_connectors_original = [
+    ("pmoda", "N15 L14 K16 K14 N16 L15 J16 J14"), # XADC
+    ("pmodb", "T20  U20  V20  W20  Y18  Y19  W18  W19"),
     ("pmodc", "V15 W15 T11 T10 W14 Y14 T12 U12"),
     ("pmodd", "T14 T15 P14 R14 U14 U15 V17 V18"),
     ("pmode", "V12 W16 J15 H15 V13 U17 T17 Y17"),
@@ -89,6 +159,22 @@ _connectors = [
 ps7_config = {
     "z7-20" : {
         "PCW_UIPARAM_DDR_PARTNO"        : "MT41K256M16 RE-125",
+        "PCW_FPGA_FCLK0_ENABLE"         : "1",
+        "PCW_UART1_BAUD_RATE"           : "115200",
+        "PCW_EN_UART1"                  : "1",
+        "PCW_UART1_PERIPHERAL_ENABLE"   : "1",
+        "PCW_UART1_UART1_IO"            : "MIO 48 .. 49",
+        "PCW_PRESET_BANK1_VOLTAGE"      : "LVCMOS 1.8V",
+        "PCW_USE_M_AXI_GP0"             : "1",
+        "PCW_USE_S_AXI_GP0"             : "1",
+        "PCW_USB0_PERIPHERAL_ENABLE"    : "1",
+        "PCW_USB0_USB0_IO"              : "MIO 28 .. 39",
+        "PCW_USB0_RESET_ENABLE"         : "1",
+        "PCW_USB0_RESET_IO"             : "MIO 46",
+        "PCW_EN_USB0"                   : "1"
+    },
+    "original" : {
+        "PCW_UIPARAM_DDR_PARTNO"        : "MT41K128M16 RE-125",
         "PCW_FPGA_FCLK0_ENABLE"         : "1",
         "PCW_UART1_BAUD_RATE"           : "115200",
         "PCW_EN_UART1"                  : "1",
@@ -113,9 +199,13 @@ class Platform(Xilinx7SeriesPlatform):
     def __init__(self, variant="z7-20", toolchain="vivado"):
         device = {
             "z7-10": "xc7z010-clg400-1",
-            "z7-20": "xc7z020-clg400-1"
+            "z7-20": "xc7z020-clg400-1",
+            "original": "xc7z010-clg400-1"
         }[variant]
-        Xilinx7SeriesPlatform.__init__(self, device, _io,  _connectors, toolchain=toolchain)
+        if variant == "original":
+            Xilinx7SeriesPlatform.__init__(self, device, _io_original,  _connectors_original, toolchain=toolchain)
+        else:
+            Xilinx7SeriesPlatform.__init__(self, device, _io_z7,  _connectors_z7, toolchain=toolchain)
         self.add_extension(_ps7_io)
         self.add_extension(_usb_uart_pmod_io)
         self.ps7_config = ps7_config[variant]

--- a/litex_boards/targets/xilinx_zybo_z7.py
+++ b/litex_boards/targets/xilinx_zybo_z7.py
@@ -3,7 +3,7 @@
 #
 # This file is part of LiteX-Boards.
 #
-# Copyright (c) 2019-2020 Florent Kermarrec <florent@enjoy-digital.fr>,
+# Copyright (c) 2019-2020 Florent Kermarrec <florent@enjoy-digital.fr>, Oliver Szabo <16oliver16@gmail.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
@@ -59,12 +59,12 @@ class BaseSoC(SoCCore):
             self.mem_map = {
                 'csr': 0x4000_0000,  # Zynq GP0 default
             }
-        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Zybo Z7", **kwargs)
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Zybo Z7/original Zybo", **kwargs)
 
         # Zynq7000 Integration ---------------------------------------------------------------------
         if kwargs.get("cpu_type", None) == "zynq7000":
             self.cpu.use_rom = True
-            if variant == "z7-10":
+            if variant == "z7-10" or variant == "original":
                 # Get and set the pre-generated .xci FIXME: change location? add it to the repository? Make config
                 os.makedirs("xci", exist_ok=True)
                 os.system("wget https://github.com/litex-hub/litex-boards/files/8339591/zybo_z7_ps7.txt")
@@ -99,7 +99,7 @@ class BaseSoC(SoCCore):
 
         # PS7 as Slave Integration ---------------------------------------------------------------------
         elif with_ps7:
-            if variant == "z7-20":
+            if variant == "z7-20" or variant == "original":
                 cpu_cls = cpu.CPUS["zynq7000"]
                 zynq    = cpu_cls(self.platform, "standard") # zynq7000 has no variants
                 zynq.set_ps7(name="ps", config = platform.ps7_config)
@@ -170,9 +170,9 @@ class BaseSoC(SoCCore):
 
 def main():
     from litex.build.parser import LiteXArgumentParser
-    parser = LiteXArgumentParser(platform=digilent_zybo_z7.Platform, description="LiteX SoC on Zybo Z7")
+    parser = LiteXArgumentParser(platform=digilent_zybo_z7.Platform, description="LiteX SoC on Zybo Z7/original Zybo")
     parser.add_target_argument("--sys-clk-freq",    default=125e6, type=float,  help="System clock frequency.")
-    parser.add_target_argument("--variant",         default="z7-10",            help="Board variant (z7-10 or z7-20).")
+    parser.add_target_argument("--variant",         default="z7-10",            help="Board variant (z7-10, z7-20 or original).")
     parser.add_target_argument("--with-ps7",        action="store_true",        help="Add the PS7 as slave for soft CPUs.")
     args = parser.parse_args()
 


### PR DESCRIPTION
This is my modification of files for Zybo Z7 to reintroduce the original Zybo plus I added the HDMI and fixed the pins for buttons on Z7. Im sorry for creating a second pull request but I deleted the original fork so I cant rebase the original pull request.