### PR TITLE
ZynqXXX boards: remove CSR definition and GP0 connection to CPU

### DIFF
--- a/litex_boards/targets/alinx_axu2cga.py
+++ b/litex_boards/targets/alinx_axu2cga.py
@@ -77,22 +77,11 @@ class BaseSoC(SoCCore):
         if kwargs.get("cpu_type", None) == "zynqmp":
             kwargs["integrated_sram_size"] = 0
             kwargs["with_uart"] = False
-            self.mem_map = {
-                "csr": 0x8000_0000, # Zynq GP0 default
-            }
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Alinx AXU2CGA", **kwargs)
 
         # ZynqMP Integration ---------------------------------------------------------------------
         if kwargs.get("cpu_type", None) == "zynqmp":
             self.cpu.config.update(platform.psu_config)
-
-            # Connect AXI HPM0 LPD to the SoC
-            wb_lpd = wishbone.Interface()
-            self.submodules += axi.AXI2Wishbone(
-                axi          = self.cpu.add_axi_gp_master(2, 32),
-                wishbone     = wb_lpd,
-                base_address = self.mem_map["csr"])
-            self.bus.add_master(master=wb_lpd)
 
             self.bus.add_region("sram", SoCRegion(
                 origin = self.cpu.mem_map["sram"],

--- a/litex_boards/targets/digilent_pynq_z1.py
+++ b/litex_boards/targets/digilent_pynq_z1.py
@@ -79,14 +79,6 @@ class BaseSoC(SoCCore):
             os.system("mv zybo_z7_ps7.txt xci/zybo_z7_ps7.xci")
             self.cpu.set_ps7_xci("xci/zybo_z7_ps7.xci")
 
-            # Connect AXI GP0 to the SoC with base address of 0x43c00000 (default one)
-            wb_gp0  = wishbone.Interface()
-            self.submodules += axi.AXI2Wishbone(
-                axi          = self.cpu.add_axi_gp_master(),
-                wishbone     = wb_gp0,
-                base_address = 0x43c00000)
-            self.bus.add_master(master=wb_gp0)
-
         # Video ------------------------------------------------------------------------------------
         if with_video_terminal:
             self.videophy = VideoS7HDMIPHY(platform.request("hdmi_tx"), clock_domain="hdmi")

--- a/litex_boards/targets/digilent_zedboard.py
+++ b/litex_boards/targets/digilent_zedboard.py
@@ -50,7 +50,6 @@ class _CRG(LiteXModule):
 
 
 class BaseSoC(SoCCore):
-    mem_map = {"csr": 0x43c0_0000}  # default GP0 address on Zynq
 
     def __init__(self, sys_clk_freq=100e6, with_led_chaser=True, **kwargs):
         platform = digilent_zedboard.Platform()
@@ -69,14 +68,6 @@ class BaseSoC(SoCCore):
             self.cpu.set_ps7(name="Zynq",
                              preset="ZedBoard",
                              config={'PCW_FPGA0_PERIPHERAL_FREQMHZ': sys_clk_freq / 1e6})
-
-            # Connect AXI GP0 to the SoC
-            wb_gp0 = wishbone.Interface()
-            self.submodules += axi.AXI2Wishbone(
-                axi          = self.cpu.add_axi_gp_master(),
-                wishbone     = wb_gp0,
-                base_address = self.mem_map["csr"])
-            self.bus.add_master(master=wb_gp0)
 
             self.bus.add_region("sram", SoCRegion(
                 origin = self.cpu.mem_map["sram"],

--- a/litex_boards/targets/krtkl_snickerdoodle.py
+++ b/litex_boards/targets/krtkl_snickerdoodle.py
@@ -81,20 +81,11 @@ class BaseSoC(SoCCore):
         if kwargs.get("cpu_type", None) == "zynq7000":
             kwargs["integrated_sram_size"] = 0
             kwargs["with_uart"]            = False
-            self.mem_map = {"csr": 0x4000_0000}  # Zynq GP0 default
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Snickerdoodle", **kwargs)
 
         # Zynq7000 Integration ---------------------------------------------------------------------
         if kwargs.get("cpu_type", None) == "zynq7000":
             load_ps7(self, xci_file)
-
-            # Connect AXI GP0 to the SoC with base address of 0x43c00000 (default one)
-            wb_gp0  = wishbone.Interface()
-            self.submodules += axi.AXI2Wishbone(
-                axi          = self.cpu.add_axi_gp_master(),
-                wishbone     = wb_gp0,
-                base_address = self.mem_map["csr"])
-            self.bus.add_master(master=wb_gp0)
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:

--- a/litex_boards/targets/redpitaya.py
+++ b/litex_boards/targets/redpitaya.py
@@ -62,9 +62,6 @@ class BaseSoC(SoCCore):
         if kwargs.get("cpu_type", None) == "zynq7000":
             kwargs["integrated_sram_size"] = 0
             kwargs["with_uart"]            = False
-            self.mem_map = {
-                'csr': 0x43c0_0000,  # Zynq GP0 default
-            }
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Zebboard", **kwargs)
 
         # Zynq7000 Integration ---------------------------------------------------------------------
@@ -75,13 +72,6 @@ class BaseSoC(SoCCore):
             os.system("cp redpitaya_ps7.txt xci/redpitaya_ps7.xci")
             self.cpu.set_ps7_xci("xci/redpitaya_ps7.xci")
 
-            # Connect AXI GP0 to the SoC with base address of 0x43c00000 (default one)
-            wb_gp0  = wishbone.Interface()
-            self.submodules += axi.AXI2Wishbone(
-                axi          = self.cpu.add_axi_gp_master(),
-                wishbone     = wb_gp0,
-                base_address = 0x43c00000)
-            self.bus.add_master(master=wb_gp0)
             self.bus.add_region("flash",  SoCRegion(origin=0xFC00_0000, size=0x4_0000, mode="rwx"))
 
         # Leds -------------------------------------------------------------------------------------

--- a/litex_boards/targets/xilinx_kv260.py
+++ b/litex_boards/targets/xilinx_kv260.py
@@ -56,8 +56,6 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    mem_map = {"csr": 0xA000_0000}  # default GP0 address on ZynqMP
-
     def __init__(self, sys_clk_freq=100e6, **kwargs):
         platform = xilinx_kv260.Platform()
 
@@ -127,13 +125,6 @@ class BaseSoC(SoCCore):
                 'PSU__UART1__PERIPHERAL__IO'       : 'MIO 36 .. 37',
             })
 
-            # Connect Zynq AXI master to the SoC
-            wb_gp0 = wishbone.Interface()
-            self.submodules += axi.AXI2Wishbone(
-                axi          = self.cpu.add_axi_gp_master(),
-                wishbone     = wb_gp0,
-                base_address = self.mem_map["csr"])
-            self.bus.add_master(master=wb_gp0)
             self.bus.add_region("sram", SoCRegion(
                 origin = self.cpu.mem_map["sram"],
                 size   = 2 * 1024 * 1024 * 1024)  # DDR

--- a/litex_boards/targets/xilinx_zcu216.py
+++ b/litex_boards/targets/xilinx_zcu216.py
@@ -46,8 +46,6 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    mem_map = {"csr": 0xA000_0000}  # default GP0 address on ZynqMP
-
     def __init__(self, sys_clk_freq=100e6, with_led_chaser=True, **kwargs):
         platform = xilinx_zcu216.Platform()
 
@@ -108,13 +106,6 @@ class BaseSoC(SoCCore):
                 'PSU__UART0__PERIPHERAL__IO'       : 'MIO 18 .. 19',
             })
 
-            # Connect Zynq AXI master to the SoC
-            wb_gp0 = wishbone.Interface()
-            self.submodules += axi.AXI2Wishbone(
-                axi          = self.cpu.add_axi_gp_master(),
-                wishbone     = wb_gp0,
-                base_address = self.mem_map["csr"])
-            self.bus.add_master(master=wb_gp0)
             self.bus.add_region("sram", SoCRegion(
                 origin = self.cpu.mem_map["sram"],
                 size   = 2 * 1024 * 1024 * 1024)  # DDR

--- a/litex_boards/targets/xilinx_zybo_z7.py
+++ b/litex_boards/targets/xilinx_zybo_z7.py
@@ -57,9 +57,6 @@ class BaseSoC(SoCCore):
         if kwargs.get("cpu_type", None) == "zynq7000":
             kwargs["integrated_sram_size"] = 0x0
             kwargs["with_uart"] = False
-            self.mem_map = {
-                'csr': 0x4000_0000,  # Zynq GP0 default
-            }
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Zybo Z7/original Zybo", **kwargs)
 
         # Zynq7000 Integration ---------------------------------------------------------------------
@@ -74,13 +71,6 @@ class BaseSoC(SoCCore):
             else:
                 self.cpu.set_ps7(name="ps", config = platform.ps7_config)
 
-            # Connect AXI GP0 to the SoC with base address of 0x40000000 (default one)
-            wb_gp0  = wishbone.Interface()
-            self.submodules += axi.AXI2Wishbone(
-                axi          = self.cpu.add_axi_gp_master(),
-                wishbone     = wb_gp0,
-                base_address = 0x40000000)
-            self.bus.add_master(master=wb_gp0)
             #TODO memory size dependend on board variant
             self.bus.add_region("sram", SoCRegion(
                 origin = self.cpu.mem_map["sram"],


### PR DESCRIPTION
With this [PR](https://github.com/enjoy-digital/litex/pull/1994) CSR are now defined at CPU core level and the first CPU interface is automatically connected to the SoC. This allows to reduces logic at target level and behavior is now nearest as others CPUs.

Tested using zedboard, artyZ7 and ZCU102.