### PR TITLE
Allow building digilent_arty using f4pga

### DIFF
--- a/litex_boards/targets/digilent_arty.py
+++ b/litex_boards/targets/digilent_arty.py
@@ -91,11 +91,13 @@ class BaseSoC(SoCCore):
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Arty A7", **kwargs)
 
         # XADC -------------------------------------------------------------------------------------
-        self.xadc = XADC()
+        if toolchain == "vivado":
+            self.xadc = XADC()
 
         # DNA --------------------------------------------------------------------------------------
-        self.dna = DNA()
-        self.dna.add_timing_constraints(platform, sys_clk_freq, self.crg.cd_sys.clk)
+        if toolchain == "vivado":
+            self.dna = DNA()
+            self.dna.add_timing_constraints(platform, sys_clk_freq, self.crg.cd_sys.clk)
 
         # DDR3 SDRAM -------------------------------------------------------------------------------
         if not self.integrated_main_ram_size:


### PR DESCRIPTION
Only use XADC() and DNA() functions if vivado is the current toolchain.

I believe that this fixes #466 and https://github.com/chipsalliance/f4pga/issues/648