### PR TITLE
lattice_ecp5_evn: add_jtagbone flag

### DIFF
--- a/litex_boards/prog/openocd_evn_ecp5.cfg
+++ b/litex_boards/prog/openocd_evn_ecp5.cfg
@@ -1,9 +1,10 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6010
-ftdi_channel 0
-ftdi_layout_init 0xfff8 0xfffb
+adapter driver ftdi
+adapter speed 25000
+transport select jtag
+ftdi vid_pid 0x0403 0x6010
+ftdi channel 0
+ftdi layout_init 0x00e8 0x60eb
 reset_config none
 
-adapter_khz 5000
-
-jtag newtap ecp5 tap -irlen 8 -expected-id 0x81113043
+set _CHIPNAME ecp5
+jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x81113043

--- a/litex_boards/targets/lattice_ecp5_evn.py
+++ b/litex_boards/targets/lattice_ecp5_evn.py
@@ -46,6 +46,7 @@ class _CRG(LiteXModule):
 class BaseSoC(SoCCore):
     def __init__(self, sys_clk_freq=50e6, toolchain="trellis", x5_clk_freq=None,
         with_led_chaser = True,
+        with_jtagbone   = True,
         **kwargs):
         platform = lattice_ecp5_evn.Platform(toolchain=toolchain)
 
@@ -54,6 +55,10 @@ class BaseSoC(SoCCore):
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on ECP5 Evaluation Board", **kwargs)
+
+        # JtagBone ---------------------------------------------------------------------------------
+        if with_jtagbone:
+            self.add_jtagbone()
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:
@@ -68,12 +73,14 @@ def main():
     parser = LiteXArgumentParser(platform=lattice_ecp5_evn.Platform, description="LiteX SoC on ECP5 Evaluation Board.")
     parser.add_target_argument("--sys-clk-freq", default=60e6, type=float, help="System clock frequency.")
     parser.add_target_argument("--x5-clk-freq",  type=int,                 help="Use X5 oscillator as system clock at the specified frequency.")
+    parser.add_target_argument("--with-jtagbone", action="store_true",     help="Add JTAGBone.")
     args = parser.parse_args()
 
     soc = BaseSoC(
         toolchain    = args.toolchain,
         sys_clk_freq = args.sys_clk_freq,
         x5_clk_freq  = args.x5_clk_freq,
+        with_jtagbone = args.with_jtagbone,
         **parser.soc_argdict)
     builder = Builder(soc, **parser.builder_argdict)
     if args.build:


### PR DESCRIPTION
This follows https://github.com/enjoy-digital/litex/pull/1087 which allows using the built-in JTAG for both the FPGA programming and the internal designs. Kuddos!

Starting LiteX server with it:
```
$ litex_server --jtag-config=targets/openocd.cfg --jtag
Open On-Chip Debugger 0.12.0+dev-g7023deb (2023-07-29-00:21)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
jtagstream_serve
Info : ftdi: if you experience problems at higher adapter clocks, try the command "ftdi tdo_sam
ple_edge falling"
Info : clock speed 25000 kHz
Info : JTAG tap: ecp5.tap tap/device found: 0x81113043 (mfg: 0x021 (Lattice Semi.), part: 0x111
3, ver: 0x8)
Warn : gdb services need one or more targets defined
[CommUART] port: JTAG / tcp port: 1234
Connected with 127.0.0.1:40662
Disconnect
Connected with 127.0.0.1:40674
Disconnect
Connected with 127.0.0.1:46370
Disconnect
Connected with 127.0.0.1:44228
Disconnect
```

The content of `openocd.cfg` (separate pull request with that):
```
adapter driver ftdi
adapter speed 25000
transport select jtag
ftdi vid_pid 0x0403 0x6010
ftdi channel 0
ftdi layout_init 0x00e8 0x60eb
reset_config none

set _CHIPNAME ecp5
jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x81113043
```

And then, I can get the bus values!
```
litex@lap1:$ litex_cli --regs --csr-csv=csr.csv
0xf0000000 : 0x00000000 ctrl_reset
0xf0000004 : 0x12345678 ctrl_scratch
0xf0000008 : 0x00000000 ctrl_bus_errors
0xf0001000 : 0x00000000 leds_out
0xf0001800 : 0x00e4e1c0 timer0_load
0xf0001804 : 0x00000000 timer0_reload
0xf0001808 : 0x00000001 timer0_en
0xf000180c : 0x00000001 timer0_update_value
0xf0001810 : 0x00000000 timer0_value
0xf0001814 : 0x00000001 timer0_ev_status
0xf0001818 : 0x00000001 timer0_ev_pending
0xf000181c : 0x00000000 timer0_ev_enable
0xf0002000 : 0x00000000 uart_rxtx
0xf0002004 : 0x00000000 uart_txfull
0xf0002008 : 0x00000001 uart_rxempty
0xf000200c : 0x00000001 uart_ev_status
0xf0002010 : 0x00000000 uart_ev_pending
0xf0002014 : 0x00000003 uart_ev_enable
0xf0002018 : 0x00000001 uart_txempty
0xf000201c : 0x00000000 uart_rxfull
litex@lap1:$
```
