### PR TITLE
Digilent CMOD A7 ISSIRAM fix

### DIFF
--- a/litex_boards/platforms/digilent_cmod_a7.py
+++ b/litex_boards/platforms/digilent_cmod_a7.py
@@ -49,6 +49,7 @@ _io = [
             IOStandard("LVCMOS33")),
         Subsignal("wen", Pins("R19"), IOStandard("LVCMOS33")),
         Subsignal("cen", Pins("N19"), IOStandard("LVCMOS33")),
+        Subsignal("oe",  Pins("P19"), IOStandard("LVCMOS33")),
         Misc("SLEW=FAST"),
     ),
 

--- a/litex_boards/targets/digilent_cmod_a7.py
+++ b/litex_boards/targets/digilent_cmod_a7.py
@@ -70,7 +70,8 @@ class AsyncSRAM(LiteXModule):
         self.comb += [
             cen.eq(~chip_ena),
             wen.eq(~write_ena),
-            tristate_data.oe.eq(write_ena)
+            tristate_data.oe.eq(write_ena),
+            oe.eq(tristate_data.oe),
         ]
         ########################
         # address and data

--- a/litex_boards/targets/digilent_cmod_a7.py
+++ b/litex_boards/targets/digilent_cmod_a7.py
@@ -56,6 +56,7 @@ class AsyncSRAM(LiteXModule):
         data = issiram.data
         wen = issiram.wen
         cen = issiram.cen
+        oe = issiram.oe
         ########################
         tristate_data = TSTriple(data_width)
         self.specials += tristate_data.get_tristate(data)


### PR DESCRIPTION
# Description

The default platform/target files for the Digilent Cmod A7 (https://digilent.com/reference/programmable-logic/cmod-a7/reference-manual) are not driving the `OE` pin on the ISSIRAM, so each read will fail and just return (0xFFFFFFFF), writes are working fine ( verified this with a scope ).

The ISSI documentation ( https://www.issi.com/WW/pdf/61-64WV5128Axx-Bxx.pdf?_ga=2.137274229.438686238.1691258285-1474693682.1688611108) clearly mentions the OE pin (as an active low signal) that needs to be driven low for reads.

According to the XDC provided by Digilent the `OE` pin is on **`P19`** ( Source: https://github.com/Digilent/digilent-xdc/blob/deb00e66689337700b3a18c0e3776dcf4a59655b/Cmod-A7-Master.xdc#L129 ) 

I just added the missing pin/subsignal definiton to the IO array in `platforms/digilent_cmod.a7.py` and added the logic to `targets/digilent_cmod_a7.py` to drive it based on the already defined tristate `OE` logic.

# Tests

Here is a screenshot of my plain soc with a UARTBone interactive terminal before the the fix trying to read/write to the SRAM (at address 0x40000000 - 0x40080000, 512Kb):

![kép](https://github.com/litex-hub/litex-boards/assets/3492831/b1ebec33-762e-4266-9715-de5ec05abd0b)

And after the fix applied:

![kép](https://github.com/litex-hub/litex-boards/assets/3492831/b9481885-8923-4256-8c68-39499da9dc3f)

