### PR TITLE
OpenOCD config file updates

### DIFF
--- a/litex_boards/prog/openocd_butterstick.cfg
+++ b/litex_boards/prog/openocd_butterstick.cfg
@@ -1,10 +1,10 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6014
-ftdi_channel 0
-ftdi_layout_init 0x00e8 0x60eb
+adapter driver ftdi
+adapter speed 25000
+transport select jtag
+ftdi vid_pid 0x0403 0x6014
+ftdi channel 0
+ftdi layout_init 0x00e8 0x60eb
 reset_config none
-
-adapter_khz 25000
 
 set _CHIPNAME ecp5
 jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x81113043

--- a/litex_boards/prog/openocd_colorlight_5a_75b.cfg
+++ b/litex_boards/prog/openocd_colorlight_5a_75b.cfg
@@ -6,4 +6,5 @@ reset_config none
 
 adapter_khz 25000
 
-jtag newtap ecp5 tap -irlen 8 -expected-id 0x41111043
+set _CHIPNAME ecp5
+jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x41111043

--- a/litex_boards/prog/openocd_colorlight_5a_75b.cfg
+++ b/litex_boards/prog/openocd_colorlight_5a_75b.cfg
@@ -1,10 +1,10 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6014
-ftdi_channel 0
-ftdi_layout_init 0x00e8 0x60eb
+adapter driver ftdi
+adapter speed 25000
+transport select jtag
+ftdi vid_pid 0x0403 0x6014
+ftdi channel 0
+ftdi layout_init 0x00e8 0x60eb
 reset_config none
-
-adapter_khz 25000
 
 set _CHIPNAME ecp5
 jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x41111043

--- a/litex_boards/prog/openocd_ecpix5.cfg
+++ b/litex_boards/prog/openocd_ecpix5.cfg
@@ -6,4 +6,5 @@ reset_config none
 
 adapter_khz 25000
 
-jtag newtap ecp5 tap -irlen 8 -expected-id 0x81113043
+set _CHIPNAME ecp5
+jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x81113043

--- a/litex_boards/prog/openocd_ecpix5.cfg
+++ b/litex_boards/prog/openocd_ecpix5.cfg
@@ -1,10 +1,10 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6010
-ftdi_channel 0
-ftdi_layout_init 0xfff8 0xfffb
+adapter driver ftdi
+adapter speed 25000
+transport select jtag
+ftdi vid_pid 0x0403 0x6010
+ftdi channel 0
+ftdi layout_init 0xfff8 0xfffb
 reset_config none
-
-adapter_khz 25000
 
 set _CHIPNAME ecp5
 jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x81113043

--- a/litex_boards/prog/openocd_fpc_iii.cfg
+++ b/litex_boards/prog/openocd_fpc_iii.cfg
@@ -1,18 +1,12 @@
 adapter driver ftdi
+adapter speed 25000
 transport select jtag
-
-# ftdi_device_desc "FPC-III" (once programmed)
-ftdi_vid_pid 0x1209 0xFC30 0x0403 0x6010
-
-ftdi_channel 0
-
-ftdi_layout_init 0xfff8 0xfffb
-ftdi_layout_signal LED -ndata 0x10
+#ftdi device_desc "FPC-III" (once programmed)
+ftdi vid_pid 0x1209 0xFC30 0x0403 0x6010
+ftdi channel 0
+ftdi layout_init 0xfff8 0xfffb
+ftdi layout_signal LED -ndata 0x10
 reset_config none
 
-# default speed
-adapter speed 25000
-
-# ECP5 device - LFE5U-85
 set _CHIPNAME ecp5
 jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x41113043

--- a/litex_boards/prog/openocd_fpc_iii.cfg
+++ b/litex_boards/prog/openocd_fpc_iii.cfg
@@ -14,4 +14,5 @@ reset_config none
 adapter speed 25000
 
 # ECP5 device - LFE5U-85
-jtag newtap ecp5 tap -irlen 8 -expected-id 0x41113043
+set _CHIPNAME ecp5
+jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x41113043

--- a/litex_boards/prog/openocd_genesys2.cfg
+++ b/litex_boards/prog/openocd_genesys2.cfg
@@ -1,12 +1,12 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6010
-ftdi_channel 1
-ftdi_layout_init 0x00e8 0x60eb
+adapter driver ftdi
+adapter speed 25000
+ftdi vid_pid 0x0403 0x6010
+ftdi channel 1
+ftdi layout_init 0x00e8 0x60eb
 reset_config none
 
 source [find cpld/xilinx-xc7.cfg]
 source [find cpld/jtagspi.cfg]
-adapter_khz 25000
 
 proc fpga_program {} {
     global _CHIPNAME

--- a/litex_boards/prog/openocd_limesdr_mini_v2.cfg
+++ b/litex_boards/prog/openocd_limesdr_mini_v2.cfg
@@ -1,10 +1,9 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6010
-ftdi_channel 0
-ftdi_layout_init 0xfff8 0xfffb
+adapter driver ftdi
+adapter speed 25000
+ftdi vid_pid 0x0403 0x6010
+ftdi channel 0
+ftdi layout_init 0xfff8 0xfffb
 reset_config none
-
-adapter_khz 25000
 
 set _CHIPNAME ecp5
 jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x41112043

--- a/litex_boards/prog/openocd_limesdr_mini_v2.cfg
+++ b/litex_boards/prog/openocd_limesdr_mini_v2.cfg
@@ -7,4 +7,4 @@ reset_config none
 adapter_khz 25000
 
 set _CHIPNAME ecp5
-jtag newtap ecp5 tap -irlen 8 -expected-id 0x41112043
+jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x41112043

--- a/litex_boards/prog/openocd_marblemini.cfg
+++ b/litex_boards/prog/openocd_marblemini.cfg
@@ -1,10 +1,11 @@
 # openocd config file for Marble Mini
 # https://github.com/BerkeleyLab/Marble-mini
 
-interface ftdi
+adapter driver ftdi
+adapter speed 15000
 
 # This string needs programming into U21 EEPROM attached to U23 FT4232H
-# ftdi_device_desc "Marble Mini"
+#ftdi device_desc "Marble Mini"
 
 # Pin assignment consistent with MPSSE Channel A, Table 3.14 for FT4232H-56Q
 #  ADBUS0 (pin 12) USB_TCK
@@ -18,18 +19,15 @@ interface ftdi
 #  also to Q5, forces disable of Self_FPGA_* buffers
 
 # Default for FT4232H
-ftdi_vid_pid 0x0403 0x6011
+ftdi vid_pid 0x0403 0x6011
 
 # Choose channel for FPGA JTAG, 0 == Channel A?
-ftdi_channel 0
+ftdi channel 0
 
 # Just TCK TDI TDO TMS, all other pins driven high.
 # Not sure what controls DBUS banks C, D, and maybe even B.
-ftdi_layout_init 0xfff8 0xfffb
+ftdi layout_init 0xfff8 0xfffb
 reset_config none
-
-# default speed
-adapter_khz 15000
 
 # Cribbed from openocd-code/tcl/board/kasli.cfg
 source [find cpld/xilinx-xc7.cfg]

--- a/litex_boards/prog/openocd_netv2_rpi.cfg
+++ b/litex_boards/prog/openocd_netv2_rpi.cfg
@@ -1,13 +1,13 @@
-interface bcm2835gpio
+adapter driver bcm2835gpio
+adapter speed 10000
 transport select jtag
-bcm2835gpio_peripheral_base 0x3F000000
-bcm2835gpio_speed_coeffs 100000 5
-bcm2835gpio_jtag_nums 4 17 27 22
-bcm2835gpio_srst_num 24
+bcm2835gpio peripheral_base 0x3F000000
+bcm2835gpio speed_coeffs 100000 5
+bcm2835gpio jtag_nums 4 17 27 22
+bcm2835gpio srst_num 24
 reset_config none
 
 source [find cpld/xilinx-xc7.cfg]
-adapter_khz 10000
 
 proc fpga_program {} {
     global _CHIPNAME

--- a/litex_boards/prog/openocd_nexys_video.cfg
+++ b/litex_boards/prog/openocd_nexys_video.cfg
@@ -1,12 +1,12 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6010
-ftdi_channel 1
-ftdi_layout_init 0x00e8 0x60eb
+adapter driver ftdi
+adapter speed 25000
+ftdi vid_pid 0x0403 0x6010
+ftdi channel 1
+ftdi layout_init 0x00e8 0x60eb
 reset_config none
 
 source [find cpld/xilinx-xc7.cfg]
 source [find cpld/jtagspi.cfg]
-adapter_khz 25000
 
 proc fpga_program {} {
     global _CHIPNAME

--- a/litex_boards/prog/openocd_trellisboard.cfg
+++ b/litex_boards/prog/openocd_trellisboard.cfg
@@ -6,4 +6,5 @@ reset_config none
 
 adapter_khz 5000
 
-jtag newtap ecp5 tap -irlen 8 -expected-id 0x81113043
+set _CHIPNAME ecp5
+jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x81113043

--- a/litex_boards/prog/openocd_trellisboard.cfg
+++ b/litex_boards/prog/openocd_trellisboard.cfg
@@ -1,10 +1,9 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6010
-ftdi_channel 0
-ftdi_layout_init 0xfff8 0xfffb
+adapter driver ftdi
+adapter speed 5000
+ftdi vid_pid 0x0403 0x6010
+ftdi channel 0
+ftdi layout_init 0xfff8 0xfffb
 reset_config none
-
-adapter_khz 5000
 
 set _CHIPNAME ecp5
 jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x81113043

--- a/litex_boards/prog/openocd_versa_ecp5.cfg
+++ b/litex_boards/prog/openocd_versa_ecp5.cfg
@@ -1,10 +1,9 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6010
-ftdi_channel 0
-ftdi_layout_init 0xfff8 0xfffb
+adapter driver ftdi
+adapter speed 25000
+ftdi vid_pid 0x0403 0x6010
+ftdi channel 0
+ftdi layout_init 0xfff8 0xfffb
 reset_config none
-
-adapter_khz 25000
 
 set _CHIPNAME ecp5
 jtag newtap _CHIPNAME tap -irlen 8 -expected-id 0x81112043

--- a/litex_boards/prog/openocd_versa_ecp5.cfg
+++ b/litex_boards/prog/openocd_versa_ecp5.cfg
@@ -6,4 +6,5 @@ reset_config none
 
 adapter_khz 25000
 
-jtag newtap ecp5 tap -irlen 8 -expected-id 0x81112043
+set _CHIPNAME ecp5
+jtag newtap _CHIPNAME tap -irlen 8 -expected-id 0x81112043

--- a/litex_boards/prog/openocd_xc6_ft2232.cfg
+++ b/litex_boards/prog/openocd_xc6_ft2232.cfg
@@ -1,12 +1,12 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6010
-ftdi_channel 0
-ftdi_layout_init 0x00e8 0x60eb
+adapter driver ftdi
+adapter speed 25000
+ftdi vid_pid 0x0403 0x6010
+ftdi channel 0
+ftdi layout_init 0x00e8 0x60eb
 reset_config none
 
 source [find cpld/xilinx-xc6s.cfg]
 source [find cpld/jtagspi.cfg]
-adapter_khz 25000
 
 proc fpga_program {} {
     global _CHIPNAME

--- a/litex_boards/prog/openocd_xc6_ft232.cfg
+++ b/litex_boards/prog/openocd_xc6_ft232.cfg
@@ -1,12 +1,12 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6014
-ftdi_channel 0
-ftdi_layout_init 0x00e8 0x60eb
+adapter driver ftdi
+adapter speed 25000
+ftdi vid_pid 0x0403 0x6014
+ftdi channel 0
+ftdi layout_init 0x00e8 0x60eb
 reset_config none
 
 source [find cpld/xilinx-xc6s.cfg]
 source [find cpld/jtagspi.cfg]
-adapter_khz 25000
 
 proc fpga_program {} {
     global _CHIPNAME

--- a/litex_boards/prog/openocd_xc7_ft2232.cfg
+++ b/litex_boards/prog/openocd_xc7_ft2232.cfg
@@ -1,12 +1,12 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6010
-ftdi_channel 0
-ftdi_layout_init 0x00e8 0x60eb
+adapter driver ftdi
+adapter speed 25000
+ftdi vid_pid 0x0403 0x6010
+ftdi channel 0
+ftdi layout_init 0x00e8 0x60eb
 reset_config none
 
 source [find cpld/xilinx-xc7.cfg]
 source [find cpld/jtagspi.cfg]
-adapter_khz 25000
 
 proc fpga_program {} {
     global _CHIPNAME

--- a/litex_boards/prog/openocd_xc7_ft232.cfg
+++ b/litex_boards/prog/openocd_xc7_ft232.cfg
@@ -1,12 +1,12 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6014
-ftdi_channel 0
-ftdi_layout_init 0x00e8 0x60eb
+adapter driver ftdi
+adapter speed 25000
+ftdi vid_pid 0x0403 0x6014
+ftdi channel 0
+ftdi layout_init 0x00e8 0x60eb
 reset_config none
 
 source [find cpld/xilinx-xc7.cfg]
 source [find cpld/jtagspi.cfg]
-adapter_khz 25000
 
 proc fpga_program {} {
     global _CHIPNAME

--- a/litex_boards/prog/openocd_xc7_ft4232.cfg
+++ b/litex_boards/prog/openocd_xc7_ft4232.cfg
@@ -1,12 +1,12 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6011
-ftdi_channel 0
-ftdi_layout_init 0x00e8 0x60eb
+adapter driver ftdi
+adapter speed 25000
+ftdi vid_pid 0x0403 0x6011
+ftdi channel 0
+ftdi layout_init 0x00e8 0x60eb
 reset_config none
 
 source [find cpld/xilinx-xc7.cfg]
 source [find cpld/jtagspi.cfg]
-adapter_khz 25000
 
 proc fpga_program {} {
     global _CHIPNAME

--- a/litex_boards/prog/openocd_xcau25p_ft323.cfg
+++ b/litex_boards/prog/openocd_xcau25p_ft323.cfg
@@ -1,10 +1,11 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6014
-ftdi_channel 0
-ftdi_layout_init 0x00e8 0x60eb
+adapter driver ftdi
+adapter speed 25000
+ftdi vid_pid 0x0403 0x6014
+ftdi channel 0
+ftdi layout_init 0x00e8 0x60eb
 reset_config none
 
-#openocd missing support, added to local cfg file
+# openocd missing support, added to local cfg file
 
 set CHIP XCAU25P
 
@@ -55,7 +56,6 @@ proc xcu_program {tap} {
 }
 
 source [find cpld/jtagspi.cfg]
-adapter_khz 25000
 
 
 proc fpga_program {} {


### PR DESCRIPTION
As discussed in #513 here are two commits adjusting the config:

- 63adcb931b2c44c0b4c3d8a28cde2732acc1c318 which fixes a bug when `$_CHIPNAME` is not defined:
  `set _CHIPNAME ecp5` as the only change.

- 95b6fa1587612bda7279bfdcb1e7b843db5f1c76 which convert the syntax to the supported format.

These kind of refactoring are not *expected* to break anything, but still has the risk of any refactoring.
Should I keep the second commit away until everything can be tested again?