### PR TITLE
Better Altera SDRAM IO properties for more speed

### DIFF
--- a/litex_boards/platforms/qmtech_10cl006.py
+++ b/litex_boards/platforms/qmtech_10cl006.py
@@ -42,8 +42,13 @@ _io = [
         Subsignal("we_n",  Pins("P6")),
         Subsignal("dq", Pins(
             "K5 L3 L4 K6 N3 M6 P3 N5",
-            "N2 N1 L1 L2 K1 K2 J1 J2")),
+            "N2 N1 L1 L2 K1 K2 J1 J2"),
+             Misc("FAST_OUTPUT_ENABLE_REGISTER ON"),
+             Misc("FAST_INPUT_REGISTER ON")),
         Subsignal("dm", Pins("N6 P1")),
+        Misc("CURRENT_STRENGTH_NEW \"MAXIMUM CURRENT\""),
+        Misc("FAST_OUTPUT_REGISTER ON"),
+        Misc("ALLOW_SYNCH_CTRL_USAGE OFF"),
         IOStandard("3.3-V LVTTL")
     ),
 ]

--- a/litex_boards/platforms/qmtech_5cefa2.py
+++ b/litex_boards/platforms/qmtech_5cefa2.py
@@ -42,8 +42,13 @@ _io = [
         Subsignal("we_n",  Pins("W9")),
         Subsignal("dq", Pins(
             "AA12 Y11 AA10 AB10 Y10 AA9 AB8 AA8",
-            " U10 T10 U11  R12  U12 P12 R10 R11")),
+            " U10 T10 U11  R12  U12 P12 R10 R11"),
+            Misc("FAST_OUTPUT_ENABLE_REGISTER ON"),
+            Misc("FAST_INPUT_REGISTER ON")),
         Subsignal("dm", Pins("AB7 V10")),
+        Misc("CURRENT_STRENGTH_NEW \"MAXIMUM CURRENT\""),
+        Misc("FAST_OUTPUT_REGISTER ON"),
+        Misc("ALLOW_SYNCH_CTRL_USAGE OFF"),
         IOStandard("3.3-V LVTTL")
     ),
 ]

--- a/litex_boards/platforms/qmtech_5cefa5.py
+++ b/litex_boards/platforms/qmtech_5cefa5.py
@@ -44,8 +44,13 @@ _io = [
         Subsignal("we_n",  Pins("U20")),
         Subsignal("dq", Pins(
             "AA22 AB22 Y22 Y21 W22 W21 V21 U22 M21 M22 T22 R21 R22 P22 N20 N21 ",
-            "K22   K21 J22 J21 H21 G22 G21 F22 E22 E20 D22 D21 C21 B22 A22 B21")),
+            "K22   K21 J22 J21 H21 G22 G21 F22 E22 E20 D22 D21 C21 B22 A22 B21"),
+            Misc("FAST_OUTPUT_ENABLE_REGISTER ON"),
+            Misc("FAST_INPUT_REGISTER ON")),
         Subsignal("dm", Pins("U21 L22 K20 E21")),
+        Misc("CURRENT_STRENGTH_NEW \"MAXIMUM CURRENT\""),
+        Misc("FAST_OUTPUT_REGISTER ON"),
+        Misc("ALLOW_SYNCH_CTRL_USAGE OFF"),
         IOStandard("3.3-V LVCMOS")
     ),
 ]

--- a/litex_boards/platforms/qmtech_ep4cex5.py
+++ b/litex_boards/platforms/qmtech_ep4cex5.py
@@ -43,8 +43,13 @@ _io = [
         Subsignal("we_n",  Pins("AB4")),
         Subsignal("dq", Pins(
             "AA10 AB9 AA9 AB8 AA8 AB7 AA7 AB5",
-            "Y7 W8 Y8 V9 V10 Y10 W10 V11")),
+            "Y7 W8 Y8 V9 V10 Y10 W10 V11"),
+             Misc("FAST_OUTPUT_ENABLE_REGISTER ON"),
+             Misc("FAST_INPUT_REGISTER ON")),
         Subsignal("dm", Pins("AA5 W7")),
+        Misc("CURRENT_STRENGTH_NEW \"MAXIMUM CURRENT\""),
+        Misc("FAST_OUTPUT_REGISTER ON"),
+        Misc("ALLOW_SYNCH_CTRL_USAGE OFF"),
         IOStandard("3.3-V LVTTL")
     ),
 ]

--- a/litex_boards/platforms/qmtech_ep4cgx150.py
+++ b/litex_boards/platforms/qmtech_ep4cgx150.py
@@ -43,8 +43,13 @@ _io = [
         Subsignal("we_n",  Pins("G25")),
         Subsignal("dq", Pins(
             "B25 B26 C25 C26 D25 D26 E25 E26",
-            "H23 G24 G22 F24 F23 E24 D24 C24")),
+            "H23 G24 G22 F24 F23 E24 D24 C24"),
+             Misc("FAST_OUTPUT_ENABLE_REGISTER ON"),
+             Misc("FAST_INPUT_REGISTER ON")),
         Subsignal("dm", Pins("F26 H24")),
+        Misc("CURRENT_STRENGTH_NEW \"MAXIMUM CURRENT\""),
+        Misc("FAST_OUTPUT_REGISTER ON"),
+        Misc("ALLOW_SYNCH_CTRL_USAGE OFF"),
         IOStandard("3.3-V LVTTL")
     ),
 ]

--- a/litex_boards/targets/qmtech_5cefa5.py
+++ b/litex_boards/targets/qmtech_5cefa5.py
@@ -75,7 +75,7 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=80e6, with_daughterboard=False,
+    def __init__(self, sys_clk_freq=95e6, with_daughterboard=False,
         with_ethernet          = False,
         with_etherbone         = False,
         eth_ip                 = "192.168.1.50",

--- a/litex_boards/targets/qmtech_ep4cgx150.py
+++ b/litex_boards/targets/qmtech_ep4cgx150.py
@@ -136,7 +136,7 @@ class BaseSoC(SoCCore):
 def main():
     from litex.build.parser import LiteXArgumentParser
     parser = LiteXArgumentParser(platform=qmtech_ep4cgx150.Platform, description="LiteX SoC on QMTECH EP4CE15.")
-    parser.add_target_argument("--sys-clk-freq",        default=80e6, type=float, help="System clock frequency.")
+    parser.add_target_argument("--sys-clk-freq",        default=90e6, type=float, help="System clock frequency.")
     parser.add_target_argument("--sdram-rate",          default="1:1",            help="SDRAM Rate (1:1 Full Rate or 1:2 Half Rate).")
     parser.add_target_argument("--with-daughterboard",  action="store_true",      help="Board plugged into the QMTech daughterboard.")
     ethopts = parser.target_group.add_mutually_exclusive_group()


### PR DESCRIPTION
```
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2024 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Mar 30 2024 20:12:42
 BIOS CRC passed (796e7126)

 LiteX git sha1: 87137c30

--=============== SoC ==================--
CPU:		VexRiscv @ 95MHz
BUS:		wishbone 32-bit @ 4GiB
CSR:		32-bit data
ROM:		128.0KiB
SRAM:		8.0KiB
L2:		8.0KiB
SDRAM:		64.0MiB 32-bit @ 95MT/s (CL-2 CWL-2)
MAIN-RAM:	64.0MiB

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB     
   Read: 0x40000000-0x40200000 2.0MiB     
Memtest OK
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 31.7MiB/s
   Read speed: 47.8MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
             Timeout
No boot medium found

--============= Console ================--

litex> 
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2024 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Mar 30 2024 20:22:03
 BIOS CRC passed (15e4f7d8)

 LiteX git sha1: 87137c30

--=============== SoC ==================--
CPU:		VexRiscv @ 90MHz
BUS:		wishbone 32-bit @ 4GiB
CSR:		32-bit data
ROM:		128.0KiB
SRAM:		8.0KiB
L2:		8.0KiB
SDRAM:		32.0MiB 16-bit @ 90MT/s (CL-2 CWL-2)
MAIN-RAM:	32.0MiB

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB     
   Read: 0x40000000-0x40200000 2.0MiB     
Memtest OK
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 25.3MiB/s
   Read speed: 39.8MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
             Timeout
No boot medium found

--============= Console ================--
litex> ident
Ident: LiteX SoC on QMTECH EP4CGX150 + Daughterboard 2024-03-30 20:22:01
```