### PR TITLE
Resolve High Density bank IOStandard error

### DIFF
--- a/litex_boards/platforms/xilinx_zcu102.py
+++ b/litex_boards/platforms/xilinx_zcu102.py
@@ -13,8 +13,8 @@ from litex.build.xilinx import XilinxUSPPlatform, VivadoProgrammer
 _io = [
     # Clk / Rst
     ("clk125", 0,
-        Subsignal("p", Pins("G21"), IOStandard("LVDS")),
-        Subsignal("n", Pins("F21"), IOStandard("LVDS")),
+        Subsignal("p", Pins("G21"), IOStandard("LVDS_25")),
+        Subsignal("n", Pins("F21"), IOStandard("LVDS_25")),
     ),
     ("clk300", 0,
         Subsignal("p", Pins("AL8"), IOStandard("DIFF_SSTL12_DCI")),


### PR DESCRIPTION
This resolves the following error during `build` on Vivado 2023.1:
``ERROR: [DRC BIVB-1] Bank IO standard Support: Bank 47 has incompatible IO(s) because: The LVDS I/O standard is not supported for banks of type High Density. Move the following ports or change their properties:
clk125_p``