### PR TITLE
Fix Memory initialization of Alveo U200 failed #1606

### DIFF
--- a/litex_boards/targets/xilinx_alveo_u200.py
+++ b/litex_boards/targets/xilinx_alveo_u200.py
@@ -75,6 +75,7 @@ class BaseSoC(SoCCore):
             self.ddrphy = usddrphy.USPDDRPHY(platform.request("ddram"),
                 memtype          = "DDR4",
                 sys_clk_freq     = sys_clk_freq,
+                cmd_latency      = 1,
                 iodelay_clk_freq = 500e6,
                 is_rdimm         = True)
             self.add_sdram("sdram",


### PR DESCRIPTION
I fixed the issue Memory initialization of Alveo U200 as discussed in https://github.com/enjoy-digital/litex/issues/1606.
Both offnaria and I confirmed that it works OK.