### PR TITLE
Correct pinout for VGA connector

### DIFF
--- a/litex_boards/platforms/digilent_basys3.py
+++ b/litex_boards/platforms/digilent_basys3.py
@@ -67,7 +67,7 @@ _io = [
     # VGA
     ("vga", 0,
         Subsignal("hsync_n", Pins("P19")),
-        Subsignal("vsync_n", Pins("R18")),
+        Subsignal("vsync_n", Pins("R19")),
         Subsignal("r", Pins("G19 H19 J19 N19")),
         Subsignal("g", Pins("J17 H17 G17 D17")),
         Subsignal("b", Pins("N18 L18 K18 J18")),


### PR DESCRIPTION
I spent quite some time scratching my head why i got no picture from litex when all looked good and the default basys example produced a very crisp picture.. Until i found this!

And an open question: i notice there are no defines either for the onboard flash or the 4x7 segment, should i add these? perhaps in a separate PR?