### PR TITLE
sitlinv_stlv7325: use S7PLL instead of S7MMCM for system clock

### DIFF
--- a/litex_boards/targets/sitlinv_stlv7325.py
+++ b/litex_boards/targets/sitlinv_stlv7325.py
@@ -47,7 +47,7 @@ class _CRG(LiteXModule):
         rst_n  = platform.request("cpu_reset_n")
 
         # PLL.
-        self.pll = pll = S7MMCM(speedgrade=-2)
+        self.pll = pll = S7PLL(speedgrade=-2)
         self.comb += pll.reset.eq(~rst_n | self.rst)
         pll.register_clkin(clk200, 200e6)
         pll.create_clkout(self.cd_sys,    sys_clk_freq)


### PR DESCRIPTION
As we do not need fine phase tweaking for the main system clock, use S7PLL instead of S7MMCM to allow higher VCO frequency and more flexible sys_clk_freq.