### PR TITLE
machdyne: fix typos; add vanille and lakritz

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,12 @@ Some of the suported boards, see yours? Give LiteX-Boards a try!
     ├── machdyne_lakritz
     ├── machdyne_minze
     ├── machdyne_mozart_ml1
+    ├── machdyne_mozart_ml2
+    ├── machdyne_mozart_mx1
     ├── machdyne_noir
     ├── machdyne_schoko
     ├── machdyne_vanille
+    ├── machdyne_vivaldi_ml1
     ├── marblemini
     ├── marble
     ├── micronova_mercury2

--- a/README.md
+++ b/README.md
@@ -176,10 +176,12 @@ Some of the suported boards, see yours? Give LiteX-Boards a try!
     ├── machdyne_konfekt
     ├── machdyne_kopflos
     ├── machdyne_krote
+    ├── machdyne_lakritz
     ├── machdyne_minze
     ├── machdyne_mozart_ml1
     ├── machdyne_noir
     ├── machdyne_schoko
+    ├── machdyne_vanille
     ├── marblemini
     ├── marble
     ├── micronova_mercury2

--- a/litex_boards/platforms/machdyne_konfekt.py
+++ b/litex_boards/platforms/machdyne_konfekt.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.build.generic_platform import *
-from litex.build.lattice import LatticePlatform
+from litex.build.lattice import LatticeECP5Platform
 from litex.build.openfpgaloader import OpenFPGALoader
 
 # IOs ----------------------------------------------------------------------------------------------
@@ -129,7 +129,7 @@ _connectors_vx = [
 
 # Platform -----------------------------------------------------------------------------------------
 
-class Platform(LatticePlatform):
+class Platform(LatticeECP5Platform):
     default_clk_name   = "clk48"
     default_clk_period = 1e9/48e6
 
@@ -143,11 +143,11 @@ class Platform(LatticePlatform):
 
         if revision == "v0": io += _io_v0
 
-        LatticePlatform.__init__(self, f"LFE5U-{device}-6BG256", io, connectors, toolchain=toolchain, **kwargs)
+        LatticeECP5Platform.__init__(self, f"LFE5U-{device}-6BG256", io, connectors, toolchain=toolchain, **kwargs)
 
     def create_programmer(self, cable):
         return OpenFPGALoader(cable=cable)
 
     def do_finalize(self, fragment):
-        LatticePlatform.do_finalize(self, fragment)
+        LatticeECP5Platform.do_finalize(self, fragment)
         self.add_period_constraint(self.lookup_request("clk48", loose=True), 1e9/48e6)

--- a/litex_boards/platforms/machdyne_kopflos.py
+++ b/litex_boards/platforms/machdyne_kopflos.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.build.generic_platform import *
-from litex.build.lattice import LatticePlatform
+from litex.build.lattice import LatticeECP5Platform
 from litex.build.openfpgaloader import OpenFPGALoader
 
 # IOs ----------------------------------------------------------------------------------------------
@@ -135,7 +135,7 @@ _connectors_vx = [
 
 # Platform -----------------------------------------------------------------------------------------
 
-class Platform(LatticePlatform):
+class Platform(LatticeECP5Platform):
     default_clk_name   = "clk48"
     default_clk_period = 1e9/48e6
 
@@ -149,11 +149,11 @@ class Platform(LatticePlatform):
 
         if revision == "v0": io += _io_v0
 
-        LatticePlatform.__init__(self, f"LFE5U-{device}-6BG256", io, connectors, toolchain=toolchain, **kwargs)
+        LatticeECP5Platform.__init__(self, f"LFE5U-{device}-6BG256", io, connectors, toolchain=toolchain, **kwargs)
 
     def create_programmer(self, cable):
         return OpenFPGALoader(cable=cable)
 
     def do_finalize(self, fragment):
-        LatticePlatform.do_finalize(self, fragment)
+        LatticeECP5Platform.do_finalize(self, fragment)
         self.add_period_constraint(self.lookup_request("clk48", loose=True), 1e9/48e6)

--- a/litex_boards/platforms/machdyne_kopflos.py
+++ b/litex_boards/platforms/machdyne_kopflos.py
@@ -1,7 +1,7 @@
 #
 # This file is part of LiteX-Boards.
 #
-# Copright (c) 2023 Lone Dynamics Corporation <info@lonedynamics.com>
+# Copyright (c) 2023 Lone Dynamics Corporation <info@lonedynamics.com>
 #
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/litex_boards/platforms/machdyne_lakritz.py
+++ b/litex_boards/platforms/machdyne_lakritz.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.build.generic_platform import *
-from litex.build.lattice import LatticePlatform
+from litex.build.lattice import LatticeECP5Platform
 from litex.build.openfpgaloader import OpenFPGALoader
 
 # IOs ----------------------------------------------------------------------------------------------
@@ -120,7 +120,7 @@ _connectors_vx = [
 
 # Platform -----------------------------------------------------------------------------------------
 
-class Platform(LatticePlatform):
+class Platform(LatticeECP5Platform):
     default_clk_name   = "clk48"
     default_clk_period = 1e9/48e6
 
@@ -134,11 +134,11 @@ class Platform(LatticePlatform):
 
         if revision == "v0": io += _io_v0
 
-        LatticePlatform.__init__(self, f"LFE5U-{device}-6BG256", io, connectors, toolchain=toolchain, **kwargs)
+        LatticeECP5Platform.__init__(self, f"LFE5U-{device}-6BG256", io, connectors, toolchain=toolchain, **kwargs)
 
     def create_programmer(self, cable):
         return OpenFPGALoader(cable=cable)
 
     def do_finalize(self, fragment):
-        LatticePlatform.do_finalize(self, fragment)
+        LatticeECP5Platform.do_finalize(self, fragment)
         self.add_period_constraint(self.lookup_request("clk48", loose=True), 1e9/48e6)

--- a/litex_boards/platforms/machdyne_lakritz.py
+++ b/litex_boards/platforms/machdyne_lakritz.py
@@ -17,18 +17,7 @@ _io_vx = [
     ("clk48", 0,  Pins("A7"),  IOStandard("LVCMOS33")),
 
     # Leds
-    ("user_led", 0, Pins("G1"), IOStandard("LVCMOS33")),
-    ("user_led", 1, Pins("E1"), IOStandard("LVCMOS33")),
-    ("user_led", 2, Pins("C1"),  IOStandard("LVCMOS33")),
-
-    ("rgb_led", 0,
-        Subsignal("r", Pins("G1"), IOStandard("LVCMOS33")),
-        Subsignal("g", Pins("E1"), IOStandard("LVCMOS33")),
-        Subsignal("b", Pins("C1"),  IOStandard("LVCMOS33")),
-    ),
-
-    # Buttons
-    ("usr_btn", 0, Pins("K1"), IOStandard("LVCMOS33")),
+    ("user_led", 0, Pins("A2"), IOStandard("LVCMOS33")),
 
     # SDRAM
     ("sdram_clock", 0, Pins("F16"), IOStandard("LVTTL33")),
@@ -43,21 +32,21 @@ _io_vx = [
         Subsignal("cas_n", Pins("K16")),
         Subsignal("we_n",  Pins("L15")),
         Subsignal("dq", Pins(
-            "R15 R16 P16 P15 N16 N14 M16 M15",
-            "E15 D16 D14 C16 B16 C14 C15 B15")),
-        Subsignal("dm", Pins("L16 E16")),
+            "R15 R16 P15 P16 N16 N14 M16 M15",
+            "E16 D14 D16 C15 C16 C14 B16 B15")),
+        Subsignal("dm", Pins("L16 E15")),
         IOStandard("LVTTL33")
     ),
 
     # Differential Data Multiple Interface
     ("ddmi", 0,
-        Subsignal("clk_p",    Pins("M1"),
+        Subsignal("clk_p",    Pins("L1"),
             IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
-        Subsignal("data0_p",  Pins("P1"),
+        Subsignal("data0_p",  Pins("M1"),
             IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
         Subsignal("data1_p",  Pins("R2"),
             IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
-        Subsignal("data2_p",  Pins("R5"),
+        Subsignal("data2_p",  Pins("R4"),
             IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
     ),
 
@@ -71,52 +60,54 @@ _io_vx = [
 
     # USB HOST
     ("usb_host", 0,
-        Subsignal("dp", Pins("B1")),
-        Subsignal("dm", Pins("B2")),
+        #Subsignal("dp", Pins("A3")),
+        #Subsignal("dm", Pins("A4")),
+        Subsignal("dp", Pins("A3 B1")),
+        Subsignal("dm", Pins("A4 B2")),
         IOStandard("LVCMOS33")
     ),
 
     # 3.5MM AUDIO
     ("audio_pwm", 0,
-        Subsignal("left", Pins("M11")),
-        Subsignal("right", Pins("P12")),
+        Subsignal("left", Pins("M3")),
+        Subsignal("right", Pins("N1")),
         IOStandard("LVCMOS33")
     ),
 
     # 3.5MM VIDEO
     ("video_dac", 0,
-        Subsignal("data", Pins("T13 R12 T14 R13")),
+        Subsignal("data", Pins("P1 R1 P2 N3")),
         IOStandard("LVCMOS33")
     ),
 
-    # DEBUG UART
-    ("serial", 0,
-        Subsignal("tx", Pins("J2")),
-        Subsignal("rx", Pins("J1")),
-        IOStandard("LVCMOS33")
-    ),
 ]
 
 _io_v0 = [
 
     # SD card w/ SD-mode interface
     ("sdcard", 0,
-    #    Subsignal("cd", Pins("A5")),
-        Subsignal("clk", Pins("B4")),
-        Subsignal("cmd", Pins("A3")),
-        Subsignal("data", Pins("A4 B5 A2 B3")),
+        Subsignal("clk", Pins("F2"), Misc("PULLMODE=NONE")),
+        Subsignal("cmd", Pins("K1"), Misc("PULLMODE=NONE")),
+        Subsignal("data", Pins("F3 F1 K3 K2"), Misc("PULLMODE=NONE")),
         Misc("SLEWRATE=FAST"),
         IOStandard("LVCMOS33")
     ),
 
     # SD card w/ SPI interface
     ("spisdcard", 0,
-        Subsignal("clk",  Pins("B4")),
-        Subsignal("mosi", Pins("A3")),
-        Subsignal("cs_n", Pins("B3")),
-        Subsignal("miso", Pins("A4")),
+        Subsignal("clk",  Pins("F2")),
+        Subsignal("mosi", Pins("K1")),
+        Subsignal("cs_n", Pins("K2")),
+        Subsignal("miso", Pins("F3")),
         Misc("SLEWRATE=FAST"),
         IOStandard("LVCMOS33"),
+    ),
+
+    # UART PMOD
+    ("serial", 0,
+        Subsignal("tx", Pins("PMODA:1")),
+        Subsignal("rx", Pins("PMODA:2")),
+        IOStandard("LVCMOS33")
     ),
 
 ]
@@ -124,7 +115,7 @@ _io_v0 = [
 # Connectors ---------------------------------------------------------------------------------------
 
 _connectors_vx = [
-
+    ("PMODA", "B11 B12 B13 B14 A11 A12 A13 A14")
 ]
 
 # Platform -----------------------------------------------------------------------------------------
@@ -133,7 +124,7 @@ class Platform(LatticePlatform):
     default_clk_name   = "clk48"
     default_clk_period = 1e9/48e6
 
-    def __init__(self, revision="v0", device="12F", toolchain="trellis", **kwargs):
+    def __init__(self, revision="v0", device="25F", toolchain="trellis", **kwargs):
         assert revision in ["v0"]
         assert device in ["12F", "25F", "45F", "85F"]
         self.revision = revision

--- a/litex_boards/platforms/machdyne_minze.py
+++ b/litex_boards/platforms/machdyne_minze.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.build.generic_platform import *
-from litex.build.lattice import LatticePlatform
+from litex.build.lattice import LatticeECP5Platform
 from litex.build.openfpgaloader import OpenFPGALoader
 
 # IOs ----------------------------------------------------------------------------------------------
@@ -106,7 +106,7 @@ _connectors_vx = [
 
 # Platform -----------------------------------------------------------------------------------------
 
-class Platform(LatticePlatform):
+class Platform(LatticeECP5Platform):
     default_clk_name   = "clk48"
     default_clk_period = 1e9/48e6
 
@@ -120,11 +120,11 @@ class Platform(LatticePlatform):
 
         if revision == "v0": io += _io_v0
 
-        LatticePlatform.__init__(self, f"LFE5U-{device}-6BG256", io, connectors, toolchain=toolchain, **kwargs)
+        LatticeECP5Platform.__init__(self, f"LFE5U-{device}-6BG256", io, connectors, toolchain=toolchain, **kwargs)
 
     def create_programmer(self, cable):
         return OpenFPGALoader(cable=cable)
 
     def do_finalize(self, fragment):
-        LatticePlatform.do_finalize(self, fragment)
+        LatticeECP5Platform.do_finalize(self, fragment)
         self.add_period_constraint(self.lookup_request("clk48", loose=True), 1e9/48e6)

--- a/litex_boards/platforms/machdyne_minze.py
+++ b/litex_boards/platforms/machdyne_minze.py
@@ -1,7 +1,7 @@
 #
 # This file is part of LiteX-Boards.
 #
-# Copright (c) 2023 Lone Dynamics Corporation <info@lonedynamics.com>
+# Copyright (c) 2023 Lone Dynamics Corporation <info@lonedynamics.com>
 #
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/litex_boards/platforms/machdyne_mozart_ml1.py
+++ b/litex_boards/platforms/machdyne_mozart_ml1.py
@@ -1,7 +1,7 @@
 #
 # This file is part of LiteX-Boards.
 #
-# Copright (c) 2023 Lone Dynamics Corporation <info@lonedynamics.com>
+# Copyright (c) 2023 Lone Dynamics Corporation <info@lonedynamics.com>
 #
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/litex_boards/platforms/machdyne_mozart_ml2.py
+++ b/litex_boards/platforms/machdyne_mozart_ml2.py
@@ -1,7 +1,7 @@
 #
 # This file is part of LiteX-Boards.
 #
-# Copyright (c) 2022 Lone Dynamics Corporation <info@lonedynamics.com>
+# Copyright (c) 2023 Lone Dynamics Corporation <info@lonedynamics.com>
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -14,17 +14,7 @@ from litex.build.openfpgaloader import OpenFPGALoader
 _io_vx = [
 
     # Clock
-    ("clk48", 0,  Pins("A7"),  IOStandard("LVCMOS33")),
-
-    # Leds
-    ("user_led", 0, Pins("C1"), IOStandard("LVCMOS33")),
-    ("user_led", 1, Pins("E1"), IOStandard("LVCMOS33")),
-    ("user_led", 2, Pins("G1"),  IOStandard("LVCMOS33")),
-    ("rgb_led", 0,
-        Subsignal("r", Pins("C1"), IOStandard("LVCMOS33")),
-        Subsignal("g", Pins("E1"), IOStandard("LVCMOS33")),
-        Subsignal("b", Pins("G1"),  IOStandard("LVCMOS33")),
-    ),
+    ("clk48", 0,  Pins("C7"),  IOStandard("LVCMOS33")),
 
     # DDR3L
     ("ddram", 0,
@@ -54,74 +44,61 @@ _io_vx = [
 
     # Differential Data Multiple Interface
     ("ddmi", 0,
-        Subsignal("clk_p",    Pins("M1"),
+        Subsignal("clk_p",    Pins("B10"),
             IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
-        Subsignal("data0_p",  Pins("P1"),
+        Subsignal("data0_p",  Pins("A9"),
             IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
-        Subsignal("data1_p",  Pins("R2"),
+        Subsignal("data1_p",  Pins("C8"),
             IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
-        Subsignal("data2_p",  Pins("R5"),
+        Subsignal("data2_p",  Pins("A11"),
             IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
     ),
 
     # USB-C
     ("usb", 0,
-        Subsignal("d_p", Pins("T6")),
-        Subsignal("d_n", Pins("R6")),
-        Subsignal("pullup", Pins("R7")),
+        Subsignal("d_p", Pins("A13")),
+        Subsignal("d_n", Pins("A14")),
+        Subsignal("pullup", Pins("B14")),
         IOStandard("LVCMOS33")
     ),
 
-    # USB HOST
+    # DUAL USB HOST
     ("usb_host", 0,
-        Subsignal("dp", Pins("B1")),
-        Subsignal("dm", Pins("B2")),
+        Subsignal("dp", Pins("A5 A3")),
+        Subsignal("dm", Pins("A6 A4")),
         IOStandard("LVCMOS33")
     ),
 
-    # 3.5MM AUDIO
-    ("audio_pwm", 0,
-        Subsignal("left", Pins("N7")),
-        Subsignal("right", Pins("M7")),
+    # ETHERNET
+    ("eth_clocks", 0,
+        Subsignal("ref_clk", Pins("A7")),
+        IOStandard("LVCMOS33")
+    ),
+    ("eth", 0,
+        Subsignal("rx_data", Pins("B5 B4"), Misc("PULLMODE=UP")),
+        Subsignal("tx_data", Pins("C6 B6")),
+        Subsignal("tx_en", Pins("C5")),
+        Subsignal("crs_dv", Pins("E7"), Misc("PULLMODE=UP")),
+        Subsignal("rst_n", Pins("D7")),
         IOStandard("LVCMOS33")
     ),
 
     # DEBUG UART
     ("serial", 0,
-        Subsignal("tx", Pins("J2")),
-        Subsignal("rx", Pins("J1")),
+        Subsignal("tx", Pins("B3")),
+        Subsignal("rx", Pins("A2")),
         IOStandard("LVCMOS33")
     ),
-
-    # SPI
-    ("spiflash", 0,
-        Subsignal("cs_n",   Pins("N8")),
-        Subsignal("miso",   Pins("T7")),
-        Subsignal("mosi",   Pins("T8")),
-        Misc("SLEWRATE=FAST"),
-        IOStandard("LVCMOS33"),
-    ),
-
 ]
 
 _io_v0 = [
 
-    # SD card w/ SD-mode interface
-    ("sdcard", 0,
-        Subsignal("cd", Pins("A5")),
-        Subsignal("clk", Pins("B4")),
-        Subsignal("cmd", Pins("A3"), Misc("PULLMODE=UP")),
-        Subsignal("data", Pins("A4 B5 A2 B3"), Misc("PULLMODE=UP")),
-        Misc("SLEWRATE=FAST"),
-        IOStandard("LVCMOS33")
-    ),
-
     # SD card w/ SPI interface
     ("spisdcard", 0,
-        Subsignal("clk",  Pins("B4")),
-        Subsignal("mosi", Pins("A3")),
-        Subsignal("cs_n", Pins("B3")),
-        Subsignal("miso", Pins("A4")),
+        Subsignal("clk",  Pins("L1")),
+        Subsignal("mosi", Pins("L4")),
+        Subsignal("cs_n", Pins("L2")),
+        Subsignal("miso", Pins("L3")),
         Misc("SLEWRATE=FAST"),
         IOStandard("LVCMOS33"),
     ),
@@ -131,6 +108,7 @@ _io_v0 = [
 # Connectors ---------------------------------------------------------------------------------------
 
 _connectors_vx = [
+
 ]
 
 # Platform -----------------------------------------------------------------------------------------

--- a/litex_boards/platforms/machdyne_mozart_mx1.py
+++ b/litex_boards/platforms/machdyne_mozart_mx1.py
@@ -1,0 +1,164 @@
+#
+# This file is part of LiteX-Boards.
+#
+#
+# Copyright (c) 2015 Yann Sionneau <yann.sionneau@gmail.com>
+# Copyright (c) 2015-2019 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2024 Lone Dynamics Corporation <info@lonedynamics.com>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import Xilinx7SeriesPlatform
+from litex.build.openfpgaloader import OpenFPGALoader
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io_vx = [
+
+    # Clock
+    ("clk48", 0,  Pins("F5"),  IOStandard("LVCMOS33")),
+    ("clk50", 0,  Pins("D4"),  IOStandard("LVCMOS33")),
+
+    # SDRAM
+    ("sdram_clock", 0, Pins("C8"), IOStandard("LVTTL")),
+    ("sdram", 0,
+        Subsignal("a", Pins(
+            "D15 D16 E15 E16 C9 D9 D8 C7",
+            "E6 D6 C16 D5 E5")),
+        Subsignal("ba",    Pins("B9 A8")),
+        Subsignal("cs_n",  Pins("A9")),
+        Subsignal("cke",   Pins("C4")),
+        Subsignal("ras_n", Pins("B10")),
+        Subsignal("cas_n", Pins("A10")),
+        Subsignal("we_n",  Pins("B11")),
+        Subsignal("dq", Pins(
+            "B16 A15 B15 A14 B14 A13 C13 A12",
+            "B6 C6 A5 B5 A4 B4 C3 A3")),
+        Subsignal("dm", Pins("B12 A7")),
+        IOStandard("LVTTL")
+    ),
+
+    # Differential Data Multiple Interface
+    ("ddmi", 0,
+        Subsignal("clk_p",    Pins("C1"), IOStandard("TMDS_33")),
+        Subsignal("clk_n",    Pins("B1"), IOStandard("TMDS_33")),
+        Subsignal("data0_p",  Pins("E2"), IOStandard("TMDS_33")),
+        Subsignal("data0_n",  Pins("D1"), IOStandard("TMDS_33")),
+        Subsignal("data1_p",  Pins("F2"), IOStandard("TMDS_33")),
+        Subsignal("data1_n",  Pins("E1"), IOStandard("TMDS_33")),
+        Subsignal("data2_p",  Pins("G2"), IOStandard("TMDS_33")),
+        Subsignal("data2_n",  Pins("G1"), IOStandard("TMDS_33"))
+    ),
+
+    # USB-C
+    ("usb", 0,
+        Subsignal("d_p", Pins("B2")),
+        Subsignal("d_n", Pins("A2")),
+        Subsignal("pullup", Pins("C2")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # DUAL USB HOST
+    ("usb_host", 0,
+        Subsignal("dp", Pins("H2 K1")),
+        Subsignal("dm", Pins("H1 J1")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # ETHERNET
+    ("eth", 0,
+        Subsignal("rx_data", Pins("F3 F4"), Misc("PULLUP")),
+        Subsignal("tx_data", Pins("D3 E3")),
+        Subsignal("tx_en", Pins("G4")),
+        Subsignal("crs_dv", Pins("H3"), Misc("PULLUP")),
+        Subsignal("rst_n", Pins("H4")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # LVDS
+    ("lvds", 0,
+        Subsignal("tx_p", Pins("R2")),
+        Subsignal("tx_n", Pins("R1")),
+        Subsignal("rx_p", Pins("T4")),
+        Subsignal("rx_n", Pins("T3")),
+        IOStandard("LVDS_25")
+    ),
+
+    # MMOD
+    ("spiflash4x", 0,
+        Subsignal("cs_n", Pins("L12")),
+        #Subsignal("clk",  Pins("")), # Accessed through STARTUPE2
+        Subsignal("dq",   Pins("J13 J14 K15 K16")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # DEBUG UART
+    ("serial", 0,
+        Subsignal("tx", Pins("L2")),
+        Subsignal("rx", Pins("L3")),
+        IOStandard("LVCMOS33")
+    ),
+]
+
+_io_v0 = [
+
+    # SD card w/ SD-mode interface
+    ("sdcard", 0,
+        Subsignal("cd", Pins("K3")),
+        Subsignal("clk", Pins("R6")),
+        Subsignal("cmd", Pins("T8")),
+        Subsignal("data", Pins("T7 P8 T9 T5")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # SD card w/ SPI interface
+    ("spisdcard", 0,
+        Subsignal("clk",  Pins("R6")),
+        Subsignal("mosi", Pins("T8")),
+        Subsignal("cs_n", Pins("T5")),
+        Subsignal("miso", Pins("T7")),
+        IOStandard("LVCMOS33"),
+    ),
+
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors_vx = [
+
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(Xilinx7SeriesPlatform):
+    def __init__(self, revision="v0", variant="a7-35", toolchain="vivado"):
+
+        assert revision in ["v0"]
+        self.revision = revision
+
+        io = _io_vx
+        connectors = _connectors_vx
+
+        if revision == "v0": io += _io_v0
+
+        device = {
+            "a7-35":  "xc7a35tftg256-1"
+        }[variant]
+        Xilinx7SeriesPlatform.__init__(self, device, io, connectors, toolchain=toolchain)
+        self.toolchain.bitstream_commands = \
+            ["set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]"]
+        self.toolchain.additional_commands = \
+            ["write_cfgmem -force -format bin -interface spix4 -size 16 "
+             "-loadbit \"up 0x0 {build_name}.bit\" -file {build_name}.bin"]
+        self.add_platform_command("set_property INTERNAL_VREF 0.675 [get_iobanks 34]")
+
+    def create_programmer(self):
+        bscan_spi = "bscan_spi_xc7a100t.bit" if "xc7a100t" in self.device else "bscan_spi_xc7a35t.bit"
+        return OpenOCD("openocd_xc7_ft2232.cfg", bscan_spi)
+
+    def do_finalize(self, fragment):
+        Xilinx7SeriesPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk48", loose=True), 1e9/48e6)
+        self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)
+

--- a/litex_boards/platforms/machdyne_noir.py
+++ b/litex_boards/platforms/machdyne_noir.py
@@ -1,7 +1,7 @@
 #
 # This file is part of LiteX-Boards.
 #
-# Copright (c) 2022 Lone Dynamics Corporation <info@lonedynamics.com>
+# Copyright (c) 2022 Lone Dynamics Corporation <info@lonedynamics.com>
 #
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/litex_boards/platforms/machdyne_schoko.py
+++ b/litex_boards/platforms/machdyne_schoko.py
@@ -1,7 +1,7 @@
 #
 # This file is part of LiteX-Boards.
 #
-# Copright (c) 2022 Lone Dynamics Corporation <info@lonedynamics.com>
+# Copyright (c) 2022 Lone Dynamics Corporation <info@lonedynamics.com>
 #
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/litex_boards/platforms/machdyne_schoko.py
+++ b/litex_boards/platforms/machdyne_schoko.py
@@ -77,8 +77,10 @@ _io_vx = [
 
     # USB HOST
     ("usb_host", 0,
-        Subsignal("dp", Pins("F2")),
-        Subsignal("dm", Pins("E1")),
+        Subsignal("dp", Pins("PMODB:0 PMODB:2")),
+        Subsignal("dm", Pins("PMODB:1 PMODB:3")),
+        #Subsignal("dp", Pins("F2 PMODB:0")),
+        #Subsignal("dm", Pins("E1 PMODB:1")),
         IOStandard("LVCMOS33")
     ),
 
@@ -102,20 +104,6 @@ _io_vx = [
 ]
 
 _io_v1 = [
-
-    # SD card w/ SPI interface
-    ("spisdcard", 0,
-        Subsignal("clk",  Pins("D6")),
-        Subsignal("mosi", Pins("C6")),
-        Subsignal("cs_n", Pins("B6")),
-        Subsignal("miso", Pins("E6")),
-        Misc("SLEWRATE=FAST"),
-        IOStandard("LVCMOS33"),
-    ),
-
-]
-
-_io_v2 = [
 
     # SD card w/ SD-mode interface
     ("sdcard", 0,
@@ -143,14 +131,13 @@ class Platform(LatticeECP5Platform):
 
     def __init__(self, revision="v1", device="45F", toolchain="trellis", **kwargs):
         assert revision in ["v1", "v2"]
-        assert device in ["25F", "45F", "85F"]
+        assert device in ["12F", "25F", "45F", "85F"]
         self.revision = revision
 
         io = _io_vx
         connectors = _connectors_vx
 
         if revision == "v1": io += _io_v1
-        if revision == "v2": io += _io_v2
 
         LatticeECP5Platform.__init__(self, f"LFE5U-{device}-6BG256", io, connectors, toolchain=toolchain, **kwargs)
 

--- a/litex_boards/platforms/machdyne_vanille.py
+++ b/litex_boards/platforms/machdyne_vanille.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.build.generic_platform import *
-from litex.build.lattice import LatticePlatform
+from litex.build.lattice import LatticeECP5Platform
 from litex.build.openfpgaloader import OpenFPGALoader
 
 # IOs ----------------------------------------------------------------------------------------------
@@ -95,7 +95,7 @@ _connectors_vx = [
 
 # Platform -----------------------------------------------------------------------------------------
 
-class Platform(LatticePlatform):
+class Platform(LatticeECP5Platform):
     default_clk_name   = "clk48"
     default_clk_period = 1e9/48e6
 
@@ -109,11 +109,11 @@ class Platform(LatticePlatform):
 
         if revision == "v0": io += _io_v0
 
-        LatticePlatform.__init__(self, f"LFE5U-{device}-6TG144", io, connectors, toolchain=toolchain, **kwargs)
+        LatticeECP5Platform.__init__(self, f"LFE5U-{device}-6TG144", io, connectors, toolchain=toolchain, **kwargs)
 
     def create_programmer(self, cable):
         return OpenFPGALoader(cable=cable)
 
     def do_finalize(self, fragment):
-        LatticePlatform.do_finalize(self, fragment)
+        LatticeECP5Platform.do_finalize(self, fragment)
         self.add_period_constraint(self.lookup_request("clk48", loose=True), 1e9/48e6)

--- a/litex_boards/platforms/machdyne_vanille.py
+++ b/litex_boards/platforms/machdyne_vanille.py
@@ -1,0 +1,119 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2022 Lone Dynamics Corporation <info@lonedynamics.com>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.lattice import LatticePlatform
+from litex.build.openfpgaloader import OpenFPGALoader
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io_vx = [
+
+    # Clock
+    ("clk48", 0,  Pins("128"),  IOStandard("LVCMOS33")),
+
+    # LED
+    ("user_led", 0, Pins("52"), IOStandard("LVCMOS33")),
+
+    # SDRAM
+    ("sdram_clock", 0, Pins("72"), IOStandard("LVTTL33")),
+    ("sdram", 0,
+        Subsignal("a", Pins(
+            "81 80 79 78 105 106 107 108 "
+            "110 111 82 112 113")),
+        Subsignal("ba",    Pins("92 91")),
+        Subsignal("cs_n",  Pins("84")),
+        Subsignal("cke",   Pins("114")),
+        Subsignal("ras_n", Pins("88")),
+        Subsignal("cas_n", Pins("89")),
+        Subsignal("we_n",  Pins("90")),
+        Subsignal("dq", Pins(
+            "104 103 102 99 98 97 95 94 ",
+            "116 117 118 119 120 121 124 125")),
+        Subsignal("dm", Pins("93 115")),
+        IOStandard("LVTTL33")
+    ),
+
+    # Differential Data Multiple Interface
+    ("ddmi", 0,
+        Subsignal("clk_p",    Pins("69"),
+            IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
+        Subsignal("data0_p",  Pins("71"),
+            IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
+        Subsignal("data1_p",  Pins("74"),
+            IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
+        Subsignal("data2_p",  Pins("77"),
+            IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
+    ),
+
+    # USB-C
+    ("usb", 0,
+        Subsignal("d_p", Pins("40")),
+        Subsignal("d_n", Pins("44")),
+        Subsignal("pullup", Pins("45")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # USB HOST
+    ("usb_host", 0,
+        Subsignal("dp", Pins("39")),
+        Subsignal("dm", Pins("41")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # DEBUG UART (on USB host port)
+    #("serial", 0,
+    #    Subsignal("tx", Pins("39")),
+    #    Subsignal("rx", Pins("41")),
+    #    IOStandard("LVCMOS33")
+    #),
+]
+
+_io_v0 = [
+
+    # SD card w/ SPI interface
+    ("spisdcard", 0,
+        Subsignal("clk",  Pins("50")),
+        Subsignal("mosi", Pins("47")),
+        Subsignal("cs_n", Pins("48")),
+        Subsignal("miso", Pins("46")),
+        Misc("SLEWRATE=FAST"),
+        IOStandard("LVCMOS33"),
+    ),
+
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors_vx = [
+
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(LatticePlatform):
+    default_clk_name   = "clk48"
+    default_clk_period = 1e9/48e6
+
+    def __init__(self, revision="v0", device="12F", toolchain="trellis", **kwargs):
+        assert revision in ["v0"]
+        assert device in ["12F", "25F", "45F", "85F"]
+        self.revision = revision
+
+        io = _io_vx
+        connectors = _connectors_vx
+
+        if revision == "v0": io += _io_v0
+
+        LatticePlatform.__init__(self, f"LFE5U-{device}-6TG144", io, connectors, toolchain=toolchain, **kwargs)
+
+    def create_programmer(self, cable):
+        return OpenFPGALoader(cable=cable)
+
+    def do_finalize(self, fragment):
+        LatticePlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk48", loose=True), 1e9/48e6)

--- a/litex_boards/platforms/machdyne_vivaldi_ml1.py
+++ b/litex_boards/platforms/machdyne_vivaldi_ml1.py
@@ -36,23 +36,10 @@ _io_vx = [
         IOStandard("LVTTL33")
     ),
 
-    # Differential Data Multiple Interface
-    ("ddmi", 0,
-        Subsignal("clk_p",    Pins("B13"),
-            IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
-        Subsignal("data0_p",  Pins("A11"),
-            IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
-        Subsignal("data1_p",  Pins("B12"),
-            IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
-        Subsignal("data2_p",  Pins("B10"),
-            IOStandard("LVCMOS33D"), Misc("DRIVE=4")),
-    ),
-
-    # USB-C
-    ("usb", 0,
-        Subsignal("d_p", Pins("A13")),
-        Subsignal("d_n", Pins("A14")),
-        Subsignal("pullup", Pins("D13")),
+    # I2C
+    ("i2c", 0,
+        Subsignal("sda", Pins("A13")),
+        Subsignal("scl", Pins("A11")),
         IOStandard("LVCMOS33")
     ),
 
@@ -72,14 +59,22 @@ _io_vx = [
         Subsignal("rst_n", Pins("B5")),
         IOStandard("LVCMOS33")
     ),
+    ("eth", 1,
+        Subsignal("rx_data", Pins("B3 A2"), Misc("PULLMODE=UP")),
+        Subsignal("tx_data", Pins("A4 A3")),
+        Subsignal("tx_en", Pins("R12")),
+        Subsignal("crs_dv", Pins("T13"), Misc("PULLMODE=UP")),
+        Subsignal("rst_n", Pins("T14")),
+        IOStandard("LVCMOS33")
+    ),
 
     # SD card w/ SD-mode interface
     ("sdcard", 0,
-        Subsignal("cd", Pins("A6"), Misc("PULLMODE=NONE")),
-        Subsignal("clk", Pins("L3"), Misc("PULLMODE=NONE")),
-        Subsignal("cmd", Pins("M1"), Misc("PULLMODE=NONE")),
-        Subsignal("data", Pins("L1 M2 M3 L2"), Misc("PULLMODE=NONE")),
-        #Misc("SLEWRATE=FAST"),
+        Subsignal("cd", Pins("A6")),
+        Subsignal("clk", Pins("L3")),
+        Subsignal("cmd", Pins("M1")),
+        Subsignal("data", Pins("L1 M2 M3 L2")),
+        Misc("SLEWRATE=FAST"),
         IOStandard("LVCMOS33")
     ),
 
@@ -119,7 +114,6 @@ _io_v2 = [
 # Connectors ---------------------------------------------------------------------------------------
 
 _connectors_vx = [
-    ("X", "A4 A3 B3 A2"),
 ]
 
 # Platform -----------------------------------------------------------------------------------------

--- a/litex_boards/targets/machdyne_konfekt.py
+++ b/litex_boards/targets/machdyne_konfekt.py
@@ -18,7 +18,6 @@ from litex.gen import *
 
 from litex_boards.platforms import machdyne_konfekt
 
-from litex.build.lattice.trellis import trellis_args, trellis_argdict
 from litex.build.io import DDROutput
 
 from litex.soc.cores.clock import *
@@ -40,7 +39,7 @@ from litex.soc.integration.soc import SoCRegion
 # CRG ---------------------------------------------------------------------------------------------
 
 class _CRG(LiteXModule):
-    def __init__(self, platform, sys_clk_freq, sdram_rate):
+    def __init__(self, platform, sys_clk_freq, sdram_rate = "1:2"):
         self.rst        = Signal()
         self.cd_por     = ClockDomain()
         self.cd_sys     = ClockDomain()
@@ -109,7 +108,7 @@ class BaseSoC(SoCCore):
     }}
     def __init__(self, revision="v0", device="12F", sdram_device="W9825G6KH6", sdram_rate="1:2", sys_clk_freq=int(40e6), toolchain="trellis", with_led_chaser=True, with_usb_host=False, **kwargs):
 
-        platform = machdyne_konfekt.Platform(revision=revision, device=device ,toolchain=toolchain)
+        platform = machdyne_konfekt.Platform(revision=revision, device=device, toolchain=toolchain)
 
         # CRG --------------------------------------------------------------------------------------
         self.crg = _CRG(platform, sys_clk_freq, sdram_rate=sdram_rate)
@@ -165,45 +164,26 @@ class BaseSoC(SoCCore):
 # Build --------------------------------------------------------------------------------------------
 
 def main():
-    from litex.soc.integration.soc import LiteXSoCArgumentParser
-    parser = LiteXSoCArgumentParser(description="LiteX SoC on Konfekt")
-    target_group = parser.add_argument_group(title="Target options")
-    target_group.add_argument("--build",           action="store_true",  help="Build design.")
-    target_group.add_argument("--load",            action="store_true",  help="Load bitstream to SRAM.")
-    target_group.add_argument("--flash",           action="store_true",  help="Flash bitstream to MMOD.")
-    target_group.add_argument("--toolchain",       default="trellis",    help="FPGA toolchain (trellis or diamond).")
-    target_group.add_argument("--sys-clk-freq",    default=40e6,         help="System clock frequency.")
-    target_group.add_argument("--revision",        default="v0",         help="Board Revision (v0).")
-    target_group.add_argument("--device",          default="12F",        help="ECP5 device (25F, 45F or 85F).")
-    target_group.add_argument("--cable",           default="usb-blaster", help="Specify an openFPGALoader cable.")
-    target_group.add_argument("--with-sdcard",     action="store_true",  help="Enable SDCard support.")
-    target_group.add_argument("--with-spi-sdcard", action="store_true",  help="Enable SPI-mode SDCard support.")
-    target_group.add_argument("--with-usb-host",   action="store_true",  help="Enable USB host support.")
-    target_group.add_argument("--boot-from-flash", action="store_true",  help="Boot from flash MMOD.")
-    target_group.add_argument("--sdram-device",    default="W9825G6KH6", help="SDRAM device (W9825G6KH6 or IS42S16320).")
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=machdyne_konfekt.Platform, description="LiteX SoC on Konfekt")
+    parser.add_argument("--sys-clk-freq",    default=40e6,         help="System clock frequency.")
+    parser.add_argument("--revision",        default="v0",         help="Board Revision (v0).")
+    parser.add_argument("--device",          default="12F",        help="ECP5 device (12F, 25F, 45F or 85F).")
+    parser.add_argument("--cable",           default="dirtyJtag",  help="OpenFPGALoader cable type.")
+    parser.add_argument("--with-sdcard",     action="store_true",  help="Enable SDCard support.")
+    parser.add_argument("--with-spi-sdcard", action="store_true",  help="Enable SPI-mode SDCard support.")
+    parser.add_argument("--with-usb-host",   action="store_true",  help="Enable USB host support.")
+    parser.add_argument("--sdram-device",    default="W9825G6KH6", help="SDRAM device (W9825G6KH6 or IS42S16320).")
 
-    builder_args(parser)
-    soc_core_args(parser)
-    trellis_args(parser)
     args = parser.parse_args()
 
-    print("")
-    print("")
-    print("")
-    print(args)
-
-    print("")
-    print("")
-    print("")
-
     soc = BaseSoC(
-        toolchain    = args.toolchain,
-        revision     = args.revision,
-        device       = args.device,
         sys_clk_freq = int(float(args.sys_clk_freq)),
+        revision = args.revision,
+        device = args.device,
         sdram_device = args.sdram_device,
         with_usb_host = args.with_usb_host,
-        **soc_core_argdict(args))
+        **parser.soc_argdict)
 
     if args.with_sdcard:
         soc.add_sdcard()
@@ -211,19 +191,13 @@ def main():
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()
 
-    builder = Builder(soc, **builder_argdict(args))
-    builder_kargs = trellis_argdict(args) if args.toolchain == "trellis" else {}
-
+    builder = Builder(soc, **parser.builder_argdict)
     if args.build:
-        builder.build(**builder_kargs)
+        builder.build(**parser.toolchain_argdict)
 
     if args.load:
-        prog = soc.platform.create_programmer(args.cable)
+        prog = soc.platform.create_programmer(cable=args.cable)
         prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
-
-    if args.flash:
-        prog = soc.platform.create_programmer(args.cable)
-        prog.flash(0x100000, builder.get_bitstream_filename(mode="sram"))
 
 if __name__ == "__main__":
     main()

--- a/litex_boards/targets/machdyne_lakritz.py
+++ b/litex_boards/targets/machdyne_lakritz.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) Lone Dynamics Corporation <info@lonedynamics.com>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+import os
+import sys
+import json
+
+from migen import *
+
+from litex.gen import *
+
+from litex_boards.platforms import machdyne_lakritz
+
+from litex.build.lattice.trellis import trellis_args, trellis_argdict
+from litex.build.io import DDROutput
+
+from litex.soc.cores.clock import *
+from litex.soc.cores.led import LedChaser
+from litex.soc.cores.usb_ohci import USBOHCI
+from litex.soc.cores.video import VideoVGAPHY
+from litex.soc.cores.video import VideoHDMIPHY
+
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+
+from litedram.modules import W9825G6KH6
+from litedram.modules import IS42S16320
+
+from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
+
+from litex.soc.integration.soc import SoCRegion
+
+# CRG ---------------------------------------------------------------------------------------------
+
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq, sdram_rate = "1:2"):
+        self.rst        = Signal()
+        self.cd_por     = ClockDomain()
+        self.cd_sys     = ClockDomain()
+        self.cd_video   = ClockDomain()
+        self.cd_video5x = ClockDomain()
+
+        # Clk / Rst
+        clk48 = platform.request("clk48")
+
+        # Power on reset
+        por_count = Signal(16, reset=2**16-1)
+        por_done  = Signal()
+        self.comb += self.cd_por.clk.eq(clk48)
+        self.comb += por_done.eq(por_count == 0)
+        self.sync.por += If(~por_done, por_count.eq(por_count - 1))
+
+        # PLL
+        self.pll = pll = ECP5PLL()
+        self.comb += pll.reset.eq(~por_done | self.rst)
+        pll.register_clkin(clk48, 48e6)
+        pll.create_clkout(self.cd_sys, sys_clk_freq)
+
+        if sdram_rate == "1:2":
+            self.cd_sys2x    = ClockDomain()
+            self.cd_sys2x_ps = ClockDomain()
+            pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
+            pll.create_clkout(self.cd_sys2x_ps, 2*sys_clk_freq, phase=180)
+        elif sdram_rate == "1:4":
+            self.cd_sys2x    = ClockDomain()
+            self.cd_sys4x    = ClockDomain()
+            self.cd_sys4x_ps = ClockDomain()
+            pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
+            pll.create_clkout(self.cd_sys4x,    4*sys_clk_freq)
+            pll.create_clkout(self.cd_sys4x_ps, 4*sys_clk_freq, phase=180)
+        else:
+            self.cd_sys_ps = ClockDomain()
+            pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
+
+        if sdram_rate == "1:2":
+            sdram_clk = ClockSignal("sys2x_ps")
+        elif sdram_rate == "1:4":
+            sdram_clk = ClockSignal("sys4x_ps")
+        else:
+            sdram_clk = ClockSignal("sys_ps")
+
+        self.specials += DDROutput(1, 0, platform.request("sdram_clock"), sdram_clk)
+        pll2 = ECP5PLL()
+        self.pll2 = pll2
+        pll2.register_clkin(clk48, 48e6)
+        pll2.create_clkout(self.cd_video, 25e6)
+        pll2.create_clkout(self.cd_video5x, 125e6)
+
+        self.cd_usb_12 = ClockDomain()
+        self.cd_usb    = ClockDomain()
+        self.cd_usb_48 = ClockDomain()
+        self.cd_usb_48 = self.cd_usb
+        pll2.create_clkout(self.cd_usb, 48e6)
+        pll2.create_clkout(self.cd_usb_12, 12e6)
+        self.comb += pll2.reset.eq(~por_done)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    mem_map = {**SoCCore.mem_map, **{
+        "usb_ohci":     0xc0000000,
+    }}
+    def __init__(self, revision="v0", device="25F", sdram_device="W9825G6KH6", sdram_rate="1:2", sys_clk_freq=int(48e6), toolchain="trellis", with_led_chaser=False, with_video_framebuffer=False, with_usb_host=False, **kwargs):
+
+        platform = machdyne_lakritz.Platform(revision=revision, device=device ,toolchain=toolchain)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.crg = _CRG(platform, sys_clk_freq, sdram_rate=sdram_rate)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Lakritz", **kwargs)
+
+        # DRAM -------------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            if sdram_rate == "1:2":
+                sdrphy_cls = HalfRateGENSDRPHY
+            elif sdram_rate == "1:4":
+                from litedram.phy import QuarterRateGENSDRPHY
+                sdrphy_cls = QuarterRateGENSDRPHY
+            else:
+                sdrphy_cls = GENSDRPHY
+
+            self.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
+
+            if sdram_device == "W9825G6KH6":
+                self.add_sdram("sdram",
+                    phy           = self.sdrphy,
+                    module        = W9825G6KH6(sys_clk_freq, sdram_rate),
+                    l2_cache_size = kwargs.get("l2_size", 0)
+                )
+
+            if sdram_device == "IS42S16320":
+                self.add_sdram("sdram",
+                    phy           = self.sdrphy,
+                    module        = IS42S16320(self.clk_freq, sdram_rate),
+                    l2_cache_size = kwargs.get("l2_size", 0)
+                )
+
+        # USB Host ---------------------------------------------------------------------------------
+        if with_usb_host:
+            self.usb_ohci = USBOHCI(platform, platform.request("usb_host"), usb_clk_freq=int(48e6))
+            self.bus.add_slave("usb_ohci_ctrl", self.usb_ohci.wb_ctrl, region=SoCRegion(origin=self.mem_map["usb_ohci"], size=0x100000, cached=False))
+            self.dma_bus.add_master("usb_ohci_dma", master=self.usb_ohci.wb_dma)
+            self.comb += self.cpu.interrupt[16].eq(self.usb_ohci.interrupt)
+
+        # DDMI Framebuffer -------------------------------------------------------------------------------------
+        if with_video_framebuffer:
+            self.videophy = VideoHDMIPHY(platform.request("ddmi"),
+                clock_domain="video")
+            self.add_video_framebuffer(phy=self.videophy,
+                timings="640x480@60Hz",
+                clock_domain="video",
+                format="rgb565")
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    from litex.soc.integration.soc import LiteXSoCArgumentParser
+    parser = LiteXSoCArgumentParser(description="LiteX SoC on Lakritz")
+    target_group = parser.add_argument_group(title="Target options")
+    target_group.add_argument("--build",           action="store_true",  help="Build design.")
+    target_group.add_argument("--load",            action="store_true",  help="Load bitstream to SRAM.")
+    target_group.add_argument("--flash",           action="store_true",  help="Flash bitstream to MMOD.")
+    target_group.add_argument("--toolchain",       default="trellis",    help="FPGA toolchain (trellis or diamond).")
+    target_group.add_argument("--sys-clk-freq",    default=48e6,         help="System clock frequency.")
+    target_group.add_argument("--revision",        default="v0",         help="Board Revision (v0).")
+    target_group.add_argument("--device",          default="25F",        help="ECP5 device (25F, 45F or 85F).")
+    target_group.add_argument("--cable",           default="usb-blaster", help="Specify an openFPGALoader cable.")
+    target_group.add_argument("--with-sdcard",     action="store_true",  help="Enable SDCard support.")
+    target_group.add_argument("--with-spi-sdcard", action="store_true",  help="Enable SPI-mode SDCard support.")
+    target_group.add_argument("--with-video-framebuffer",   action="store_true",  help="Enable DDMI framebuffer.")
+    target_group.add_argument("--with-usb-host",   action="store_true",  help="Enable USB host support.")
+    target_group.add_argument("--boot-from-flash", action="store_true",  help="Boot from flash MMOD.")
+    target_group.add_argument("--sdram-device",    default="W9825G6KH6", help="SDRAM device (W9825G6KH6 or IS42S16320).")
+
+    builder_args(parser)
+    soc_core_args(parser)
+    trellis_args(parser)
+    args = parser.parse_args()
+
+    print("")
+    print("")
+    print("")
+    print(args)
+
+    print("")
+    print("")
+    print("")
+
+    soc = BaseSoC(
+        toolchain    = args.toolchain,
+        revision     = args.revision,
+        device       = args.device,
+        sys_clk_freq = int(float(args.sys_clk_freq)),
+        sdram_device = args.sdram_device,
+        with_usb_host = args.with_usb_host,
+        **soc_core_argdict(args))
+
+    if args.with_sdcard:
+        soc.add_sdcard()
+
+    if args.with_spi_sdcard:
+        soc.add_spi_sdcard()
+
+    builder = Builder(soc, **builder_argdict(args))
+    builder_kargs = trellis_argdict(args) if args.toolchain == "trellis" else {}
+
+    if args.build:
+        builder.build(**builder_kargs)
+
+    if args.load:
+        prog = soc.platform.create_programmer(args.cable)
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+    if args.flash:
+        prog = soc.platform.create_programmer(args.cable)
+        prog.flash(0x100000, builder.get_bitstream_filename(mode="sram"))
+
+if __name__ == "__main__":
+    main()

--- a/litex_boards/targets/machdyne_mozart_mx1.py
+++ b/litex_boards/targets/machdyne_mozart_mx1.py
@@ -3,6 +3,9 @@
 #
 # This file is part of LiteX-Boards.
 #
+# Copyright (c) 2015-2019 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2020 Antmicro <www.antmicro.com>
+# Copyright (c) 2022 Victor Suarez Rovere <suarezvictor@gmail.com>
 # Copyright (c) Lone Dynamics Corporation <info@lonedynamics.com>
 #
 # SPDX-License-Identifier: BSD-2-Clause
@@ -16,20 +19,21 @@ from migen import *
 
 from litex.gen import *
 
-from litex_boards.platforms import machdyne_vanille
+from litex_boards.platforms import machdyne_mozart_mx1
 
 from litex.build.io import DDROutput
 
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
 from litex.soc.cores.clock import *
 from litex.soc.cores.usb_ohci import USBOHCI
-from litex.soc.cores.video import VideoHDMIPHY
+from litex.soc.cores.video import VideoS7HDMIPHY
 
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
+from litex.soc.interconnect.csr_eventmanager import *
 
 from litedram.modules import W9825G6KH6
-from litedram.modules import IS42S16320
-
 from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
 
 from litex.soc.integration.soc import SoCRegion
@@ -38,13 +42,20 @@ from litex.soc.integration.soc import SoCRegion
 
 class _CRG(LiteXModule):
     def __init__(self, platform, sys_clk_freq, sdram_rate):
+        self.rst        = Signal()
         self.cd_por     = ClockDomain()
         self.cd_sys     = ClockDomain()
+        self.cd_init    = ClockDomain()
+        self.cd_eth     = ClockDomain()
         self.cd_video   = ClockDomain()
         self.cd_video5x = ClockDomain()
 
+        self.stop  = Signal()
+        self.reset = Signal()
+
         # Clk / Rst
         clk48 = platform.request("clk48")
+        clk50 = platform.request("clk50")
 
         # Power on reset
         por_count = Signal(16, reset=2**16-1)
@@ -54,19 +65,19 @@ class _CRG(LiteXModule):
         self.sync.por += If(~por_done, por_count.eq(por_count - 1))
 
         # PLL
-        self.pll = pll = ECP5PLL()
-        self.comb += pll.reset.eq(~por_done)
+        self.pll = pll = S7PLL()
+        self.comb += pll.reset.eq(~por_done | self.rst)
         pll.register_clkin(clk48, 48e6)
         pll.create_clkout(self.cd_sys, sys_clk_freq)
 
         if sdram_rate == "1:2":
-            self.cd_sys2x    = ClockDomain()
+            self.cd_sys2x = ClockDomain()
             self.cd_sys2x_ps = ClockDomain()
             pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
             pll.create_clkout(self.cd_sys2x_ps, 2*sys_clk_freq, phase=180)
         elif sdram_rate == "1:4":
-            self.cd_sys2x    = ClockDomain()
-            self.cd_sys4x    = ClockDomain()
+            self.cd_sys2x = ClockDomain()
+            self.cd_sys4x = ClockDomain()
             self.cd_sys4x_ps = ClockDomain()
             pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
             pll.create_clkout(self.cd_sys4x,    4*sys_clk_freq)
@@ -83,19 +94,24 @@ class _CRG(LiteXModule):
             sdram_clk = ClockSignal("sys_ps")
 
         self.specials += DDROutput(1, 0, platform.request("sdram_clock"), sdram_clk)
-        pll2 = ECP5PLL()
+
+        pll2 = S7PLL()
         self.pll2 = pll2
-        pll2.register_clkin(clk48, 48e6)
+        pll2.register_clkin(clk50, 50e6)
+        pll2.create_clkout(self.cd_eth, 50e6)
         pll2.create_clkout(self.cd_video, 25e6)
         pll2.create_clkout(self.cd_video5x, 125e6)
 
+        pll3 = S7PLL()
+        self.pll3 = pll3
+        pll3.register_clkin(clk48, 48e6)
         self.cd_usb_12 = ClockDomain()
-        self.cd_usb    = ClockDomain()
+        self.cd_usb = ClockDomain()
         self.cd_usb_48 = ClockDomain()
         self.cd_usb_48 = self.cd_usb
-        pll2.create_clkout(self.cd_usb, 48e6)
-        pll2.create_clkout(self.cd_usb_12, 12e6)
-        self.comb += pll2.reset.eq(~por_done)
+        pll3.create_clkout(self.cd_usb, 48e6)
+        pll3.create_clkout(self.cd_usb_12, 12e6)
+        self.comb += pll3.reset.eq(~por_done)
 
 # BaseSoC ------------------------------------------------------------------------------------------
 
@@ -103,41 +119,47 @@ class BaseSoC(SoCCore):
     mem_map = {**SoCCore.mem_map, **{
         "usb_ohci":     0xc0000000,
     }}
-    def __init__(self, revision="v0", device="12F", sdram_device="W9825G6KH6", sdram_rate="1:2", sys_clk_freq=int(48e6), toolchain="trellis", with_usb_host=False, **kwargs):
+    def __init__(self, revision="v0", variant="a7-35", toolchain="vivado", sdram_rate="1:2", sys_clk_freq=int(80e6), with_usb_host=False, with_ethernet=False, with_xadc=False, **kwargs):
+    #def __init__(self, revision="v0", variant="a7-35", toolchain="yosys+nextpnr", sdram_rate="1:2", sys_clk_freq=int(48e6), with_usb_host=False, with_ethernet=False, **kwargs):
 
-        platform = machdyne_vanille.Platform(revision=revision, device=device ,toolchain=toolchain)
+        platform = machdyne_mozart_mx1.Platform(revision=revision, variant=variant, toolchain=toolchain)
 
         # CRG --------------------------------------------------------------------------------------
         self.crg = _CRG(platform, sys_clk_freq, sdram_rate=sdram_rate)
 
         # SoCCore ----------------------------------------------------------------------------------
-        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Vanille", **kwargs)
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Mozart ML1", **kwargs)
 
         # DRAM -------------------------------------------------------------------------------------
         if not self.integrated_main_ram_size:
             if sdram_rate == "1:2":
                 sdrphy_cls = HalfRateGENSDRPHY
             elif sdram_rate == "1:4":
-                from litedram.phy import QuarterRateGENSDRPHY
                 sdrphy_cls = QuarterRateGENSDRPHY
             else:
                 sdrphy_cls = GENSDRPHY
 
             self.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
+            self.add_sdram("sdram",
+                phy           = self.sdrphy,
+                module        = W9825G6KH6(sys_clk_freq, sdram_rate),
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
 
-            if sdram_device == "W9825G6KH6":
-                self.add_sdram("sdram",
-                    phy           = self.sdrphy,
-                    module        = W9825G6KH6(sys_clk_freq, sdram_rate),
-                    l2_cache_size = kwargs.get("l2_size", 0)
-                )
+        # XADC -------------------------------------------------------------------------------------
+        if with_xadc:
+            self.xadc = XADC()
 
-            if sdram_device == "IS42S16320":
-                self.add_sdram("sdram",
-                    phy           = self.sdrphy,
-                    module        = IS42S16320(self.clk_freq, sdram_rate),
-                    l2_cache_size = kwargs.get("l2_size", 0)
-                )
+        # SPI Flash --------------------------------------------------------------------------------
+        from litespi.modules import W25Q32
+        from litespi.opcodes import SpiNorFlashOpCodes as Codes
+        self.add_spi_flash(mode="4x", module=W25Q32(Codes.READ_1_1_1), with_master=False)
+
+        # DDMI Framebuffer -------------------------------------------------------------------------------------
+        self.videophy = VideoS7HDMIPHY(platform.request("ddmi"),
+            clock_domain="video")
+        self.add_video_framebuffer(phy=self.videophy, timings="640x480@60Hz",
+            clock_domain="video", format="rgb565")
 
         # USB Host ---------------------------------------------------------------------------------
         if with_usb_host:
@@ -146,36 +168,41 @@ class BaseSoC(SoCCore):
             self.dma_bus.add_master("usb_ohci_dma", master=self.usb_ohci.wb_dma)
             self.comb += self.cpu.interrupt[16].eq(self.usb_ohci.interrupt)
 
-        # DDMI Framebuffer -------------------------------------------------------------------------------------
-        self.videophy = VideoHDMIPHY(platform.request("ddmi"),
-            clock_domain="video")
-        self.add_video_framebuffer(phy=self.videophy, timings="640x480@60Hz",
-            clock_domain="video", format="rgb565")
+        # Ethernet ---------------------------------------------------------------------------------
+        if with_ethernet:
+            from liteeth.phy.rmii import LiteEthPHYRMII
+            self.ethphy = LiteEthPHYRMII(
+                #clock_pads = platform.request("eth_clocks"),
+                clock_pads=None,
+                pads = platform.request("eth"),
+                with_hw_init_reset=True,
+                refclk_cd="eth")
+                #refclk_cd=None)
+            self.add_ethernet(phy=self.ethphy)
 
 # Build --------------------------------------------------------------------------------------------
 
 def main():
     from litex.build.parser import LiteXArgumentParser
-    parser = LiteXArgumentParser(platform=machdyne_vanille.Platform, description="LiteX SoC on Vanille")
-    parser.add_argument("--sys-clk-freq",    default=48e6,         help="System clock frequency.")
+    parser = LiteXArgumentParser(platform=machdyne_mozart_mx1.Platform, description="LiteX SoC on Mozart MX1.")
+    parser.add_argument("--sys-clk-freq",    default=80e6,         help="System clock frequency.")
     parser.add_argument("--revision",        default="v0",         help="Board Revision (v0).")
-    parser.add_argument("--device",          default="12F",        help="ECP5 device (25F, 45F or 85F).")
+    parser.add_argument("--device",          default="45F",        help="ECP5 device (12F, 25F, 45F or 85F).")
     parser.add_argument("--cable",           default="usb-blaster", help="Specify an openFPGALoader cable.")
     parser.add_argument("--with-sdcard",     action="store_true",  help="Enable SDCard support.")
     parser.add_argument("--with-spi-sdcard", action="store_true",  help="Enable SPI-mode SDCard support.")
     parser.add_argument("--with-usb-host",   action="store_true",  help="Enable USB host support.")
+    parser.add_argument("--with-ethernet",   action="store_true",  help="Enable ethernet support.")
     parser.add_argument("--boot-from-flash", action="store_true",  help="Boot from flash MMOD.")
-    parser.add_argument("--sdram-device",    default="W9825G6KH6", help="SDRAM device (W9825G6KH6 or IS42S16320).")
 
     args = parser.parse_args()
 
     soc = BaseSoC(
         toolchain    = args.toolchain,
         revision     = args.revision,
-        device       = args.device,
         sys_clk_freq = int(float(args.sys_clk_freq)),
-        sdram_device = args.sdram_device,
         with_usb_host = args.with_usb_host,
+        with_ethernet = args.with_ethernet,
         **parser.soc_argdict)
 
     if args.with_sdcard:
@@ -188,10 +215,6 @@ def main():
 
     if args.build:
         builder.build(**parser.toolchain_argdict)
-
-    if args.load:
-        prog = soc.platform.create_programmer(cable=args.cable)
-        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
 
 if __name__ == "__main__":
     main()

--- a/litex_boards/targets/machdyne_noir.py
+++ b/litex_boards/targets/machdyne_noir.py
@@ -19,7 +19,6 @@ from litex.gen import *
 
 from litex_boards.platforms import machdyne_noir
 
-from litex.build.lattice.trellis import trellis_args, trellis_argdict
 from litex.build.io import DDROutput
 
 from migen.genlib.resetsync import AsyncResetSynchronizer
@@ -41,7 +40,7 @@ from litex.soc.integration.soc import SoCRegion
 # CRG ---------------------------------------------------------------------------------------------
 
 class _CRG(LiteXModule):
-    def __init__(self, platform, sys_clk_freq, sdram_rate):
+    def __init__(self, platform, sys_clk_freq):
         self.rst        = Signal()
         self.cd_por     = ClockDomain()
         self.cd_sys     = ClockDomain()
@@ -109,15 +108,15 @@ class BaseSoC(SoCCore):
     mem_map = {**SoCCore.mem_map, **{
         "usb_ohci":     0xc0000000,
     }}
-    def __init__(self, revision="v0", device="45F", sdram_device="MT41K128M16", sdram_rate="1:2", sys_clk_freq=int(40e6), toolchain="trellis", with_led_chaser=True, with_usb_host=False, with_ethernet=False, **kwargs):
+    def __init__(self, revision="v0", device="45F", sdram_device="MT41K128M16", sys_clk_freq=int(50e6), toolchain="trellis", with_led_chaser=True, with_usb_host=False, with_ethernet=False, **kwargs):
 
-        platform = machdyne_noir.Platform(revision=revision, device=device ,toolchain=toolchain)
+        platform = machdyne_noir.Platform(revision=revision, device=device, toolchain=toolchain)
 
         # CRG --------------------------------------------------------------------------------------
-        self.crg = _CRG(platform, sys_clk_freq, sdram_rate=sdram_rate)
+        self.crg = _CRG(platform, sys_clk_freq)
 
         # SoCCore ----------------------------------------------------------------------------------
-        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Schoko", **kwargs)
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Noir", **kwargs)
 
         # DDR3L ----------------------------------------------------------------------------------
 
@@ -166,47 +165,29 @@ class BaseSoC(SoCCore):
 # Build --------------------------------------------------------------------------------------------
 
 def main():
-    from litex.soc.integration.soc import LiteXSoCArgumentParser
-    parser = LiteXSoCArgumentParser(description="LiteX SoC on Schoko")
-    target_group = parser.add_argument_group(title="Target options")
-    target_group.add_argument("--build",           action="store_true",  help="Build design.")
-    target_group.add_argument("--load",            action="store_true",  help="Load bitstream to SRAM.")
-    target_group.add_argument("--flash",           action="store_true",  help="Flash bitstream to MMOD.")
-    target_group.add_argument("--toolchain",       default="trellis",    help="FPGA toolchain (trellis or diamond).")
-    target_group.add_argument("--sys-clk-freq",    default=40e6,         help="System clock frequency.")
-    target_group.add_argument("--revision",        default="v0",         help="Board Revision (v0).")
-    target_group.add_argument("--device",          default="45F",        help="ECP5 device (25F, 45F or 85F).")
-    target_group.add_argument("--cable",           default="usb-blaster", help="Specify an openFPGALoader cable.")
-    target_group.add_argument("--with-sdcard",     action="store_true",  help="Enable SDCard support.")
-    target_group.add_argument("--with-spi-sdcard", action="store_true",  help="Enable SPI-mode SDCard support.")
-    target_group.add_argument("--with-usb-host",   action="store_true",  help="Enable USB host support.")
-    target_group.add_argument("--with-ethernet",   action="store_true",  help="Enable ethernet support.")
-    target_group.add_argument("--boot-from-flash", action="store_true",  help="Boot from flash MMOD.")
-    target_group.add_argument("--sdram-device",    default="MT41K128M16", help="SDRAM device.")
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=machdyne_noir.Platform, description="LiteX SoC on Noir")
+    parser.add_argument("--sys-clk-freq",    default=50e6,         help="System clock frequency.")
+    parser.add_argument("--revision",        default="v0",         help="Board Revision (v0).")
+    parser.add_argument("--device",          default="45F",        help="ECP5 device (25F, 45F or 85F).")
+    parser.add_argument("--cable",           default="usb-blaster", help="Specify an openFPGALoader cable.")
+    parser.add_argument("--with-sdcard",     action="store_true",  help="Enable SDCard support.")
+    parser.add_argument("--with-spi-sdcard", action="store_true",  help="Enable SPI-mode SDCard support.")
+    parser.add_argument("--with-usb-host",   action="store_true",  help="Enable USB host support.")
+    parser.add_argument("--with-ethernet",   action="store_true",  help="Enable ethernet support.")
+    parser.add_argument("--boot-from-flash", action="store_true",  help="Boot from flash MMOD.")
+    parser.add_argument("--sdram-device",    default="MT41K128M16", help="SDRAM device.")
 
-    builder_args(parser)
-    soc_core_args(parser)
-    trellis_args(parser)
     args = parser.parse_args()
 
-    print("")
-    print("")
-    print("")
-    print(args)
-
-    print("")
-    print("")
-    print("")
-
     soc = BaseSoC(
-        toolchain    = args.toolchain,
         revision     = args.revision,
         device       = args.device,
         sys_clk_freq = int(float(args.sys_clk_freq)),
         sdram_device = args.sdram_device,
         with_usb_host = args.with_usb_host,
         with_ethernet = args.with_ethernet,
-        **soc_core_argdict(args))
+        **parser.soc_argdict)
 
     if args.with_sdcard:
         soc.add_sdcard()
@@ -214,19 +195,14 @@ def main():
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()
 
-    builder = Builder(soc, **builder_argdict(args))
-    builder_kargs = trellis_argdict(args) if args.toolchain == "trellis" else {}
+    builder = Builder(soc, **parser.builder_argdict)
 
     if args.build:
-        builder.build(**builder_kargs)
+        builder.build(**parser.toolchain_argdict)
 
     if args.load:
-        prog = soc.platform.create_programmer(args.cable)
+        prog = soc.platform.create_programmer(cable=args.cable)
         prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
-
-    if args.flash:
-        prog = soc.platform.create_programmer(args.cable)
-        prog.flash(0x100000, builder.get_bitstream_filename(mode="sram"))
 
 if __name__ == "__main__":
     main()

--- a/litex_boards/targets/machdyne_vanille.py
+++ b/litex_boards/targets/machdyne_vanille.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) Lone Dynamics Corporation <info@lonedynamics.com>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+import os
+import sys
+import json
+
+from migen import *
+
+from litex.gen import *
+
+from litex_boards.platforms import machdyne_vanille
+
+from litex.build.lattice.trellis import trellis_args, trellis_argdict
+from litex.build.io import DDROutput
+
+from litex.soc.cores.clock import *
+from litex.soc.cores.usb_ohci import USBOHCI
+from litex.soc.cores.video import VideoHDMIPHY
+
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+
+from litedram.modules import W9825G6KH6
+from litedram.modules import IS42S16320
+
+from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
+
+from litex.soc.integration.soc import SoCRegion
+
+# CRG ---------------------------------------------------------------------------------------------
+
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq, sdram_rate):
+        self.cd_por     = ClockDomain()
+        self.cd_sys     = ClockDomain()
+        self.cd_video   = ClockDomain()
+        self.cd_video5x = ClockDomain()
+
+        # Clk / Rst
+        clk48 = platform.request("clk48")
+
+        # Power on reset
+        por_count = Signal(16, reset=2**16-1)
+        por_done  = Signal()
+        self.comb += self.cd_por.clk.eq(clk48)
+        self.comb += por_done.eq(por_count == 0)
+        self.sync.por += If(~por_done, por_count.eq(por_count - 1))
+
+        # PLL
+        self.pll = pll = ECP5PLL()
+        self.comb += pll.reset.eq(~por_done)
+        pll.register_clkin(clk48, 48e6)
+        pll.create_clkout(self.cd_sys, sys_clk_freq)
+
+        if sdram_rate == "1:2":
+            self.cd_sys2x    = ClockDomain()
+            self.cd_sys2x_ps = ClockDomain()
+            pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
+            pll.create_clkout(self.cd_sys2x_ps, 2*sys_clk_freq, phase=180)
+        elif sdram_rate == "1:4":
+            self.cd_sys2x    = ClockDomain()
+            self.cd_sys4x    = ClockDomain()
+            self.cd_sys4x_ps = ClockDomain()
+            pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
+            pll.create_clkout(self.cd_sys4x,    4*sys_clk_freq)
+            pll.create_clkout(self.cd_sys4x_ps, 4*sys_clk_freq, phase=180)
+        else:
+            self.cd_sys_ps = ClockDomain()
+            pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90)
+
+        if sdram_rate == "1:2":
+            sdram_clk = ClockSignal("sys2x_ps")
+        elif sdram_rate == "1:4":
+            sdram_clk = ClockSignal("sys4x_ps")
+        else:
+            sdram_clk = ClockSignal("sys_ps")
+
+        self.specials += DDROutput(1, 0, platform.request("sdram_clock"), sdram_clk)
+        pll2 = ECP5PLL()
+        self.pll2 = pll2
+        pll2.register_clkin(clk48, 48e6)
+        pll2.create_clkout(self.cd_video, 25e6)
+        pll2.create_clkout(self.cd_video5x, 125e6)
+
+        self.cd_usb_12 = ClockDomain()
+        self.cd_usb    = ClockDomain()
+        self.cd_usb_48 = ClockDomain()
+        self.cd_usb_48 = self.cd_usb
+        pll2.create_clkout(self.cd_usb, 48e6)
+        pll2.create_clkout(self.cd_usb_12, 12e6)
+        self.comb += pll2.reset.eq(~por_done)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    mem_map = {**SoCCore.mem_map, **{
+        "usb_ohci":     0xc0000000,
+    }}
+    def __init__(self, revision="v0", device="12F", sdram_device="W9825G6KH6", sdram_rate="1:2", sys_clk_freq=int(48e6), toolchain="trellis", with_usb_host=False, **kwargs):
+
+        platform = machdyne_vanille.Platform(revision=revision, device=device ,toolchain=toolchain)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.crg = _CRG(platform, sys_clk_freq, sdram_rate=sdram_rate)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Vanille", **kwargs)
+
+        # DRAM -------------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            if sdram_rate == "1:2":
+                sdrphy_cls = HalfRateGENSDRPHY
+            elif sdram_rate == "1:4":
+                from litedram.phy import QuarterRateGENSDRPHY
+                sdrphy_cls = QuarterRateGENSDRPHY
+            else:
+                sdrphy_cls = GENSDRPHY
+
+            self.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
+
+            if sdram_device == "W9825G6KH6":
+                self.add_sdram("sdram",
+                    phy           = self.sdrphy,
+                    module        = W9825G6KH6(sys_clk_freq, sdram_rate),
+                    l2_cache_size = kwargs.get("l2_size", 0)
+                )
+
+            if sdram_device == "IS42S16320":
+                self.add_sdram("sdram",
+                    phy           = self.sdrphy,
+                    module        = IS42S16320(self.clk_freq, sdram_rate),
+                    l2_cache_size = kwargs.get("l2_size", 0)
+                )
+
+        # USB Host ---------------------------------------------------------------------------------
+        if with_usb_host:
+            self.usb_ohci = USBOHCI(platform, platform.request("usb_host"), usb_clk_freq=int(48e6))
+            self.bus.add_slave("usb_ohci_ctrl", self.usb_ohci.wb_ctrl, region=SoCRegion(origin=self.mem_map["usb_ohci"], size=0x100000, cached=False))
+            self.dma_bus.add_master("usb_ohci_dma", master=self.usb_ohci.wb_dma)
+            self.comb += self.cpu.interrupt[16].eq(self.usb_ohci.interrupt)
+
+        # DDMI Framebuffer -------------------------------------------------------------------------------------
+        self.videophy = VideoHDMIPHY(platform.request("ddmi"),
+            clock_domain="video")
+        self.add_video_framebuffer(phy=self.videophy, timings="640x480@60Hz",
+            clock_domain="video", format="rgb565")
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    from litex.soc.integration.soc import LiteXSoCArgumentParser
+    parser = LiteXSoCArgumentParser(description="LiteX SoC on Vanille")
+    target_group = parser.add_argument_group(title="Target options")
+    target_group.add_argument("--build",           action="store_true",  help="Build design.")
+    target_group.add_argument("--load",            action="store_true",  help="Load bitstream to SRAM.")
+    target_group.add_argument("--flash",           action="store_true",  help="Flash bitstream to MMOD.")
+    target_group.add_argument("--toolchain",       default="trellis",    help="FPGA toolchain (trellis or diamond).")
+    target_group.add_argument("--sys-clk-freq",    default=48e6,         help="System clock frequency.")
+    target_group.add_argument("--revision",        default="v0",         help="Board Revision (v0).")
+    target_group.add_argument("--device",          default="12F",        help="ECP5 device (25F, 45F or 85F).")
+    target_group.add_argument("--cable",           default="usb-blaster", help="Specify an openFPGALoader cable.")
+    target_group.add_argument("--with-sdcard",     action="store_true",  help="Enable SDCard support.")
+    target_group.add_argument("--with-spi-sdcard", action="store_true",  help="Enable SPI-mode SDCard support.")
+    target_group.add_argument("--with-usb-host",   action="store_true",  help="Enable USB host support.")
+    target_group.add_argument("--boot-from-flash", action="store_true",  help="Boot from flash MMOD.")
+    target_group.add_argument("--sdram-device",    default="W9825G6KH6", help="SDRAM device (W9825G6KH6 or IS42S16320).")
+
+    builder_args(parser)
+    soc_core_args(parser)
+    trellis_args(parser)
+    args = parser.parse_args()
+
+    print("")
+    print("")
+    print("")
+    print(args)
+
+    print("")
+    print("")
+    print("")
+
+    soc = BaseSoC(
+        toolchain    = args.toolchain,
+        revision     = args.revision,
+        device       = args.device,
+        sys_clk_freq = int(float(args.sys_clk_freq)),
+        sdram_device = args.sdram_device,
+        with_usb_host = args.with_usb_host,
+        **soc_core_argdict(args))
+
+    if args.with_sdcard:
+        soc.add_sdcard()
+
+    if args.with_spi_sdcard:
+        soc.add_spi_sdcard()
+
+    builder = Builder(soc, **builder_argdict(args))
+    builder_kargs = trellis_argdict(args) if args.toolchain == "trellis" else {}
+
+    if args.build:
+        builder.build(**builder_kargs)
+
+    if args.load:
+        prog = soc.platform.create_programmer(args.cable)
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+    if args.flash:
+        prog = soc.platform.create_programmer(args.cable)
+        prog.flash(0x100000, builder.get_bitstream_filename(mode="sram"))
+
+if __name__ == "__main__":
+    main()

--- a/litex_boards/targets/machdyne_vanille.py
+++ b/litex_boards/targets/machdyne_vanille.py
@@ -111,6 +111,9 @@ class BaseSoC(SoCCore):
         self.crg = _CRG(platform, sys_clk_freq, sdram_rate=sdram_rate)
 
         # SoCCore ----------------------------------------------------------------------------------
+
+        kwargs['uart_name'] = "stub"
+
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Vanille", **kwargs)
 
         # DRAM -------------------------------------------------------------------------------------

--- a/litex_boards/targets/machdyne_vivaldi_ml1.py
+++ b/litex_boards/targets/machdyne_vivaldi_ml1.py
@@ -16,20 +16,20 @@ from migen import *
 
 from litex.gen import *
 
-from litex_boards.platforms import machdyne_vanille
+from litex_boards.platforms import machdyne_vivaldi_ml1
 
 from litex.build.io import DDROutput
 
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
 from litex.soc.cores.clock import *
 from litex.soc.cores.usb_ohci import USBOHCI
-from litex.soc.cores.video import VideoHDMIPHY
 
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
+from litex.soc.interconnect.csr_eventmanager import *
 
 from litedram.modules import W9825G6KH6
-from litedram.modules import IS42S16320
-
 from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
 
 from litex.soc.integration.soc import SoCRegion
@@ -38,13 +38,20 @@ from litex.soc.integration.soc import SoCRegion
 
 class _CRG(LiteXModule):
     def __init__(self, platform, sys_clk_freq, sdram_rate):
+        self.rst        = Signal()
         self.cd_por     = ClockDomain()
         self.cd_sys     = ClockDomain()
+        self.cd_init    = ClockDomain()
         self.cd_video   = ClockDomain()
         self.cd_video5x = ClockDomain()
+        self.cd_eth     = ClockDomain()
+
+        self.stop  = Signal()
+        self.reset = Signal()
 
         # Clk / Rst
         clk48 = platform.request("clk48")
+        clk50 = platform.request("clk50")
 
         # Power on reset
         por_count = Signal(16, reset=2**16-1)
@@ -55,18 +62,18 @@ class _CRG(LiteXModule):
 
         # PLL
         self.pll = pll = ECP5PLL()
-        self.comb += pll.reset.eq(~por_done)
+        self.comb += pll.reset.eq(~por_done | self.rst)
         pll.register_clkin(clk48, 48e6)
         pll.create_clkout(self.cd_sys, sys_clk_freq)
 
         if sdram_rate == "1:2":
-            self.cd_sys2x    = ClockDomain()
+            self.cd_sys2x = ClockDomain()
             self.cd_sys2x_ps = ClockDomain()
             pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
             pll.create_clkout(self.cd_sys2x_ps, 2*sys_clk_freq, phase=180)
         elif sdram_rate == "1:4":
-            self.cd_sys2x    = ClockDomain()
-            self.cd_sys4x    = ClockDomain()
+            self.cd_sys2x = ClockDomain()
+            self.cd_sys4x = ClockDomain()
             self.cd_sys4x_ps = ClockDomain()
             pll.create_clkout(self.cd_sys2x,    2*sys_clk_freq)
             pll.create_clkout(self.cd_sys4x,    4*sys_clk_freq)
@@ -83,19 +90,25 @@ class _CRG(LiteXModule):
             sdram_clk = ClockSignal("sys_ps")
 
         self.specials += DDROutput(1, 0, platform.request("sdram_clock"), sdram_clk)
+
         pll2 = ECP5PLL()
         self.pll2 = pll2
-        pll2.register_clkin(clk48, 48e6)
+        pll2.register_clkin(clk50, 50e6)
+        pll2.create_clkout(self.cd_eth, 50e6)
         pll2.create_clkout(self.cd_video, 25e6)
         pll2.create_clkout(self.cd_video5x, 125e6)
+        self.comb += pll2.reset.eq(~por_done)
 
+        pll3 = ECP5PLL()
+        self.pll3 = pll3
+        pll3.register_clkin(clk48, 48e6)
         self.cd_usb_12 = ClockDomain()
-        self.cd_usb    = ClockDomain()
+        self.cd_usb = ClockDomain()
         self.cd_usb_48 = ClockDomain()
         self.cd_usb_48 = self.cd_usb
-        pll2.create_clkout(self.cd_usb, 48e6)
-        pll2.create_clkout(self.cd_usb_12, 12e6)
-        self.comb += pll2.reset.eq(~por_done)
+        pll3.create_clkout(self.cd_usb, 48e6)
+        pll3.create_clkout(self.cd_usb_12, 12e6)
+        self.comb += pll3.reset.eq(~por_done)
 
 # BaseSoC ------------------------------------------------------------------------------------------
 
@@ -103,41 +116,31 @@ class BaseSoC(SoCCore):
     mem_map = {**SoCCore.mem_map, **{
         "usb_ohci":     0xc0000000,
     }}
-    def __init__(self, revision="v0", device="12F", sdram_device="W9825G6KH6", sdram_rate="1:2", sys_clk_freq=int(48e6), toolchain="trellis", with_usb_host=False, **kwargs):
+    def __init__(self, revision="v2", device="45F", sdram_rate="1:2", sys_clk_freq=int(48e6), toolchain="trellis", with_usb_host=False, with_ethernet=False, **kwargs):
 
-        platform = machdyne_vanille.Platform(revision=revision, device=device ,toolchain=toolchain)
+        platform = machdyne_vivaldi_ml1.Platform(revision=revision, device=device ,toolchain=toolchain)
 
         # CRG --------------------------------------------------------------------------------------
         self.crg = _CRG(platform, sys_clk_freq, sdram_rate=sdram_rate)
 
         # SoCCore ----------------------------------------------------------------------------------
-        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Vanille", **kwargs)
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Vivaldi ML1", **kwargs)
 
         # DRAM -------------------------------------------------------------------------------------
         if not self.integrated_main_ram_size:
             if sdram_rate == "1:2":
                 sdrphy_cls = HalfRateGENSDRPHY
             elif sdram_rate == "1:4":
-                from litedram.phy import QuarterRateGENSDRPHY
                 sdrphy_cls = QuarterRateGENSDRPHY
             else:
                 sdrphy_cls = GENSDRPHY
 
             self.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
-
-            if sdram_device == "W9825G6KH6":
-                self.add_sdram("sdram",
-                    phy           = self.sdrphy,
-                    module        = W9825G6KH6(sys_clk_freq, sdram_rate),
-                    l2_cache_size = kwargs.get("l2_size", 0)
-                )
-
-            if sdram_device == "IS42S16320":
-                self.add_sdram("sdram",
-                    phy           = self.sdrphy,
-                    module        = IS42S16320(self.clk_freq, sdram_rate),
-                    l2_cache_size = kwargs.get("l2_size", 0)
-                )
+            self.add_sdram("sdram",
+                phy           = self.sdrphy,
+                module        = W9825G6KH6(sys_clk_freq, sdram_rate),
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
 
         # USB Host ---------------------------------------------------------------------------------
         if with_usb_host:
@@ -146,26 +149,41 @@ class BaseSoC(SoCCore):
             self.dma_bus.add_master("usb_ohci_dma", master=self.usb_ohci.wb_dma)
             self.comb += self.cpu.interrupt[16].eq(self.usb_ohci.interrupt)
 
-        # DDMI Framebuffer -------------------------------------------------------------------------------------
-        self.videophy = VideoHDMIPHY(platform.request("ddmi"),
-            clock_domain="video")
-        self.add_video_framebuffer(phy=self.videophy, timings="640x480@60Hz",
-            clock_domain="video", format="rgb565")
+        # Ethernet ---------------------------------------------------------------------------------
+        if with_ethernet:
+            from liteeth.phy.rmii import LiteEthPHYRMII
+            self.ethphy = LiteEthPHYRMII(
+                clock_pads=None,
+                pads = platform.request("eth", 0),
+                with_hw_init_reset=True,
+                refclk_cd="eth")
+            self.add_csr("ethphy")
+            self.add_ethernet(name="ethmac", phy=self.ethphy,
+                phy_cd="ethphy_eth")
+
+            self.ethphy1 = LiteEthPHYRMII(
+                clock_pads=None,
+                pads = platform.request("eth", 1),
+                with_hw_init_reset=True,
+                refclk_cd="eth")
+            self.add_csr("ethphy1")
+            self.add_ethernet(name="ethmac1", phy=self.ethphy1,
+                phy_cd="ethphy1_eth")
 
 # Build --------------------------------------------------------------------------------------------
 
 def main():
     from litex.build.parser import LiteXArgumentParser
-    parser = LiteXArgumentParser(platform=machdyne_vanille.Platform, description="LiteX SoC on Vanille")
+    parser = LiteXArgumentParser(platform=machdyne_vivaldi_ml1.Platform, description="LiteX SoC on Vivaldi ML1")
     parser.add_argument("--sys-clk-freq",    default=48e6,         help="System clock frequency.")
-    parser.add_argument("--revision",        default="v0",         help="Board Revision (v0).")
-    parser.add_argument("--device",          default="12F",        help="ECP5 device (25F, 45F or 85F).")
-    parser.add_argument("--cable",           default="usb-blaster", help="Specify an openFPGALoader cable.")
+    parser.add_argument("--revision",        default="v2",         help="Board Revision (v0, v1, v2).")
+    parser.add_argument("--device",          default="45F",        help="ECP5 device (12F, 25F, 45F or 85F).")
+    parser.add_argument("--cable",           default="dirtyJtag",  help="Specify an openFPGALoader cable.")
     parser.add_argument("--with-sdcard",     action="store_true",  help="Enable SDCard support.")
     parser.add_argument("--with-spi-sdcard", action="store_true",  help="Enable SPI-mode SDCard support.")
     parser.add_argument("--with-usb-host",   action="store_true",  help="Enable USB host support.")
+    parser.add_argument("--with-ethernet",   action="store_true",  help="Enable ethernet support.")
     parser.add_argument("--boot-from-flash", action="store_true",  help="Boot from flash MMOD.")
-    parser.add_argument("--sdram-device",    default="W9825G6KH6", help="SDRAM device (W9825G6KH6 or IS42S16320).")
 
     args = parser.parse_args()
 
@@ -174,8 +192,8 @@ def main():
         revision     = args.revision,
         device       = args.device,
         sys_clk_freq = int(float(args.sys_clk_freq)),
-        sdram_device = args.sdram_device,
         with_usb_host = args.with_usb_host,
+        with_ethernet = args.with_ethernet,
         **parser.soc_argdict)
 
     if args.with_sdcard:
@@ -185,7 +203,6 @@ def main():
         soc.add_spi_sdcard()
 
     builder = Builder(soc, **parser.builder_argdict)
-
     if args.build:
         builder.build(**parser.toolchain_argdict)
 


### PR DESCRIPTION
This PR fixes some typos in the Machdyne platform files and adds support for the [Vanille](https://github.com/machdyne/vanille) and [Lakritz](https://github.com/machdyne/lakritz) FPGA computers.