### PR TITLE
qmtech core boards: make core resources optional

### DIFF
--- a/litex_boards/platforms/qmtech_10cl006.py
+++ b/litex_boards/platforms/qmtech_10cl006.py
@@ -130,7 +130,7 @@ class Platform(AlteraPlatform):
         ),
     ]
 
-    def __init__(self, toolchain="quartus", with_daughterboard=False):
+    def __init__(self, toolchain="quartus", with_daughterboard=False, with_core_resources=True):
         device = "10CL006YU256C8G"
         io = _io
         connectors = _connectors
@@ -140,7 +140,7 @@ class Platform(AlteraPlatform):
             daughterboard = QMTechDaughterboard(IOStandard("3.3-V LVTTL"))
             io += daughterboard.io
             connectors += daughterboard.connectors
-        else:
+        elif with_core_resources:
             io += self.core_resources
 
         AlteraPlatform.__init__(self, device, io, connectors, toolchain=toolchain)

--- a/litex_boards/platforms/qmtech_5cefa2.py
+++ b/litex_boards/platforms/qmtech_5cefa2.py
@@ -129,7 +129,7 @@ class Platform(AlteraPlatform):
         ),
  ]
 
-    def __init__(self, toolchain="quartus", with_daughterboard=False):
+    def __init__(self, toolchain="quartus", with_daughterboard=False, with_core_resources=True):
         device = "5CEFA2F23C8"
         io = _io
         connectors = _connectors
@@ -139,7 +139,7 @@ class Platform(AlteraPlatform):
             daughterboard = QMTechDaughterboard(IOStandard("3.3-V LVTTL"))
             io += daughterboard.io
             connectors += daughterboard.connectors
-        else:
+        elif with_core_resources:
             io += self.core_resources
 
         AlteraPlatform.__init__(self, device, io, connectors, toolchain=toolchain)

--- a/litex_boards/platforms/qmtech_5cefa5.py
+++ b/litex_boards/platforms/qmtech_5cefa5.py
@@ -132,7 +132,7 @@ class Platform(AlteraPlatform):
         ),
  ]
 
-    def __init__(self, toolchain="quartus", with_daughterboard=False):
+    def __init__(self, toolchain="quartus", with_daughterboard=False, with_core_resources=True):
         device = "5CEFA5F23I7"
         io = _io
         connectors = _connectors
@@ -142,7 +142,7 @@ class Platform(AlteraPlatform):
             daughterboard = QMTechDaughterboard(IOStandard("3.3-V LVCMOS"))
             io += daughterboard.io
             connectors += daughterboard.connectors
-        else:
+        elif with_core_resources:
             io += self.core_resources
 
         AlteraPlatform.__init__(self, device, io, connectors, toolchain=toolchain)

--- a/litex_boards/platforms/qmtech_ep4cex5.py
+++ b/litex_boards/platforms/qmtech_ep4cex5.py
@@ -130,7 +130,7 @@ class Platform(AlteraPlatform):
         ),
     ]
 
-    def __init__(self, variant="ep4ce15", toolchain="quartus", with_daughterboard=False):
+    def __init__(self, variant="ep4ce15", toolchain="quartus", with_daughterboard=False, with_core_resources=True):
         device = {
             "ep4ce15": "EP4CE15F23C8",
             "ep4ce55": "EP4CE55F23C8"
@@ -143,7 +143,7 @@ class Platform(AlteraPlatform):
             daughterboard = QMTechDaughterboard(IOStandard("3.3-V LVTTL"))
             io += daughterboard.io
             connectors += daughterboard.connectors
-        else:
+        elif with_core_resources:
             io += self.core_resources
 
         AlteraPlatform.__init__(self, device, io, connectors, toolchain=toolchain)

--- a/litex_boards/platforms/qmtech_ep4cgx150.py
+++ b/litex_boards/platforms/qmtech_ep4cgx150.py
@@ -131,7 +131,7 @@ class Platform(AlteraPlatform):
         ),
     ]
 
-    def __init__(self, toolchain="quartus", with_daughterboard=False):
+    def __init__(self, toolchain="quartus", with_daughterboard=False, with_core_resources=True):
         device = "EP4CGX150DF27I7"
         io = _io
         connectors = _connectors
@@ -141,7 +141,7 @@ class Platform(AlteraPlatform):
             daughterboard = QMTechDaughterboard(IOStandard("3.3-V LVTTL"))
             io += daughterboard.io
             connectors += daughterboard.connectors
-        else:
+        elif with_core_resources:
             io += self.core_resources
 
         AlteraPlatform.__init__(self, device, io, connectors, toolchain=toolchain)

--- a/litex_boards/platforms/qmtech_xc7a35t.py
+++ b/litex_boards/platforms/qmtech_xc7a35t.py
@@ -145,7 +145,7 @@ class Platform(Xilinx7SeriesPlatform):
         ("cpu_reset", 0, Pins("K5"), IOStandard("LVCMOS33")),
     ]
 
-    def __init__(self, toolchain="vivado", with_daughterboard=False):
+    def __init__(self, toolchain="vivado", with_daughterboard=False, with_core_resources=True):
         device = "xc7a35tftg256-1"
         io = _io
         connectors = _connectors
@@ -155,7 +155,7 @@ class Platform(Xilinx7SeriesPlatform):
             daughterboard = QMTechDaughterboard(IOStandard("LVCMOS33"))
             io += daughterboard.io
             connectors += daughterboard.connectors
-        else:
+        elif with_core_resources:
             io += self.core_resources
 
         Xilinx7SeriesPlatform.__init__(self, device, io, connectors, toolchain=toolchain)

--- a/litex_boards/platforms/qmtech_xc7k325t.py
+++ b/litex_boards/platforms/qmtech_xc7k325t.py
@@ -151,7 +151,7 @@ class Platform(XilinxPlatform):
         ("user_led", 1, Pins("H26"), IOStandard("LVCMOS33")),
     ]
 
-    def __init__(self, toolchain="vivado", with_daughterboard=False):
+    def __init__(self, toolchain="vivado", with_daughterboard=False, with_core_resources=True):
         device = "xc7k325tffg676-1"
         io = _io
         connectors = _connectors
@@ -162,7 +162,7 @@ class Platform(XilinxPlatform):
             daughterboard = QMTechDaughterboard(IOStandard("LVCMOS33"))
             io += daughterboard.io
             connectors += daughterboard.connectors
-        else:
+        elif with_core_resources:
             io += self.core_resources_standalone
 
         XilinxPlatform.__init__(self, device, io, connectors, toolchain=toolchain)


### PR DESCRIPTION
This makes derivative designs (like MiSTeX) more flexible.