### PR TITLE
Fix Memory test failure of Alveo U250

### DIFF
--- a/litex_boards/targets/xilinx_alveo_u250.py
+++ b/litex_boards/targets/xilinx_alveo_u250.py
@@ -74,6 +74,7 @@ class BaseSoC(SoCCore):
             self.ddrphy = usddrphy.USPDDRPHY(platform.request("ddram"),
                 memtype          = "DDR4",
                 sys_clk_freq     = sys_clk_freq,
+                cmd_latency      = 1,
                 iodelay_clk_freq = 500e6,
                 is_rdimm         = True)
             self.add_sdram("sdram",


### PR DESCRIPTION
I had a memory test failure of AU250, the same as discussed in https://github.com/enjoy-digital/litex/issues/1606.
This is the log.
```
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2023 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Apr 24 2023 17:48:49
 BIOS CRC passed (23c21291)

 LiteX git sha1: fb1cd22a

--=============== SoC ==================--
CPU:            VexRiscv @ 125MHz
BUS:            WISHBONE 32-bit @ 4GiB
CSR:            32-bit data
ROM:            128.0KiB
SRAM:           8.0KiB
L2:             8.0KiB
SDRAM:          16.0GiB 64-bit @ 1000MT/s (CL-9 CWL-9)
MAIN-RAM:       1.0GiB

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Write leveling:
  tCK equivalent taps: 584
  Cmd/Clk scan (0-292)
  |00111  |001111111  |011111111  |111111111| best: 115
  Setting Cmd/Clk delay to 115 taps.
  Data scan:
  m0: |00000111111111111111111| delay: 67
  m1: |00011111111111111111110| delay: 44
  m2: |00000011111111111111111| delay: 85
  m3: |11111111111111110000000| delay: 00
  m4: |11111111111000000000000| delay: 00
  m5: |11111111111111111111111| delay: 00
  m6: |00000001111111111111111| delay: 98
  m7: |11111111111111110000000| delay: 00
Write latency calibration:
m0:4
m1:4
m2:4
m3:6
m4:4
m5:4
m6:0
m7:4
Read leveling:
  m0, b00: |00000000000000000000000000000000| delays: -
  m0, b01: |00000000000000000000000000000000| delays: -
  m0, b02: |00000000000000000000000000000000| delays: -
  m0, b03: |00000000000000000000000000000000| delays: -
  m0, b04: |00000000000000000000000000000000| delays: -
  m0, b05: |00000000000000000000000000000000| delays: -
  m0, b06: |00000000000000000000000000000000| delays: -
  m0, b07: |00000000000000000000000000000000| delays: -
  best: m0, b06 delays: -
  m1, b00: |00000000000000000000000000000000| delays: -
  m1, b01: |00000000000000000000000000000000| delays: -
  m1, b02: |00000000000000000000000000000000| delays: -
  m1, b03: |00000000000000000000000000000000| delays: -
  m1, b04: |00000000000000000000000000000000| delays: -
  m1, b05: |00000000000000000000000000000000| delays: -
  m1, b06: |00000000000000000000000000000000| delays: -
  m1, b07: |00000000000000000000000000000000| delays: -
  best: m1, b06 delays: -
  m2, b00: |00000000000000000000000000000000| delays: -
  m2, b01: |00000000000000000000000000000000| delays: -
  m2, b02: |00000000000000000000000000000000| delays: -
  m2, b03: |00000000000000000000000000000000| delays: -
  m2, b04: |00000000000000000000000000000000| delays: -
  m2, b05: |00000000000000000000000000000000| delays: -
  m2, b06: |00000000000000000000000000000000| delays: -
  m2, b07: |00000000000000000000000000000000| delays: -
  best: m2, b06 delays: -
  m3, b00: |00000000000000000000000000000000| delays: -
  m3, b01: |00000000000000000000000000000000| delays: -
  m3, b02: |00000000000000000000000000000000| delays: -
  m3, b03: |00000000000000000000000000000000| delays: -
  m3, b04: |00000000000000000000000000000000| delays: -
  m3, b05: |00000000000000000000000000000000| delays: -
  m3, b06: |00000000000000000000000000000000| delays: -
  m3, b07: |00000000000000000000000000000000| delays: -
  best: m3, b04 delays: -
  m4, b00: |00000000000000000000000000000000| delays: -
  m4, b01: |00000000000000000000000000000000| delays: -
  m4, b02: |00000000000000000000000000000000| delays: -
  m4, b03: |00000000000000000000000000000000| delays: -
  m4, b04: |00000000000000000000000000000000| delays: -
  m4, b05: |00000000000000000000000000000000| delays: -
  m4, b06: |00000000000000000000000000000000| delays: -
  m4, b07: |00000000000000000000000000000000| delays: -
  best: m4, b06 delays: -
  m5, b00: |00000000000000000000000000000000| delays: -
  m5, b01: |00000000000000000000000000000000| delays: -
  m5, b02: |00000000000000000000000000000000| delays: -
  m5, b03: |00000000000000000000000000000000| delays: -
  m5, b04: |00000000000000000000000000000000| delays: -
  m5, b05: |00000000000000000000000000000000| delays: -
  m5, b06: |00000000000000000000000000000000| delays: -
  m5, b07: |00000000000000000000000000000000| delays: -
  best: m5, b06 delays: -
  m6, b00: |00000000000000000000000000000000| delays: -
  m6, b01: |00000000000000000000000000000000| delays: -
  m6, b02: |00000000000000000000000000000000| delays: -
  m6, b03: |00000000000000000000000000000000| delays: -
  m6, b04: |00000000000000000000000000000000| delays: -
  m6, b05: |00000000000000000000000000000000| delays: -
  m6, b06: |00000000000000000000000000000000| delays: -
  m6, b07: |00000000000000000000000000000000| delays: -
  best: m6, b00 delays: -
  m7, b00: |00000000000000000000000000000000| delays: -
  m7, b01: |00000000000000000000000000000000| delays: -
  m7, b02: |00000000000000000000000000000000| delays: -
  m7, b03: |00000000000000000000000000000000| delays: -
  m7, b04: |00000000000000000000000000000000| delays: -
  m7, b05: |00000000000000000000000000000000| delays: -
  m7, b06: |00000000000000000000000000000000| delays: -
  m7, b07: |00000000000000000000000000000000| delays: -
  best: m7, b05 delays: -
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB
   Read: 0x40000000-0x40200000 2.0MiB
  bus errors:  255/256
  addr errors: 0/8192
  data errors: 524288/524288
Memtest KO
Memory initialization failed

--============= Console ================--

litex>
```

Like the problem of AU200, I added `cmd_latency = 1` option and then it works!
```
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2023 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Apr 24 2023 17:54:54
 BIOS CRC passed (ecdc196f)

 LiteX git sha1: fb1cd22a

--=============== SoC ==================--
CPU:            VexRiscv @ 125MHz
BUS:            WISHBONE 32-bit @ 4GiB
CSR:            32-bit data
ROM:            128.0KiB
SRAM:           8.0KiB
L2:             8.0KiB
SDRAM:          16.0GiB 64-bit @ 1000MT/s (CL-9 CWL-9)
MAIN-RAM:       1.0GiB

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Write leveling:
  tCK equivalent taps: 584
  Cmd/Clk scan (0-292)
  |00111  |000111111  |011111111  |111111111| best: 116
  Setting Cmd/Clk delay to 116 taps.
  Data scan:
  m0: |00000111111111111111111| delay: 66
  m1: |00011111111111111111110| delay: 44
  m2: |00000011111111111111111| delay: 86
  m3: |11111111111111110000000| delay: 00
  m4: |11111111111000000000000| delay: 00
  m5: |11111111111111000000000| delay: 00
  m6: |00000001111111111111111| delay: 98
  m7: |11111111111111110000000| delay: 00
Write latency calibration:
m0:6
m1:6
m2:6
m3:6
m4:6
m5:6
m6:6
m7:6
Read leveling:
  m0, b00: |00000000000000000000000000000000| delays: -
  m0, b01: |00000000000000000000000000000000| delays: -
  m0, b02: |00000000000000000000000000000000| delays: -
  m0, b03: |11111111111100000000000000000000| delays: 89+-89
  m0, b04: |00000000000000111111111111111100| delays: 342+-126
  m0, b05: |00000000000000000000000000000000| delays: 507+-03
  m0, b06: |00000000000000000000000000000000| delays: -
  m0, b07: |00000000000000000000000000000000| delays: -
  best: m0, b04 delays: 345+-127
  m1, b00: |00000000000000000000000000000000| delays: -
  m1, b01: |00000000000000000000000000000000| delays: -
  m1, b02: |00000000000000000000000000000000| delays: -
  m1, b03: |11111111111111110000000000000000| delays: 123+-123
  m1, b04: |00000000000000000011111111111111| delays: 398+-112
  m1, b05: |00000000000000000000000000000000| delays: -
  m1, b06: |00000000000000000000000000000000| delays: -
  m1, b07: |00000000000000000000000000000000| delays: -
  best: m1, b03 delays: 123+-123
  m2, b00: |00000000000000000000000000000000| delays: -
  m2, b01: |00000000000000000000000000000000| delays: -
  m2, b02: |00000000000000000000000000000000| delays: -
  m2, b03: |11100000000000000000000000000000| delays: 22+-22
  m2, b04: |00000011111111111111100000000000| delays: 205+-121
  m2, b05: |00000000000000000000000011111111| delays: 443+-68
  m2, b06: |00000000000000000000000000000000| delays: -
  m2, b07: |00000000000000000000000000000000| delays: -
  best: m2, b04 delays: 205+-122
  m3, b00: |00000000000000000000000000000000| delays: -
  m3, b01: |00000000000000000000000000000000| delays: -
  m3, b02: |00000000000000000000000000000000| delays: -
  m3, b03: |00000000000000000000000000000000| delays: -
  m3, b04: |00111111111111111100000000000000| delays: 153+-124
  m3, b05: |00000000000000000000111111111111| delays: 412+-98
  m3, b06: |00000000000000000000000000000000| delays: -
  m3, b07: |00000000000000000000000000000000| delays: -
  best: m3, b04 delays: 152+-124
  m4, b00: |00000000000000000000000000000000| delays: -
  m4, b01: |00000000000000000000000000000000| delays: -
  m4, b02: |00000000000000000000000000000000| delays: -
  m4, b03: |11111111111110000000000000000000| delays: 103+-103
  m4, b04: |00000000000000011111111111111110| delays: 362+-125
  m4, b05: |00000000000000000000000000000000| delays: -
  m4, b06: |00000000000000000000000000000000| delays: -
  m4, b07: |00000000000000000000000000000000| delays: -
  best: m4, b04 delays: 362+-126
  m5, b00: |00000000000000000000000000000000| delays: -
  m5, b01: |00000000000000000000000000000000| delays: -
  m5, b02: |00000000000000000000000000000000| delays: -
  m5, b03: |11100000000000000000000000000000| delays: 21+-21
  m5, b04: |00000111111111111111100000000000| delays: 206+-122
  m5, b05: |00000000000000000000000011111111| delays: 443+-67
  m5, b06: |00000000000000000000000000000000| delays: -
  m5, b07: |00000000000000000000000000000000| delays: -
  best: m5, b04 delays: 207+-122
  m6, b00: |00000000000000000000000000000000| delays: -
  m6, b01: |00000000000000000000000000000000| delays: -
  m6, b02: |00000000000000000000000000000000| delays: -
  m6, b03: |11111111000000000000000000000000| delays: 60+-60
  m6, b04: |00000000000111111111111111000000| delays: 289+-124
  m6, b05: |00000000000000000000000000000111| delays: 487+-24
  m6, b06: |00000000000000000000000000000000| delays: -
  m6, b07: |00000000000000000000000000000000| delays: -
  best: m6, b04 delays: 289+-124
  m7, b00: |00000000000000000000000000000000| delays: -
  m7, b01: |00000000000000000000000000000000| delays: -
  m7, b02: |10000000000000000000000000000000| delays: 05+-05
  m7, b03: |00011111111111111110000000000000| delays: 171+-128
  m7, b04: |00000000000000000000011111111111| delays: 421+-89
  m7, b05: |00000000000000000000000000000000| delays: -
  m7, b06: |00000000000000000000000000000000| delays: -
  m7, b07: |00000000000000000000000000000000| delays: -
  best: m7, b03 delays: 170+-128
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB
   Read: 0x40000000-0x40200000 2.0MiB
Memtest OK
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 108.8MiB/s
   Read speed: 93.6MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
Timeout
No boot medium found

--============= Console ================--

litex>
```

If you still have errors with `cmd_latency = 1`, please try rebooting your SoC for several times.