### PR TITLE
Allow use of OpenOCD for the Crosslink-NX

### DIFF
--- a/litex_boards/platforms/lattice_crosslink_nx_evn.py
+++ b/litex_boards/platforms/lattice_crosslink_nx_evn.py
@@ -9,6 +9,7 @@ from litex.build.generic_platform import *
 from litex.build.lattice import LatticeNexusPlatform
 from litex.build.lattice.programmer import LatticeProgrammer
 from litex.build.lattice.programmer import EcpprogProgrammer
+from litex.build.lattice.programmer import OpenOCDJTAGProgrammer
 
 # IOs ----------------------------------------------------------------------------------------------
 
@@ -271,11 +272,13 @@ class Platform(LatticeNexusPlatform):
 
     def create_programmer(self, mode = "direct", prog="radiant"):
         assert mode in ["direct","flash"]
-        assert prog in ["radiant","ecpprog"]
+        assert prog in ["radiant","ecpprog","openocd"]
 
         if prog == "ecpprog":
             return EcpprogProgrammer()
 
+        if prog == "openocd":
+            return OpenOCDJTAGProgrammer("openocd_evn_nx.cfg")
 
         xcf_template_direct = """<?xml version='1.0' encoding='utf-8' ?>
 <!DOCTYPE		ispXCF	SYSTEM	"IspXCF.dtd" >

--- a/litex_boards/prog/openocd_evn_nx.cfg
+++ b/litex_boards/prog/openocd_evn_nx.cfg
@@ -1,0 +1,10 @@
+adapter driver ftdi
+adapter speed 25000
+transport select jtag
+ftdi vid_pid 0x0403 0x6010
+ftdi channel 0
+ftdi layout_init 0x00e8 0x60eb
+reset_config none
+
+set _CHIPNAME crosslink_nx
+jtag newtap $_CHIPNAME tap -irlen 8 -expected-id 0x110f1043

--- a/litex_boards/targets/lattice_crosslink_nx_evn.py
+++ b/litex_boards/targets/lattice_crosslink_nx_evn.py
@@ -106,7 +106,7 @@ def main():
     parser.add_target_argument("--device",        default="LIFCL-40-9BG400C", help="FPGA device (LIFCL-40-9BG400C, LIFCL-40-8BG400CES, or LIFCL-40-8BG400CES2).")
     parser.add_target_argument("--sys-clk-freq",  default=75e6, type=float,   help="System clock frequency.")
     parser.add_target_argument("--serial",        default="serial",           help="UART Pins (serial (requires R15 and R17 to be soldered) or serial_pmod[0-2]).")
-    parser.add_target_argument("--programmer",    default="radiant",          help="Programmer (radiant or ecpprog).")
+    parser.add_target_argument("--programmer",    default="radiant",          help="Programmer (radiant or ecpprog or openocd).")
     parser.add_target_argument("--address",       default=0x0,                help="Flash address to program bitstream at.")
     parser.add_target_argument("--prog-target",   default="direct",           help="Programming Target (direct or flash).")
     args = parser.parse_args()


### PR DESCRIPTION
This adds the support for Crosslink-NX EVN FTDI in JTAG mode, through OpenOCD.
This does not yet permit to use the JTAG for a serial connection with the bus (JTAGBone), as the `JTAG` instance is still not figured out, but hopefully I'll get there soon!