### PR TITLE
platforms/crosslink_nx_evn: add SPI flash support

### DIFF
--- a/litex_boards/targets/lattice_crosslink_nx_evn.py
+++ b/litex_boards/targets/lattice_crosslink_nx_evn.py
@@ -68,6 +68,7 @@ class BaseSoC(SoCCore):
     }
     def __init__(self, sys_clk_freq=75e6, device="LIFCL-40-9BG400C", toolchain="radiant",
         with_led_chaser = True,
+        with_spi_flash  = False,
         **kwargs):
         platform = lattice_crosslink_nx_evn.Platform(device=device, toolchain=toolchain)
 
@@ -97,6 +98,12 @@ class BaseSoC(SoCCore):
         if debug_uart:
             self.add_uartbone()
 
+        # SPI Flash --------------------------------------------------------------------------------
+        if with_spi_flash:
+            from litespi.modules import MX25L12833F
+            from litespi.opcodes import SpiNorFlashOpCodes as Codes
+            self.add_spi_flash(mode="4x", clk_freq=100_000, module=MX25L12833F(Codes.READ_4_4_4), with_master=True)
+
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -109,12 +116,14 @@ def main():
     parser.add_target_argument("--programmer",    default="radiant",          help="Programmer (radiant or ecpprog).")
     parser.add_target_argument("--address",       default=0x0,                help="Flash address to program bitstream at.")
     parser.add_target_argument("--prog-target",   default="direct",           help="Programming Target (direct or flash).")
+    parser.add_target_argument("--with-spi-flash", action="store_true",       help="Enable SPI Flash (MMAPed).")
     args = parser.parse_args()
 
     soc = BaseSoC(
         sys_clk_freq = args.sys_clk_freq,
         device       = args.device,
         toolchain    = args.toolchain,
+        with_spi_flash = args.with_spi_flash,
         **parser.soc_argdict
     )
     builder = Builder(soc, **parser.builder_argdict)


### PR DESCRIPTION
This appears to work to me:

```
(litex-3.11) lap1$1 litex_term /dev/ttyUSB1

        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2023 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Aug 11 2023 16:21:15
 BIOS CRC passed (b12549e4)

 LiteX git sha1: 577674bf

--=============== SoC ==================--
CPU:            VexRiscv @ 75MHz
BUS:            WISHBONE 32-bit @ 4GiB
CSR:            32-bit data
ROM:            128.0KiB
SRAM:           128.0KiB
FLASH:          16.0MiB

--========== Initialization ============--

Initializing MX25L12833F SPI Flash @0x01000000...
Enabling Quad mode...
Switching to QPI mode...
SPI Flash clk configured to 0 MHz
Memspeed at 0x1000000 (Sequential, 4.0KiB)...
   Read speed: 7.2MiB/s
Memspeed at 0x1000000 (Random, 4.0KiB)...
   Read speed: 2.3MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
Timeout
No boot medium found

--============= Console ================--

litex> mem_list
Available memory regions:
ROM       0x00000000 0x20000
SRAM      0x10000000 0x20000
SPIFLASH  0x01000000 0x1000000
CSR       0xf0000000 0x10000

litex> mem_read 0x01000000 100
Memory dump:
0x01000000  49 20 62 65 6c 69 65 76 65 20 74 68 69 73 20 69  I believe this i
0x01000010  73 20 6f 6e 20 74 68 65 20 66 6c 61 73 68 2c 20  s on the flash,
0x01000020  61 6e 64 20 74 68 61 74 20 77 65 20 63 61 6e 20  and that we can
0x01000030  72 65 61 64 20 69 74 20 62 61 63 6b 20 77 69 74  read it back wit
0x01000040  68 6f 75 74 20 70 72 6f 62 6c 65 6d 2e 20 44 6f  hout problem. Do
0x01000050  6e 27 74 20 79 6f 75 3f 0a ff ff ff ff ff ff ff  n't you?........
0x01000060  ff ff ff ff                                      ....

litex>
```

I took inspiration on the other boards, is this done the right way?