### PR TITLE
Add spiflash definition to linsn_rv901t board

### DIFF
--- a/litex_boards/platforms/linsn_rv901t.py
+++ b/litex_boards/platforms/linsn_rv901t.py
@@ -28,6 +28,15 @@ _io = [
         IOStandard("LVCMOS33")
     ),
 
+    # SPIFlash (25Q32JV)
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("T3")),
+        Subsignal("clk",  Pins("R11")),
+        Subsignal("mosi", Pins("T10")),
+        Subsignal("miso", Pins("P10")),
+        IOStandard("LVCMOS33"),
+    ),
+
     # RGMII Ethernet
     ("eth_clocks", 0,
         Subsignal("tx", Pins("D1")),


### PR DESCRIPTION
Add signal definition for spiflash signals as described here:

https://github.com/q3k/chubby75/blob/master/rv901t/doc/hardware.md#connector-jp5-spi-flash