### PR TITLE
QMTech's CycloneV and XC7A200T

### DIFF
--- a/litex_boards/platforms/qmtech_5cefa5.py
+++ b/litex_boards/platforms/qmtech_5cefa5.py
@@ -1,0 +1,185 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2023 Ioannis Ioannou <roryt@roryt.gr>
+# SPDX-License-Identifier: BSD-2-Clause
+# based on qmtech_5cefa2: 
+# Copyright (c) 2021 Hans Baier <hansfbaier@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.altera import AlteraPlatform
+from litex.build.altera.programmer import USBBlaster
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk
+    ("clk50", 0, Pins("M9"), IOStandard("3.3-V LVTTL")),
+    # rst
+    ("rst_n", 0, Pins("J17"), IOStandard("3.3-V LVTTL")),
+
+    # Button
+    ("key", 0, Pins("J17"),  IOStandard("3.3-V LVTTL")),
+    ("key", 1, Pins("E16"),  IOStandard("3.3-V LVTTL")),
+
+    # SPIFlash (MT25QL128ABA)
+    ("spiflash", 0,
+        # clk
+        Subsignal("cs_n", Pins("R4")),
+        Subsignal("clk",  Pins("V3")),
+        Subsignal("mosi", Pins("AB4")),
+        Subsignal("miso", Pins("AB3")),
+        IOStandard("3.3-V LVTTL"),
+    ),
+
+    # SDR SDRAM
+    ("sdram_clock", 0, Pins("G18"), IOStandard("3.3-V LVTTL")),
+    ("sdram", 0,
+        Subsignal("a",     Pins(
+            " M20 M16 L17 L19 L18 K16 K17 J18 J19 N19 H18 H20")),
+        Subsignal("ba",    Pins("P19 P18")),
+        Subsignal("cs_n",  Pins("P17")),
+        Subsignal("cke",   Pins("G17")),
+        Subsignal("ras_n", Pins("P16")),
+        Subsignal("cas_n", Pins("T19")),
+        Subsignal("we_n",  Pins("U20")),
+        Subsignal("dq", Pins(
+            "AA22 AB22 Y22 Y21 W22 W21 V21 U22 M21 M22 T22 R21 R22 P22 N20 N21 K22 K21 J22 J21 H21 G22 G21 F22 E22 E20 D22 D21 C21 B22 A22 B21 ")),
+        Subsignal("dm", Pins("U21 L22 K20 E21")),
+        IOStandard("3.3-V LVTTL")
+    ),
+
+    ("sdram", 1,
+        Subsignal("a",     Pins(
+            " M20 M16 L17 L19 L18 K16 K17 J18 J19 N19 H18 H20")),
+        Subsignal("ba",    Pins("P19 P18")),
+        Subsignal("cs_n",  Pins("P17")),
+        Subsignal("cke",   Pins("G17")),
+        Subsignal("ras_n", Pins("P16")),
+        Subsignal("cas_n", Pins("T19")),
+        Subsignal("we_n",  Pins("U20")),
+        Subsignal("dq", Pins(
+            "AA22 AB22 Y22 Y21 W22 W21 V21 U22 M21 M22 T22 R21 R22 P22 N20 N21 K22 K21 J22 J21 H21 G22 G21 F22 E22 E20 D22 D21 C21 B22 A22 B21 ")),
+        Subsignal("dm", Pins("K20 E21")),
+        IOStandard("3.3-V LVTTL")
+    ),
+
+]
+
+# The connectors are named after the daughterboard, not the core board
+# because on the different core boards the names vary, but on the
+# daughterboard they stay the same, which we need to connect the
+# daughterboard peripherals to the core board.
+# On this board J2 is U7 and J3 is U8
+_connectors = [
+    ("J2", {
+         # odd row    even row
+          7: "AB21",  8: "AB20",
+          9: "Y19",  10: "Y20",
+         11: "AA20", 12: "AA19",
+         13: "W19",  14: "V20",
+         15: "AB18", 16: "AB17",
+         17: "U17",  18: "U16",
+         19: "R16",  20: "R17",
+         21: "T15",  22: "R15",
+         23: "R14",  24: "P14",
+         25: "AA15", 26: "AB15",
+         27: "T13",  28: "T12",
+         29: "R11",  30: "R10",
+         31: "AA13", 32: "AA14",
+         33: "Y15",  34: "Y14",
+         35: "AB12", 36: "AB13",
+         37: "AB11", 38: "AB10",
+         39: "V10",  40: "V9",
+         41: "U12",  42: "U11",
+         43: "R9",   44: "T10",
+         45: "T8",   46: "T7",
+         47: "N8",   48: "P8",
+         49: "M7",   50: "M6",
+         51: "N6",   52: "P6",
+         53: "R5",   54: "R6",
+         55: "AB8",  56: "AA8",
+         57: "AB7",  58: "AA7",
+         59: "AB5",  60: "AB6",
+    }),
+    ("J3", {
+        # odd row     even row
+         7: "F19",    8: "F18",
+         9: "E19",   10: "D19",
+        11: "C20",   12: "B20",
+        13: "A20",   14: "A19",
+        15: "C19",   16: "C18",
+        17: "A18",   18: "A17",
+        19: "B18",   20: "B17",
+        21: "B16",   22: "C16",
+        23: "C15",   24: "B15",
+        25: "E15",   26: "F15",
+        27: "A15",   28: "A14",
+        29: "B13",   30: "A13",
+        31: "B12",   32: "A12",
+        33: "G15",   34: "F14",
+        35: "H13",   36: "G13",
+        37: "D12",   38: "E12",
+        39: "H11",   40: "G12",
+        41: "A10",   42: "A9",
+        43: "J9",    44: "H9",
+        45: "E9",    46: "D9",
+        47: "H8",    48: "G8",
+        49: "L7",    50: "K7",
+        51: "J7",    52: "J8",
+        53: "A8",    54: "A7",
+        55: "B6",    56: "B7",
+        57: "C6",    58: "D6",
+        59: "A5",    60: "B5",
+    })
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(AlteraPlatform):
+    default_clk_name   = "clk50"
+    default_clk_period = 1e9/50e6
+    core_resources = [
+        ("user_led", 0, Pins("V19"), IOStandard("3.3-V LVTTL")),
+        ("user_led", 1, Pins("T20"), IOStandard("3.3-V LVTTL")),
+        ("serial", 0,
+            Subsignal("tx", Pins("J2:15"), IOStandard("3.3-V LVTTL")),
+            Subsignal("rx", Pins("J2:16"), IOStandard("3.3-V LVTTL"))
+        ),
+ ]
+
+    def __init__(self, toolchain="quartus", with_daughterboard=False):
+        device = "5CEFA5F23I7"
+        io = _io
+        connectors = _connectors
+
+        if with_daughterboard:
+            from litex_boards.platforms.qmtech_daughterboard import QMTechDaughterboard
+            daughterboard = QMTechDaughterboard(IOStandard("3.3-V LVTTL"))
+            io += daughterboard.io
+            connectors += daughterboard.connectors
+        else:
+            io += self.core_resources
+
+        AlteraPlatform.__init__(self, device, io, connectors, toolchain=toolchain)
+
+        if with_daughterboard:
+            # ethernet takes the config pin, so make it available
+            self.add_platform_command("set_global_assignment -name CYCLONEII_RESERVE_NCEO_AFTER_CONFIGURATION \"USE AS REGULAR IO\"")
+            # with the below lines MAYBE you can syntehsize a RV64 Rocket
+            self.add_platform_command("set_global_assignment -name VERILOG_MACRO \"SYNTHESIS=1\"")
+            self.add_platform_command("set_global_assignment -name OPTIMIZATION_MODE \"Aggressive Area\"")
+            self.add_platform_command("set_global_assignment -name ALM_REGISTER_PACKING_EFFORT HIGH")
+
+        # Generate PLL clock in STA
+        self.toolchain.additional_sdc_commands.append("derive_pll_clocks")
+        # Calculates clock uncertainties
+        self.toolchain.additional_sdc_commands.append("derive_clock_uncertainty")
+
+    def create_programmer(self):
+        return USBBlaster()
+
+    def do_finalize(self, fragment):
+        AlteraPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)

--- a/litex_boards/platforms/qmtech_xc7a200t.py
+++ b/litex_boards/platforms/qmtech_xc7a200t.py
@@ -1,0 +1,187 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2023 Ioannis Ioannou <roryt@roryt.gr> 
+# based on qmtech_xc7a35t:
+# Copyright (c) 2021 Hans Baier <hansfbaier@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+# 
+# BEWARE ! 
+# This is from https://www.aliexpress.com/item/1005002960622091.html with xc7a200tfbg484-1 and 
+# the github repo is https://github.com/ChinaQMTECH/QMTECH_Artix7_BGA484_Core_Board
+# There is another qmtech xc7a200t core board with different pinouts!
+
+from litex.build.generic_platform import Pins, Subsignal, IOStandard, Misc
+from litex.build.xilinx import Xilinx7SeriesPlatform
+from litex.build.openocd import OpenOCD
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("clk50", 0, Pins("W19"), IOStandard("LVCMOS33")),
+
+    # buttons
+    ("cpu_reset",   0, Pins("Y6"),   IOStandard("LVCMOS33")),
+
+    # Leds
+    ("user_led",   0, Pins("F3"),   IOStandard("LVCMOS33")),
+    ("user_led",   1, Pins("E3"),   IOStandard("LVCMOS33")),
+
+
+    # DDR3 SDRAM
+    # MT41K128M16JT-125K
+    ("ddram", 0,
+        Subsignal("a", Pins(
+            "A15 D14 A14 D15 E14 F14 E13 C13",
+            "E16 B13 C17 F13 F16 A13"),
+            IOStandard("SSTL135")),
+        Subsignal("ba",    Pins("D16 E17 B15"), IOStandard("SSTL135")),
+        Subsignal("ras_n", Pins("B17"),  IOStandard("SSTL135")),
+        Subsignal("cas_n", Pins("B16"),  IOStandard("SSTL135")),
+        Subsignal("we_n",  Pins("A16"),  IOStandard("SSTL135")),
+        # cs_n is pulled down to earth on the board 
+        # Subsignal("cs_n",  Pins("E22"),  IOStandard("SSTL135")),
+        Subsignal("dm", Pins("F19 D20"), IOStandard("SSTL135")),
+        Subsignal("dq", Pins(
+            "B20 A18 A20 D19 A19 C18 C19 E19",
+            "C20 D22 D21 E21 C22 G21 B22 E22"),
+            IOStandard("SSTL135"),
+            Misc("IN_TERM=UNTUNED_SPLIT_40")),
+        Subsignal("dqs_p", Pins("F18 B21"),
+            IOStandard("DIFF_SSTL135"),
+            Misc("IN_TERM=UNTUNED_SPLIT_40")),
+        Subsignal("dqs_n", Pins("E18 A21"),
+            IOStandard("DIFF_SSTL135"),
+            Misc("IN_TERM=UNTUNED_SPLIT_40")),
+        Subsignal("clk_p", Pins("C14"), IOStandard("DIFF_SSTL135")),
+        Subsignal("clk_n", Pins("C15"), IOStandard("DIFF_SSTL135")),
+        Subsignal("cke",   Pins("B18"), IOStandard("SSTL135")),
+        Subsignal("odt",   Pins("D17"), IOStandard("SSTL135")),
+        Subsignal("reset_n", Pins("F15"), IOStandard("SSTL135")),
+        Misc("SLEW=FAST"),
+    ),
+
+]
+# The connectors are named after the daughterboard, not the core board
+# because on the different core boards the names vary, but on the
+# daughterboard they stay the same, which we need to connect the
+# daughterboard peripherals to the core board.
+# On this board J2 is U7 and J3 is U8
+_connectors = [
+    ("J2", {
+         # odd row   even row
+          7: "H22",   8: "J22",
+          9: "H18",  10: "H17",
+         11: "K22",  12: "K21",
+         13: "G20",  14: "H20",
+         15: "H19",  16: "J19",
+         17: "J21",  18: "J20",
+         19: "J17",  20: "K17",
+         21: "L20",  22: "L19",
+         23: "H14",  24: "J14",
+         25: "K14",  26: "K13",
+         27: "M16",  28: "M15",
+         29: "M20",  30: "N20",
+         31: "M22",  32: "N22",
+         33: "L15",  34: "L14",
+         35: "N19",  36: "N18",
+         37: "P17",  38: "N17",
+         39: "T18",  40: "R18",
+         41: "Y22",  42: "Y21",
+         43: "U21",  44: "T21",
+         45: "V20",  46: "U20",
+         47: "U18",  48: "U17",
+         49: "V19",  50: "V18",
+         51: "AB22", 52: "AB21",
+         53: "AA21", 54: "AA20",
+         55: "AB20", 56: "AA19",
+         57: "Y19",  58: "Y18",
+         59: "AB18", 60: "AA18",
+    }),
+    ("J3", {
+        # odd row     even row
+         7: "B1",     8: "A1",
+         9: "C2",    10: "B2",
+        11: "E1",    12: "D1",
+        13: "E2",    14: "D2",
+        15: "G1",    16: "F1",
+        17: "H2",    18: "G2",
+        19: "K1",    20: "J1",
+        21: "K2",    22: "J2",
+        23: "M1",    24: "L1",
+        25: "K4",    26: "J4",
+        27: "L3",    28: "K3",
+        29: "M3",    30: "M2",
+        31: "P2",    32: "N2",
+        33: "R1",    34: "P1",
+        35: "P5",    36: "P4",
+        37: "R4",    38: "T4",
+        39: "T5",    40: "U5",
+        41: "T1",    42: "U1",
+        43: "W1",    44: "Y1",
+        45: "AA1",   46: "AB1",
+        47: "AB3",   48: "AB2",
+        49: "V4",    50: "W4",
+        51: "Y3",    52: "AA3",
+        53: "Y4",    54: "AA4",
+        55: "AA5",   56: "AB5",
+        57: "AB7",   58: "AB6",
+        59: "AA8",   60: "AB8",
+    })
+]
+
+
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(Xilinx7SeriesPlatform):
+    default_clk_name   = "clk50"
+    default_clk_period = 1e9/50e6
+
+    core_resources = [
+        # The core board does not have a USB serial on it,
+        # so you will have to attach an USB to serial adapter
+        # on these pins
+        ("gpio_serial", 0,
+            Subsignal("tx", Pins("J2:7")),
+            Subsignal("rx", Pins("J2:8")),
+            IOStandard("LVCMOS33")
+        ),
+    ]
+    
+
+    def __init__(self, toolchain="vivado", with_daughterboard=False):
+        device = "xc7a200tfbg484-1"
+        io = _io
+        connectors = _connectors
+
+        if with_daughterboard:
+            from litex_boards.platforms.qmtech_daughterboard import QMTechDaughterboard
+            daughterboard = QMTechDaughterboard(IOStandard("LVCMOS33"))
+            io += daughterboard.io
+            connectors += daughterboard.connectors
+        else:
+            io += self.core_resources
+
+        Xilinx7SeriesPlatform.__init__(self, device, io, connectors, toolchain=toolchain)
+        self.toolchain.bitstream_commands = \
+            ["set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]"]
+        self.toolchain.additional_commands = \
+            ["write_cfgmem -force -format bin -interface spix4 -size 16 "
+             "-loadbit \"up 0x0 {build_name}.bit\" -file {build_name}.bin"]
+        self.add_platform_command("set_property INTERNAL_VREF 0.675 [get_iobanks 16]")
+        if with_daughterboard:
+           self.add_platform_command("set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets eth_clocks_rx_IBUF]")
+        self.add_platform_command("set_property CFGBVS VCCO [current_design]")
+        self.add_platform_command("set_property CONFIG_VOLTAGE 3.3 [current_design]")
+        self.toolchain.f4pga_device = device
+
+    def create_programmer(self):
+        bscan_spi = "bscan_spi_xc7a200t.bit"
+        return OpenOCD("openocd_xc7_ft2232.cfg", bscan_spi)
+
+
+    def do_finalize(self, fragment):
+        Xilinx7SeriesPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)

--- a/litex_boards/targets/qmtech_5cefa5.py
+++ b/litex_boards/targets/qmtech_5cefa5.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2021 Hans Baier <hansfbaier@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Note: The CPU actually runs at over 100MHz, but the SDRAM only works up to 75MHz
+
+from migen import *
+
+from litex.gen import *
+
+from litex.build.io import DDROutput
+
+from litex_boards.platforms import qmtech_5cefa5
+
+from litex.soc.cores.clock import CycloneVPLL
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+
+from litedram.modules import W9825G6KH6
+from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
+
+from litex.soc.cores.video import VideoVGAPHY
+from liteeth.phy.mii import LiteEthPHYMII
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq, with_ethernet, with_vga, sdram_rate="1:1"):
+        self.rst    = Signal()
+        self.cd_sys = ClockDomain()
+
+        if sdram_rate == "1:2":
+            self.cd_sys2x    = ClockDomain()
+            self.cd_sys2x_ps = ClockDomain()
+        else:
+            self.cd_sys_ps = ClockDomain()
+
+        if with_ethernet:
+            self.cd_eth = ClockDomain()
+
+        if with_vga:
+            self.cd_vga = ClockDomain()
+
+        # # #
+
+        # Clk / Rst
+        clk50 = platform.request("clk50")
+
+        # PLL
+        self.pll = pll = CycloneVPLL(speedgrade="-I7")
+        self.comb += pll.reset.eq(self.rst)
+        pll.register_clkin(clk50, 50e6)
+        pll.create_clkout(self.cd_sys,    sys_clk_freq)
+        if sdram_rate == "1:2":
+            pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
+            # theoretically 90 degrees, but increase to relax timing
+            pll.create_clkout(self.cd_sys2x_ps, 2*sys_clk_freq, phase=180)
+        else:
+            # for 105 MHz: 10; 95 MHz: 15; 85MHz: 30 work
+            pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=10)
+
+        if with_ethernet:
+            pll.create_clkout(self.cd_eth,   25e6)
+        if with_vga:
+            pll.create_clkout(self.cd_vga,   40e6)
+
+        # SDRAM clock
+        sdram_clk = ClockSignal("sys2x_ps" if sdram_rate == "1:2" else "sys_ps")
+        self.specials += DDROutput(1, 0, platform.request("sdram_clock"), sdram_clk)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=105e6, with_daughterboard=False,
+        with_ethernet          = False,
+        with_etherbone         = False,
+        eth_ip                 = "192.168.1.50",
+        eth_dynamic_ip         = False,
+        with_led_chaser        = True,
+        with_video_terminal    = False,
+        with_video_framebuffer = False,
+        sdram_rate             = "1:1",
+        **kwargs):
+        platform = qmtech_5cefa5.Platform(with_daughterboard=with_daughterboard)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.crg = _CRG(platform, sys_clk_freq,
+            with_ethernet = with_ethernet or with_etherbone,
+            with_vga      = with_video_terminal or with_video_framebuffer,
+            sdram_rate    = sdram_rate
+        )
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            ident = "LiteX SoC on QMTECH 5CEFA5" + (" + Daughterboard" if with_daughterboard else ""),
+            **kwargs)
+
+        # SDR SDRAM --------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            sdrphy_cls = HalfRateGENSDRPHY if sdram_rate == "1:2" else GENSDRPHY
+            self.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
+            self.add_sdram("sdram",
+                phy           = self.sdrphy,
+                module        = W9825G6KH6(sys_clk_freq, sdram_rate),
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
+
+        # Ethernet / Etherbone ---------------------------------------------------------------------
+        if with_ethernet or with_etherbone:
+            self.ethphy = LiteEthPHYMII(
+                clock_pads = self.platform.request("eth_clocks"),
+                pads       = self.platform.request("eth"))
+            if with_ethernet:
+                self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip)
+            if with_etherbone:
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
+
+        # Video ------------------------------------------------------------------------------------
+        if with_video_terminal or with_video_framebuffer:
+            self.videophy = VideoVGAPHY(platform.request("vga"), clock_domain="vga")
+            if with_video_terminal:
+                self.add_video_terminal(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
+            if with_video_framebuffer:
+                self.add_video_framebuffer(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=qmtech_5cefa5.Platform, description="LiteX SoC on QMTECH 5CEFA5.")
+    parser.add_target_argument("--sys-clk-freq", default=105e6, type=float, help="System clock frequency.")
+    parser.add_target_argument("--sdram-rate",   default="1:1",             help="SDRAM Rate (1:1 Full Rate or 1:2 Half Rate).")
+    parser.add_target_argument("--with-daughterboard",  action="store_true",              help="Board plugged into the QMTech daughterboard.")
+    ethopts = parser.target_group.add_mutually_exclusive_group()
+    ethopts.add_argument("--with-ethernet",      action="store_true",              help="Enable Ethernet support.")
+    ethopts.add_argument("--with-etherbone",     action="store_true",              help="Enable Etherbone support")
+    parser.add_target_argument("--eth-ip",              default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address.")
+    parser.add_target_argument("--eth-dynamic-ip",      action="store_true",              help="Enable dynamic Ethernet IP addresses setting.")
+    sdopts = parser.target_group.add_mutually_exclusive_group()
+    sdopts.add_argument("--with-spi-sdcard",     action="store_true",              help="Enable SPI-mode SDCard support.")
+    sdopts.add_argument("--with-sdcard",         action="store_true",              help="Enable SDCard support.")
+    parser.add_target_argument("--with-spi-flash",      action="store_true",              help="Enable SPI Flash (MMAPed).")
+    viopts = parser.target_group.add_mutually_exclusive_group()
+    viopts.add_argument("--with-video-terminal",    action="store_true", help="Enable Video Terminal (VGA).")
+    viopts.add_argument("--with-video-framebuffer", action="store_true", help="Enable Video Framebuffer (VGA).")
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq           = args.sys_clk_freq,
+        with_daughterboard     = args.with_daughterboard,
+        with_ethernet          = args.with_ethernet,
+        with_etherbone         = args.with_etherbone,
+        eth_ip                 = args.eth_ip,
+        eth_dynamic_ip         = args.eth_dynamic_ip,
+        with_video_terminal    = args.with_video_terminal,
+        with_video_framebuffer = args.with_video_framebuffer,
+        with_spi_flash         = args.with_spi_flash,
+        sdram_rate             = args.sdram_rate,
+        **parser.soc_argdict
+    )
+
+    if args.with_spi_sdcard:
+        soc.add_spi_sdcard()
+    if args.with_sdcard:
+        soc.add_sdcard()
+
+    builder = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+if __name__ == "__main__":
+    main()

--- a/litex_boards/targets/qmtech_xc7a200t.py
+++ b/litex_boards/targets/qmtech_xc7a200t.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2023 Ioannis Ioannou <roryt@roryt.gr> 
+# based on qmtech_xc7a35t:
+# Copyright (c) 2021 Hans Baier <hansfbaier@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+# 
+# BEWARE ! 
+# This is from https://www.aliexpress.com/item/1005002960622091.html with xc7a200tfbg484-1 and 
+# the github repo is https://github.com/ChinaQMTECH/QMTECH_Artix7_BGA484_Core_Board
+# There is another qmtech xc7a200t core board with different pinouts!
+
+from migen import *
+
+from litex.gen import *
+
+from litex_boards.platforms import qmtech_xc7a200t
+
+from litex.soc.cores.clock import *
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.video import VideoVGAPHY
+from litex.soc.cores.led import LedChaser
+
+from litedram.modules import MT41J128M16
+from litedram.phy import s7ddrphy
+
+from liteeth.phy.mii import LiteEthPHYMII
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq, with_ethernet, with_vga):
+        self.rst          = Signal()
+        self.cd_sys       = ClockDomain()
+        self.cd_sys4x     = ClockDomain()
+        self.cd_sys4x_dqs = ClockDomain()
+        self.cd_idelay    = ClockDomain()
+        self.cd_eth       = ClockDomain()
+        if with_ethernet:
+            self.cd_eth   = ClockDomain()
+        if with_vga:
+            self.cd_vga   = ClockDomain()
+
+        # # #
+
+        self.pll = pll = S7PLL(speedgrade=-1)
+        try:
+            reset_button = platform.request("cpu_reset")
+            self.comb += pll.reset.eq(~reset_button | self.rst)
+        except:
+            self.comb += pll.reset.eq(self.rst)
+
+        pll.register_clkin(platform.request("clk50"), 50e6)
+        pll.create_clkout(self.cd_sys,       sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x,     4*sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x_dqs, 4*sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_idelay,    200e6)
+        if with_ethernet:
+            pll.create_clkout(self.cd_eth,   25e6)
+        if with_vga:
+            pll.create_clkout(self.cd_vga,   40e6)
+
+        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
+
+        self.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, toolchain="vivado", sys_clk_freq=100e6, with_daughterboard=False,
+        with_ethernet          = False,
+        with_etherbone         = False,
+        eth_ip                 = "192.168.1.50",
+        eth_dynamic_ip         = False,
+        with_led_chaser        = True,
+        with_video_terminal    = False,
+        with_video_framebuffer = False,
+        with_jtagbone          = True,
+        with_spi_flash         = False,
+        **kwargs):
+        platform = qmtech_xc7a200t.Platform(toolchain=toolchain, with_daughterboard=with_daughterboard)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.crg = _CRG(platform, sys_clk_freq,
+            with_ethernet = (with_ethernet or with_etherbone),
+            with_vga      = (with_video_terminal or with_video_framebuffer)
+        )
+
+        # SoCCore ----------------------------------------------------------------------------------
+        if (kwargs["uart_name"] == "serial") and (not with_daughterboard):
+            kwargs["uart_name"] = "gpio_serial"
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            ident = "LiteX SoC on QMTech XC7A200T" + (" + Daughterboard" if with_daughterboard else ""),
+            **kwargs)
+
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.ddrphy = s7ddrphy.A7DDRPHY(platform.request("ddram"),
+                memtype        = "DDR3",
+                nphases        = 4,
+                sys_clk_freq   = sys_clk_freq)
+            self.add_sdram("sdram",
+                phy           = self.ddrphy,
+                module        = MT41J128M16(sys_clk_freq, "1:4"),
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
+
+        # Ethernet / Etherbone ---------------------------------------------------------------------
+        if with_ethernet or with_etherbone:
+            self.ethphy = LiteEthPHYMII(
+                clock_pads = self.platform.request("eth_clocks"),
+                pads       = self.platform.request("eth"))
+            if with_ethernet:
+                self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip)
+            if with_etherbone:
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
+            # The daughterboard has the tx clock wired to a non-clock pin, so we can't help it
+            self.platform.add_platform_command("set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets eth_clocks_tx_IBUF]")
+
+
+
+        # Jtagbone ---------------------------------------------------------------------------------
+        if with_jtagbone:
+            self.add_jtagbone()
+
+        # SPI Flash --------------------------------------------------------------------------------
+        if with_spi_flash:
+            from litespi.modules import MT25QL128
+            from litespi.opcodes import SpiNorFlashOpCodes as Codes
+            self.add_spi_flash(mode="4x", module=MT25QL128(Codes.READ_1_1_1), with_master=True)
+
+        # Video ------------------------------------------------------------------------------------
+        if with_video_terminal or with_video_framebuffer:
+            self.videophy = VideoVGAPHY(platform.request("vga"), clock_domain="vga")
+            if with_video_terminal:
+                self.add_video_terminal(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
+            if with_video_framebuffer:
+                self.add_video_framebuffer(phy=self.videophy, timings="800x600@60Hz", clock_domain="vga")
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+
+        if not with_daughterboard and kwargs["uart_name"] == "serial":
+            kwargs["uart_name"] = "jtag_serial"
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=qmtech_xc7a200t.Platform, description="LiteX SoC on QMTech XC7A200T.")
+    parser.add_target_argument("--sys-clk-freq",        default=100e6, type=float,  help="System clock frequency.")
+    parser.add_target_argument("--with-daughterboard",  action="store_true",        help="Board plugged into the QMTech daughterboard.")
+    ethopts = parser.target_group.add_mutually_exclusive_group()
+    ethopts.add_argument("--with-ethernet",        action="store_true",    help="Enable Ethernet support.")
+    ethopts.add_argument("--with-etherbone",       action="store_true",    help="Enable Etherbone support.")
+    parser.add_target_argument("--eth-ip",         default="192.168.1.50", help="Ethernet/Etherbone IP address.")
+    parser.add_target_argument("--eth-dynamic-ip", action="store_true",    help="Enable dynamic Ethernet IP addresses setting.")
+    sdopts = parser.target_group.add_mutually_exclusive_group()
+    sdopts.add_argument("--with-spi-sdcard",       action="store_true", help="Enable SPI-mode SDCard support.")
+    sdopts.add_argument("--with-sdcard",           action="store_true", help="Enable SDCard support.")
+    parser.add_target_argument("--with-jtagbone",  action="store_true", help="Enable Jtagbone support.")
+    parser.add_target_argument("--with-spi-flash", action="store_true", help="Enable SPI Flash (MMAPed).")
+    viopts = parser.target_group.add_mutually_exclusive_group()
+    viopts.add_argument("--with-video-terminal",    action="store_true", help="Enable Video Terminal (VGA).")
+    viopts.add_argument("--with-video-framebuffer", action="store_true", help="Enable Video Framebuffer (VGA).")
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        toolchain              = args.toolchain,
+        sys_clk_freq           = args.sys_clk_freq,
+        with_daughterboard     = args.with_daughterboard,
+        with_ethernet          = args.with_ethernet,
+        with_etherbone         = args.with_etherbone,
+        eth_ip                 = args.eth_ip,
+        eth_dynamic_ip         = args.eth_dynamic_ip,
+        with_jtagbone          = args.with_jtagbone,
+        with_spi_flash         = args.with_spi_flash,
+        with_video_terminal    = args.with_video_terminal,
+        with_video_framebuffer = args.with_video_framebuffer,
+        **parser.soc_argdict
+    )
+
+    if args.with_spi_sdcard:
+        soc.add_spi_sdcard()
+    if args.with_sdcard:
+        soc.add_sdcard()
+
+    builder = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two boards from QMtech, one with Cyclone V 5cefa5 https://www.aliexpress.com/item/1005001795300745.html (tested with vexriscv)

and another with Artix-7 XC7A200T https://www.aliexpress.com/item/1005002960622091.html (tested with both Rocket and Naxriscv)

Both with  daughterboard support.