### PR TITLE
Update sipeed_tang_nano_9k.py so serial works

### DIFF
--- a/litex_boards/targets/sipeed_tang_nano_9k.py
+++ b/litex_boards/targets/sipeed_tang_nano_9k.py
@@ -73,7 +73,7 @@ class BaseSoC(SoCCore):
 
         # SoCCore ----------------------------------------------------------------------------------
         # Disable Integrated ROM
-        kwargs["integrated_rom_size"] = 0
+        # kwargs["integrated_rom_size"] = 0
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Tang Nano 9K", **kwargs)
 
         # SPI Flash --------------------------------------------------------------------------------
@@ -82,12 +82,12 @@ class BaseSoC(SoCCore):
         self.add_spi_flash(mode="1x", module=W25Q32(Codes.READ_1_1_1), with_master=False)
 
         # Add ROM linker region --------------------------------------------------------------------
-        self.bus.add_region("rom", SoCRegion(
-            origin = self.bus.regions["spiflash"].origin + bios_flash_offset,
-            size   = 64*kB,
-            linker = True)
-        )
-        self.cpu.set_reset_address(self.bus.regions["rom"].origin)
+        #self.bus.add_region("rom", SoCRegion(
+        #    origin = self.bus.regions["spiflash"].origin + bios_flash_offset,
+        #    size   = 64*kB,
+        #    linker = True)
+        #)
+        #self.cpu.set_reset_address(self.bus.regions["rom"].origin)
 
         # HyperRAM ---------------------------------------------------------------------------------
         if not self.integrated_main_ram_size:


### PR DESCRIPTION
I wanted to save folks the three hours of troubleshooting why there was no serial terminal that I went through yesterday :) I confirmed that with these lines uncommented I cannot connect to the device, when I comment them out the terminal/bios works fine.

Commenting these lines out was the advice I found in a number of issues. I am not sure why it's not in the board file already, I figured I'd try and help out.