### PR TITLE
platforms/crosslink_nx_evn: allow use of UARTBone

### DIFF
--- a/litex_boards/platforms/lattice_crosslink_nx_evn.py
+++ b/litex_boards/platforms/lattice_crosslink_nx_evn.py
@@ -259,6 +259,16 @@ class Platform(LatticeNexusPlatform):
         assert device in ["LIFCL-40-9BG400C", "LIFCL-40-8BG400CES"]
         LatticeNexusPlatform.__init__(self, device, _io, _connectors, toolchain=toolchain, **kwargs)
 
+    def request(self, *args, **kwargs):
+        import time
+        if "serial" in args:
+            msg =  "FT2232H will be used as serial, make sure that:\n"
+            msg += " -the hardware has been modified: R18 and R19 should be removed, two 0 Ω resistors shoud be populated on R15 (and not R16) and R17.\n"
+            msg += " -the chip is configured as UART with virtual COM on port B (With FTProg or https://github.com/trabucayre/fixFT2232_ecp5evn)."
+            print(msg)
+            time.sleep(2)
+        return LatticeNexusPlatform.request(self, *args, **kwargs)
+
     def create_programmer(self, mode = "direct", prog="radiant"):
         assert mode in ["direct","flash"]
         assert prog in ["radiant","ecpprog"]

--- a/litex_boards/targets/lattice_crosslink_nx_evn.py
+++ b/litex_boards/targets/lattice_crosslink_nx_evn.py
@@ -92,6 +92,12 @@ class BaseSoC(SoCCore):
                 pads         = Cat(*[platform.request("user_led", i) for i in range(14)]),
                 sys_clk_freq = sys_clk_freq)
 
+        # UARTBone ---------------------------------------------------------------------------------
+        debug_uart = False
+        if debug_uart:
+            self.add_uartbone()
+
+
 # Build --------------------------------------------------------------------------------------------
 
 def main():


### PR DESCRIPTION
This goes along a small resistor jumper modification and firmware flashing like it is for the ECP5 board. A warning message is added as the default serial might be affected (--serial serial by default). The FTDI modification software used for the ECP5 seems to be requried and matching.

```
litex@lap1:$ targets/lattice_crosslink_nx_evn.py --csr-csv=csr.csv --toolchain=oxide --uart-name=crossover+uartbone --build --load
[...build logs with the extra message and 2s of wait time (sorry! open to suggestions)...]
litex@lap1:$
```

```
litex@lap1:$ litex_server --uart --uart-port /dev/ttyUSB0
[CommUART] port: /dev/ttyUSB0 / baudrate: 115200 / tcp port: 1234
Connected with 127.0.0.1:41364
Disconnect
Connected with 127.0.0.1:41366
Disconnect
Connected with 127.0.0.1:41382
Disconnect
Connected with 127.0.0.1:41384
Disconnect
Connected with 127.0.0.1:41394
Disconnect
```

```
litex@lap1:$ litex_cli --regs
0xf0000000 : 0x00000000 ctrl_reset
0xf0000004 : 0x12345678 ctrl_scratch
0xf0000008 : 0x00000000 ctrl_bus_errors
0xf0001000 : 0x00000000 leds_out
0xf0001800 : 0x00000000 timer0_load
0xf0001804 : 0x00000000 timer0_reload
0xf0001808 : 0x00000000 timer0_en
0xf000180c : 0x00000000 timer0_update_value
0xf0001810 : 0x00000000 timer0_value
0xf0001814 : 0x00000001 timer0_ev_status
0xf0001818 : 0x00000001 timer0_ev_pending
0xf000181c : 0x00000000 timer0_ev_enable
0xf0002000 : 0x00000000 uart_rxtx
0xf0002004 : 0x00000001 uart_txfull
0xf0002008 : 0x00000001 uart_rxempty
0xf000200c : 0x00000000 uart_ev_status
0xf0002010 : 0x00000000 uart_ev_pending
0xf0002014 : 0x00000003 uart_ev_enable
0xf0002018 : 0x00000000 uart_txempty
0xf000201c : 0x00000000 uart_rxfull
0xf0002020 : 0x00000020 uart_xover_rxtx
0xf0002024 : 0x00000000 uart_xover_txfull
0xf0002028 : 0x00000000 uart_xover_rxempty
0xf000202c : 0x00000003 uart_xover_ev_status
0xf0002030 : 0x00000003 uart_xover_ev_pending
0xf0002034 : 0x00000000 uart_xover_ev_enable
0xf0002038 : 0x00000001 uart_xover_txempty
0xf000203c : 0x00000001 uart_xover_rxfull
litex@lap1:$
```