### PR TITLE
targets/lattice_crosslink_nx_evn: fix arguments in flash programming

### DIFF
--- a/litex_boards/targets/lattice_crosslink_nx_evn.py
+++ b/litex_boards/targets/lattice_crosslink_nx_evn.py
@@ -124,7 +124,7 @@ def main():
     if args.load:
         prog = soc.platform.create_programmer(args.prog_target, args.programmer)
         if args.programmer == "ecpprog" and args.prog_target == "flash":
-            prog.flash(address=args.address, bitstream=builder.get_bitstream_filename(mode="sram"))
+            prog.flash(args.address, builder.get_bitstream_filename(mode="sram"))
         else:
             prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
 


### PR DESCRIPTION
To reproduce the bug:
```
(litex-3.11) lap1$ targets/lattice_crosslink_nx_evn.py --programmer=ecpprog --load --prog-target flash
[...]
Traceback (most recent call last):
  File "/home/litex/litex-boards/litex_boards/targets/lattice_crosslink_nx_evn.py", line 132, in <module>
    main()
  File "/home/litex/litex-boards/litex_boards/targets/lattice_crosslink_nx_evn.py", line 127, in main
    prog.flash(address=args.address, bitstream=builder.get_bitstream_filename(mode="sram"))
TypeError: EcpprogProgrammer.flash() got an unexpected keyword argument 'bitstream'
(litex-3.11) lap1$
```

After the commit:
```
(litex-3.11) lap1$ targets/lattice_crosslink_nx_evn.py --programmer=ecpprog --load --prog-target flash
[...]
init..
IDCODE: 0x110f1043 (LIFCL-40)
NX Status Register: 0x0000110100000100
reset..
flash ID: 0xC2 0x20 0x18
file size: 958894
erase 64kB sector at 0x000000..
erase 64kB sector at 0x010000..
erase 64kB sector at 0x020000..
erase 64kB sector at 0x030000..
erase 64kB sector at 0x040000..
erase 64kB sector at 0x050000..
erase 64kB sector at 0x060000..
erase 64kB sector at 0x070000..
erase 64kB sector at 0x080000..
erase 64kB sector at 0x090000..
erase 64kB sector at 0x0A0000..
erase 64kB sector at 0x0B0000..
erase 64kB sector at 0x0C0000..
erase 64kB sector at 0x0D0000..
erase 64kB sector at 0x0E0000..
programming..  958894/958894
verify..       958894/958894  VERIFY OK
Bye.
(litex-3.11) lap1$
```