### PR TITLE
Add support for Signaloid C0-microSD

### DIFF
--- a/litex_boards/platforms/signaloid_c0_microsd.py
+++ b/litex_boards/platforms/signaloid_c0_microsd.py
@@ -1,73 +1,66 @@
-# Copyright (c) 2024, Signaloid.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to
-# deal in the Software without restriction, including without limitation the
-# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-# sell copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# This file is part of LiteX-Boards.
+# Copyright (c) 2024, Signaloid <a.vailakis@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Signaloid C0-microSD FPGA SoM:
+# - Documentation: https://c0-microsd-docs.signaloid.io/
+# - GitHub HomePage: https://github.com/signaloid/C0-microSD-Hardware
 
 from litex.build.generic_platform import IOStandard, Misc, Pins, Subsignal
 from litex.build.lattice import LatticeiCE40Platform
 
+# IOs ----------------------------------------------------------------------------------------------
+
 _io = [
-    # Default Clk
+    # Clk / Rst
     ("clk12", 0, Pins("B3"), IOStandard("LVCMOS33")),
+
     # Leds
-    ("led_red", 0, Pins("B5"), IOStandard("LVCMOS33")),
-    ("led_green", 0, Pins("A5"), IOStandard("LVCMOS33")),
+    ("user_led", 0, Pins("B5"), IOStandard("LVCMOS33")), # Red
+    ("user_led", 1, Pins("A5"), IOStandard("LVCMOS33")), # Green
+
+    # Serial
+    ("serial", 0,
+        Subsignal("rx", Pins("B3")),
+        Subsignal("tx", Pins("A4"), Misc("PULLUP")),
+        IOStandard("LVCMOS33")
+    ),
+
     # SPIFlash
-    (
-        "spiflash",
-        0,
-        Subsignal("cs_n", Pins("C1"), IOStandard("LVCMOS18")),
-        Subsignal("clk", Pins("D1"), IOStandard("LVCMOS18")),
-        Subsignal("mosi", Pins("F1"), IOStandard("LVCMOS18")),
-        Subsignal("miso", Pins("E1"), IOStandard("LVCMOS18")),
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("C1")),
+        Subsignal("clk",  Pins("D1")),
+        Subsignal("mosi", Pins("F1")),
+        Subsignal("miso", Pins("E1")),
+        IOStandard("LVCMOS18"),
     ),
-    # UART
-    (
-        "serial",
-        0,
-        Subsignal("rx", Pins("B3"), IOStandard("LVCMOS33")),
-        Subsignal("tx", Pins("A4"), IOStandard("LVCMOS33"), Misc("PULLUP")),
+
+    # SDCard (no CD)
+    ("sdcard", 0,
+        Subsignal("data", Pins("A1 A2 E5 F5")),
+        Subsignal("cmd", Pins("A4")),
+        Subsignal("clk", Pins("B3")),
+        IOStandard("LVCMOS33"),
     ),
 ]
 
+# Connectors ---------------------------------------------------------------------------------------
 
-_connectors = [
-    ("SD_DAT0", "A1"),
-    ("SD_DAT1", "A2"),
-    ("SD_DAT2", "E5"),
-    ("SD_DAT3", "F5"),
-    ("SD_CMD", "A4"),
-    ("SD_CLK", "B3"),
-    ("LED_GREEN", "A5"),
-    ("LED_RED", "B5"),
-    ("CONFIG_MOSI", "F1"),
-    ("CONFIG_MISO", "E1"),
-    ("CONFIG_SCLK", "D1"),
-    ("CONFIG_CS_N", "C1"),
-    ("CONFIG_DONE", "D3"),
-]
+_connectors = []
 
+# Platform -----------------------------------------------------------------------------------------
 
 class Platform(LatticeiCE40Platform):
-    default_clk_name = "clk12"
-    default_clk_period = 1e9 / 12e6
+    default_clk_name   = "clk12"
+    default_clk_period = 1e9/12e6
 
     def __init__(self, toolchain="icestorm"):
-        LatticeiCE40Platform.__init__(
-            self, "ice40-up5k-uwg30", _io, _connectors, toolchain=toolchain
-        )
+        LatticeiCE40Platform.__init__(self, "ice40-up5k-uwg30", _io, _connectors, toolchain=toolchain)
+
+    def create_programmer(self):
+        return IceStormProgrammer()
+
+    def do_finalize(self, fragment):
+        LatticeiCE40Platform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk12", loose=True), 1e9/12e6)

--- a/litex_boards/platforms/signaloid_c0_microsd.py
+++ b/litex_boards/platforms/signaloid_c0_microsd.py
@@ -36,13 +36,13 @@ _io = [
         IOStandard("LVCMOS18"),
     ),
 
-    # SDCard (no CD)
-    ("sdcard", 0,
-        Subsignal("data", Pins("A1 A2 E5 F5")),
-        Subsignal("cmd", Pins("A4")),
-        Subsignal("clk", Pins("B3")),
-        IOStandard("LVCMOS33"),
-    ),
+    # SD Breakout pins
+    ("SD_DAT0", 0, Pins("A1"), IOStandard("LVCMOS33")),
+    ("SD_DAT1", 0, Pins("A2"), IOStandard("LVCMOS33")),
+    ("SD_DAT2", 0, Pins("E5"), IOStandard("LVCMOS33")),
+    ("SD_DAT3", 0, Pins("F5"), IOStandard("LVCMOS33")),
+    ("SD_CMD",  0, Pins("A4"), IOStandard("LVCMOS33")),
+    ("SD_CLK",  0, Pins("B3"), IOStandard("LVCMOS33")),
 ]
 
 # Connectors ---------------------------------------------------------------------------------------

--- a/litex_boards/platforms/signaloid_c0_microsd.py
+++ b/litex_boards/platforms/signaloid_c0_microsd.py
@@ -59,7 +59,14 @@ class Platform(LatticeiCE40Platform):
         LatticeiCE40Platform.__init__(self, "ice40-up5k-uwg30", _io, _connectors, toolchain=toolchain)
 
     def create_programmer(self):
-        return IceStormProgrammer()
+        print("\033[93m")
+        print("-------------------------------------------------------------------------------")
+        print("Programming is not supported for this platform.")
+        print("Please use the official Signaloid C0-microSD utilities for flashing the device.")
+        print("https://github.com/signaloid/C0-microSD-utilities")
+        print("-------------------------------------------------------------------------------")
+        print("\033[0m")
+        return None
 
     def do_finalize(self, fragment):
         LatticeiCE40Platform.do_finalize(self, fragment)

--- a/litex_boards/platforms/signaloid_c0_microsd.py
+++ b/litex_boards/platforms/signaloid_c0_microsd.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2024, Signaloid.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+from litex.build.generic_platform import IOStandard, Misc, Pins, Subsignal
+from litex.build.lattice import LatticeiCE40Platform
+
+_io = [
+    # Default Clk
+    ("clk12", 0, Pins("B3"), IOStandard("LVCMOS33")),
+    # Leds
+    ("led_red", 0, Pins("B5"), IOStandard("LVCMOS33")),
+    ("led_green", 0, Pins("A5"), IOStandard("LVCMOS33")),
+    # SPIFlash
+    (
+        "spiflash",
+        0,
+        Subsignal("cs_n", Pins("C1"), IOStandard("LVCMOS18")),
+        Subsignal("clk", Pins("D1"), IOStandard("LVCMOS18")),
+        Subsignal("mosi", Pins("F1"), IOStandard("LVCMOS18")),
+        Subsignal("miso", Pins("E1"), IOStandard("LVCMOS18")),
+    ),
+    # UART
+    (
+        "serial",
+        0,
+        Subsignal("rx", Pins("B3"), IOStandard("LVCMOS33")),
+        Subsignal("tx", Pins("A4"), IOStandard("LVCMOS33"), Misc("PULLUP")),
+    ),
+]
+
+
+_connectors = [
+    ("SD_DAT0", "A1"),
+    ("SD_DAT1", "A2"),
+    ("SD_DAT2", "E5"),
+    ("SD_DAT3", "F5"),
+    ("SD_CMD", "A4"),
+    ("SD_CLK", "B3"),
+    ("LED_GREEN", "A5"),
+    ("LED_RED", "B5"),
+    ("CONFIG_MOSI", "F1"),
+    ("CONFIG_MISO", "E1"),
+    ("CONFIG_SCLK", "D1"),
+    ("CONFIG_CS_N", "C1"),
+    ("CONFIG_DONE", "D3"),
+]
+
+
+class Platform(LatticeiCE40Platform):
+    default_clk_name = "clk12"
+    default_clk_period = 1e9 / 12e6
+
+    def __init__(self, toolchain="icestorm"):
+        LatticeiCE40Platform.__init__(
+            self, "ice40-up5k-uwg30", _io, _connectors, toolchain=toolchain
+        )

--- a/litex_boards/platforms/signaloid_c0_microsd.py
+++ b/litex_boards/platforms/signaloid_c0_microsd.py
@@ -1,6 +1,6 @@
 #
 # This file is part of LiteX-Boards.
-# Copyright (c) 2024, Signaloid <a.vailakis@gmail.com>
+# Copyright (c) 2024, Signaloid <developer-support@signaloid.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 # Signaloid C0-microSD FPGA SoM:

--- a/litex_boards/targets/signaloid_c0_microsd.py
+++ b/litex_boards/targets/signaloid_c0_microsd.py
@@ -1,122 +1,58 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2024, Signaloid.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to
-# deal in the Software without restriction, including without limitation the
-# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-# sell copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
+# This file is part of LiteX-Boards.
+# Copyright (c) 2024, Signaloid <a.vailakis@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
 
-# This target file provides a LiteX SoC for the Signaloid C0-microSD card.
-# For a more complete example with more features, automation scripts,
-# documentation, and C based firmware compilation, refer to:
-# https://github.com/signaloid/C0-microSD-litex
-
-
-import argparse
-
-from litespi.modules.generated_modules import AT25SL128A
-from litespi.opcodes import SpiNorFlashOpCodes
-from litex.soc import doc as docs_builder
-from litex.soc.cores.ram import Up5kSPRAM
-from litex.soc.integration.builder import (
-    Builder,
-    builder_argdict,
-    builder_args,
-)
-from litex.soc.integration.doc import AutoDoc, ModuleDoc
-from litex.soc.integration.soc import (
-    ClockDomain,
-    Instance,
-    Module,
-    Signal,
-    SoCRegion,
-    log2_int,
-)
-from litex.soc.integration.soc_core import (
-    SoCCore,
-    soc_core_argdict,
-    soc_core_args,
-)
-from litex.soc.interconnect.csr import AutoCSR, CSRField, CSRStorage
-from migen import If
+from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.gen import *
 
 from litex_boards.platforms import signaloid_c0_microsd
 
+from litex.soc.cores.ram import Up5kSPRAM
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
 
-kB = 1024
-MB = 1024 * kB
+# CRG ----------------------------------------------------------------------------------------------
 
-# USER_DATA_OFFSET is the SPI Flash address of the first byte of the firmware
-# binary. It is used as a boot address for the Signaloid C0-microSD card SoC.
-#
-# The SPI Flash is connected to the Core through the SoC's memory mapped bus.
-# Hence, the CPU Reset Address is set to:
-# SPI_FLASH_BUS_ADDRESS + USER_DATA_OFFSET
-#
-# As described on the official Signaloid C0-microSD documentation, the
-# USER_DATA_OFFSET defines the start of a 14MiB address space where the
-# firmware binary and data can be stored.
-#
-# More info:
-# https://c0-microsd-docs.signaloid.io/hardware-overview/bootloader-addresssing.html
-USER_DATA_OFFSET = "0x200000"
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst         = Signal()
+        self.cd_sys      = ClockDomain()
+        self.cd_por      = ClockDomain()
+        self.cd_clk10khz = ClockDomain()
 
+        assert sys_clk_freq in [6e6, 12e6, 24e6, 48e6]
 
-class _CRG(Module, AutoDoc):
-    """Clock Resource Generator"""
+        # # #
 
-    SYS_FREQ = {
-        "48MHz": {
-            "sys_clk_freq": 48e6,
-            "p_CLKHF_DIV": "0b00",
-        },
-        "24MHz": {
-            "sys_clk_freq": 24e6,
-            "p_CLKHF_DIV": "0b01",
-        },
-        "12MHz": {
-            "sys_clk_freq": 12e6,
-            "p_CLKHF_DIV": "0b10",
-        },
-        "6MHz": {
-            "sys_clk_freq": 6e6,
-            "p_CLKHF_DIV": "0b11",
-        },
-    }
-
-    def __init__(
-        self, sys_clk_cfg: str, platform: signaloid_c0_microsd.Platform
-    ) -> None:
-        self.clock_domains.cd_sys = ClockDomain(name="sys")
-        self.clock_domains.cd_por = ClockDomain(name="por")
-        self.clock_domains.cd_clk10khz = ClockDomain(name="clk10khz")
-
-        TARGET_SYS_FREQ = self.SYS_FREQ[sys_clk_cfg]
+        # Power On Reset
+        por_count = Signal(16, reset=2**16-1)
+        por_done  = Signal()
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+        self.comb += por_done.eq(por_count == 0)
+        self.sync.por += If(~por_done, por_count.eq(por_count - 1))
 
         # High frequency oscillator (HFSOC) up to 48MHz
+        clk_hf_div = {
+            48e6: "0b00",
+            24e6: "0b01",
+            12e6: "0b10",
+             6e6: "0b11"}[sys_clk_freq]
+
         self.specials += Instance(
             "SB_HFOSC",
-            p_CLKHF_DIV=TARGET_SYS_FREQ["p_CLKHF_DIV"],
-            i_CLKHFEN=0b1,
-            i_CLKHFPU=0b1,
-            o_CLKHF=self.cd_sys.clk,
+            p_CLKHF_DIV = clk_hf_div,
+            i_CLKHFEN   = 0b1,
+            i_CLKHFPU   = 0b1,
+            o_CLKHF     = self.cd_sys.clk,
         )
-        sys_clk_freq = TARGET_SYS_FREQ["sys_clk_freq"]
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~por_done)
         platform.add_period_constraint(self.cd_sys.clk, 1e9 / sys_clk_freq)
 
         # Low frequency oscillator (LFOSC) at 10kHz
@@ -127,249 +63,98 @@ class _CRG(Module, AutoDoc):
             o_CLKLF=self.cd_clk10khz.clk,
         )
 
-        # Power-on reset: Keep reset active for a few cycles after power on.
-        self.reset = Signal()
-        por_cycles = 4096
-        por_counter = Signal(log2_int(por_cycles), reset=por_cycles - 1)
-        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
-        platform.add_period_constraint(self.cd_por.clk, 1e9 / sys_clk_freq)
-        self.sync.por += If(
-            por_counter != 0,
-            por_counter.eq(por_counter - 1),
-        )
-        self.comb += self.cd_sys.rst.eq(por_counter != 0)
-        self.specials += AsyncResetSynchronizer(self.cd_por, self.reset)
-
-
-class Leds(Module, AutoCSR, AutoDoc):
-    """Signaloid C0-microSD LED control"""
-
-    def __init__(self, platform: signaloid_c0_microsd.Platform) -> None:
-        self.intro = ModuleDoc(
-            """Signaloid C0-microSD LED control.
-            Set the LED bit to 1 to turn it on and 0 to turn it off.
-            """
-        )
-
-        self._out = CSRStorage(
-            size=2,
-            fields=[
-                CSRField(
-                    name="red",
-                    description="""The Red LED on the Signaloid C0-microSD.
-                    On when 1, off when 0.""",
-                ),
-                CSRField(
-                    name="green",
-                    description="""The Green LED on the Signaloid C0-microSD.
-                    On when 1, off when 0.""",
-                ),
-            ],
-        )
-
-        # Drive the LEDs directly.
-        #
-        # Driving the LEDs directly from the FPGA is SAFE on
-        # the Signaloid C0-microSD, since the LEDs are hard-wired to external
-        # current limiting resistors.
-        # Hence, for simplicity, the SB_RGBA_DRV hard IP can be omitted.
-        #
-        # In general, direct drive can lead to overvoltage, and damage to the
-        # LEDs and/or the board. Lattice iCE40 mitigates this issue by
-        # incorporating the SB_RGBA_DRV hard IP on LEDs without external
-        # current limiting resistors.
-        #
-        # LED driver pins are in an open-drain configuration so they should
-        # be inverted to be intuitively controlled through software.
-        #
-        self.comb += platform.request("led_red").eq(~self._out.storage[0])
-        self.comb += platform.request("led_green").eq(~self._out.storage[1])
-
+# BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    """Base SoC for Signaloid C0-microSD"""
+    def __init__(self, bios_flash_offset, sys_clk_freq=24e6,
+        with_led_chaser = True,
+        **kwargs):
+        platform = signaloid_c0_microsd.Platform()
 
-    # Statically define the memory map, to prevent it from shifting
-    # across various litex versions.
-    SoCCore.mem_map = {
-        "sram": 0x10000000,
-        "spiflash": 0x20000000,
-        "csr": 0xF0000000,
-        "vexriscv_debug": 0xF00F0000,
-    }
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
 
-    def __init__(
-        self,
-        platform: signaloid_c0_microsd.Platform,
-        sys_clk_cfg: str,
-        flash_offset: int,
-        add_uart: bool,
-        **kwargs
-    ) -> None:
-        """Extends the SoCCore class to create a BaseSoC with configuration
-        for the Signaloid C0-microSD.
-
-        :param sys_clk_cfg: The system clock frequency to use.
-        Possible values are defined on the _CRG.SYS_FREQ dict:
-        ["48MHz", "24MHz", "12MHz", "6MHz"]
-        :type sys_clk_cfg: str
-
-        :param flash_offset: The offset on the SPI Flash's address space where
-        the first byte of the firmware binary can be found.
-        :type flash_offset: int
-
-        :param add_uart: If set, creates a UART interface on the Signaloid
-        C0-microSD's platform serial pins.
-        :type add_uart: bool
-        """
-
-        self.platform = platform
-
-        # Set cpu name and variant defaults when none are provided
-        if "cpu_variant" not in kwargs:
-            kwargs["cpu_variant"] = "lite"
-
-        # Force the SRAM size to 0, because we add our own SRAM with SPRAM
+        # SoCCore ----------------------------------------------------------------------------------
+        # Disable Integrated ROM/SRAM since too large for iCE40 and UP5K has specific SPRAM.
         kwargs["integrated_sram_size"] = 0
-        kwargs["integrated_rom_size"] = 0
+        kwargs["integrated_rom_size"]  = 0
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Signaloid C0-microSD", **kwargs)
 
-        kwargs["csr_data_width"] = 32
-
-        # Set CPU reset address
-        kwargs["cpu_reset_address"] = self.mem_map["spiflash"] + flash_offset
-
-        # If debug is enabled, add a serial port on the Signaloid C0-microSD's
-        # platform serial pins.
-        if add_uart:
-            kwargs["uart_name"] = "serial"
-
-        # SoCCore
-        SoCCore.__init__(
-            self,
-            platform=self.platform,
-            clk_freq=_CRG.SYS_FREQ[sys_clk_cfg]["sys_clk_freq"],
-            **kwargs
+        # 128KB SPRAM (used as 64kB SRAM / 64kB RAM) -----------------------------------------------
+        self.spram = Up5kSPRAM(size=128 * KILOBYTE)
+        self.bus.add_slave("psram", self.spram.bus, SoCRegion(size=128 * KILOBYTE))
+        self.bus.add_region("sram", SoCRegion(
+            origin = self.bus.regions["psram"].origin + 0 * KILOBYTE,
+            size   = 64 * KILOBYTE,
+            linker = True)
         )
+        if not self.integrated_main_ram_size:
+            self.bus.add_region("main_ram", SoCRegion(
+                origin = self.bus.regions["psram"].origin + 64 * KILOBYTE,
+                size   = 64 * KILOBYTE,
+                linker = True)
+            )
 
-        self.submodules.crg = _CRG(
-            sys_clk_cfg=sys_clk_cfg,
-            platform=self.platform
-        )
-
-        # iCE40-UP5K has a single port RAM, which is a dedicated 128kB block.
-        # Use this as CPU RAM.
-        spram_size = 128 * kB
-        self.submodules.spram = Up5kSPRAM(size=spram_size)
-        self.bus.add_slave(
-            name="sram",
-            slave=self.spram.bus,
-            region=SoCRegion(
-                origin=self.mem_map["sram"],
-                size=spram_size,
-                linker=True,
-            ),
-        )
-
-        # SPI Flash
+        # SPI Flash --------------------------------------------------------------------------------
         # Signaloid C0-microSD uses the AT25QL128A SPI flash with the QPI mode
         # disabled. Hence, the AT25SL128A module is used instead, which is
         # compatible with Signaloid C0-microSD's AT25QL128A with the QPI mode
         # disabled.
-        self.add_spi_flash(
-            mode="1x",
-            module=AT25SL128A(SpiNorFlashOpCodes.READ_1_1_1),
-            with_master=False,
+        from litespi.modules import AT25SL128A
+        from litespi.opcodes import SpiNorFlashOpCodes as Codes
+        self.add_spi_flash(mode="1x", module=AT25SL128A(Codes.READ_1_1_1), with_master=False)
+
+        # Add ROM linker region --------------------------------------------------------------------
+        self.bus.add_region("rom", SoCRegion(
+            origin = self.bus.regions["spiflash"].origin + bios_flash_offset,
+            size   = 32 * KILOBYTE,
+            linker = True)
         )
+        self.cpu.set_reset_address(self.bus.regions["rom"].origin)
 
-        # Add ROM linker region
-        self.bus.add_region(
-            name="rom",
-            region=SoCRegion(
-                origin=self.mem_map["spiflash"] + flash_offset,
-                size=8 * MB,
-                linker=True,
-            ),
-        )
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
 
-        # Peripherals
-        self.submodules.leds = Leds(self.platform)
-        self.add_csr("leds")
+# Flash --------------------------------------------------------------------------------------------
 
+def flash(build_dir, build_name, bios_flash_offset):
+    from litex.build.lattice.programmer import IceStormProgrammer
+    prog = IceStormProgrammer()
+    prog.flash(bios_flash_offset, f"{build_dir}/software/bios/bios.bin")
+    prog.flash(0x00000000,        f"{build_dir}/gateware/{build_name}.bin")
 
-class SignaloidC0MicroSDBuilder:
-    def __init__(self, platform: signaloid_c0_microsd.Platform) -> None:
-        self.platform = platform
+# Build --------------------------------------------------------------------------------------------
 
-        self.parser = argparse.ArgumentParser(
-            description="LiteX SoC on Signaloid C0-microSD"
-        )
+def main():
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=signaloid_c0_microsd.Platform, description="LiteX SoC on Signaloid C0-microSD.")
+    parser.add_target_argument("--flash",             action="store_true",      help="Flash Bitstream and BIOS.")
+    parser.add_target_argument("--sys-clk-freq",      default=24e6, type=float, help="System clock frequency.")
+    parser.add_target_argument("--bios-flash-offset", default="0x200000",       help="BIOS offset in SPI Flash.")
+    parser.add_target_argument("--add_uart",          action="store_true",      help="Enable UART (shared pins with clk/SD interface.")
+    args = parser.parse_args()
 
-        builder_args(self.parser)
-        soc_core_args(self.parser)
+    if not args.add_uart:
+        args.no_uart = True
 
-        self.parser_target_group = self.parser.add_argument_group(
-            title="Target options"
-        )
-        self.parser_target_group.add_argument(
-            "--build", action="store_true", help="Build design."
-        )
-        self.parser_target_group.add_argument(
-            "--sys-clk-cfg",
-            default=list(_CRG.SYS_FREQ.keys())[0],
-            help="The system clock frequency to use. Possible values are:\n"
-            + ", ".join(_CRG.SYS_FREQ.keys()),
-        )
-        self.parser_target_group.add_argument(
-            "--flash-offset",
-            default=USER_DATA_OFFSET,
-            help="Boot offset in SPI Flash.",
-        )
-        self.parser_target_group.add_argument(
-            "--add-uart",
-            action="store_true",
-            help="Enable UART interface.",
-        )
-
-    @property
-    def args(self) -> argparse.Namespace:
-        return self.parser.parse_args()
-
-    @property
-    def builder_kwargs(self) -> dict:
-        return builder_argdict(self.args)
-
-    def get_base_soc(self) -> BaseSoC:
-        return BaseSoC(
-            platform=self.platform,
-            sys_clk_cfg=self.args.sys_clk_cfg,
-            flash_offset=int(self.args.flash_offset, 0),
-            add_uart=self.args.add_uart,
-            **soc_core_argdict(self.args)
-        )
-
-    def build(self, soc: BaseSoC) -> None:
-        # Create and run the builder
-        builder = Builder(soc, **self.builder_kwargs)
-        if self.args.build:
-            builder.build()
-
-        docs_builder.generate_docs(
-            soc,
-            "build/documentation/",
-            project_name="Signaloid C0-microSD LiteX RISC-V Example SoC",
-            author="Signaloid",
-        )
-
-
-def main() -> None:
-    builder = SignaloidC0MicroSDBuilder(
-        platform=signaloid_c0_microsd.Platform()
+    soc = BaseSoC(
+        bios_flash_offset   = int(args.bios_flash_offset, 0),
+        sys_clk_freq        = args.sys_clk_freq,
+        **parser.soc_argdict
     )
+    builder = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
 
-    soc = builder.get_base_soc()
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram", ext=".bin")) # FIXME
 
-    builder.build(soc)
-
+    if args.flash:
+        flash(builder.output_dir, soc.build_name, args.bios_flash_offset)
 
 if __name__ == "__main__":
     main()

--- a/litex_boards/targets/signaloid_c0_microsd.py
+++ b/litex_boards/targets/signaloid_c0_microsd.py
@@ -18,7 +18,6 @@ from litex.soc.integration.soc import SoCRegion
 from litex.soc.integration.builder import *
 from litex.soc.cores.led import LedChaser
 
-KILOBYTE = 1024
 
 # CRG ----------------------------------------------------------------------------------------------
 

--- a/litex_boards/targets/signaloid_c0_microsd.py
+++ b/litex_boards/targets/signaloid_c0_microsd.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2024, Signaloid.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+# This target file provides a LiteX SoC for the Signaloid C0-microSD card.
+# For a more complete example with more features, automation scripts,
+# documentation, and C based firmware compilation, refer to:
+# https://github.com/signaloid/C0-microSD-litex
+
+
+import argparse
+
+from litespi.modules.generated_modules import AT25SL128A
+from litespi.opcodes import SpiNorFlashOpCodes
+from litex.soc import doc as docs_builder
+from litex.soc.cores.ram import Up5kSPRAM
+from litex.soc.integration.builder import (
+    Builder,
+    builder_argdict,
+    builder_args,
+)
+from litex.soc.integration.doc import AutoDoc, ModuleDoc
+from litex.soc.integration.soc import (
+    ClockDomain,
+    Instance,
+    Module,
+    Signal,
+    SoCRegion,
+    log2_int,
+)
+from litex.soc.integration.soc_core import (
+    SoCCore,
+    soc_core_argdict,
+    soc_core_args,
+)
+from litex.soc.interconnect.csr import AutoCSR, CSRField, CSRStorage
+from migen import If
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex_boards.platforms import signaloid_c0_microsd
+
+
+kB = 1024
+MB = 1024 * kB
+
+# USER_DATA_OFFSET is the SPI Flash address of the first byte of the firmware
+# binary. It is used as a boot address for the Signaloid C0-microSD card SoC.
+#
+# The SPI Flash is connected to the Core through the SoC's memory mapped bus.
+# Hence, the CPU Reset Address is set to:
+# SPI_FLASH_BUS_ADDRESS + USER_DATA_OFFSET
+#
+# As described on the official Signaloid C0-microSD documentation, the
+# USER_DATA_OFFSET defines the start of a 14MiB address space where the
+# firmware binary and data can be stored.
+#
+# More info:
+# https://c0-microsd-docs.signaloid.io/hardware-overview/bootloader-addresssing.html
+USER_DATA_OFFSET = "0x200000"
+
+
+class _CRG(Module, AutoDoc):
+    """Clock Resource Generator"""
+
+    SYS_FREQ = {
+        "48MHz": {
+            "sys_clk_freq": 48e6,
+            "p_CLKHF_DIV": "0b00",
+        },
+        "24MHz": {
+            "sys_clk_freq": 24e6,
+            "p_CLKHF_DIV": "0b01",
+        },
+        "12MHz": {
+            "sys_clk_freq": 12e6,
+            "p_CLKHF_DIV": "0b10",
+        },
+        "6MHz": {
+            "sys_clk_freq": 6e6,
+            "p_CLKHF_DIV": "0b11",
+        },
+    }
+
+    def __init__(
+        self, sys_clk_cfg: str, platform: signaloid_c0_microsd.Platform
+    ) -> None:
+        self.clock_domains.cd_sys = ClockDomain(name="sys")
+        self.clock_domains.cd_por = ClockDomain(name="por")
+        self.clock_domains.cd_clk10khz = ClockDomain(name="clk10khz")
+
+        TARGET_SYS_FREQ = self.SYS_FREQ[sys_clk_cfg]
+
+        # High frequency oscillator (HFSOC) up to 48MHz
+        self.specials += Instance(
+            "SB_HFOSC",
+            p_CLKHF_DIV=TARGET_SYS_FREQ["p_CLKHF_DIV"],
+            i_CLKHFEN=0b1,
+            i_CLKHFPU=0b1,
+            o_CLKHF=self.cd_sys.clk,
+        )
+        sys_clk_freq = TARGET_SYS_FREQ["sys_clk_freq"]
+        platform.add_period_constraint(self.cd_sys.clk, 1e9 / sys_clk_freq)
+
+        # Low frequency oscillator (LFOSC) at 10kHz
+        self.specials += Instance(
+            "SB_LFOSC",
+            i_CLKLFEN=0b1,
+            i_CLKLFPU=0b1,
+            o_CLKLF=self.cd_clk10khz.clk,
+        )
+
+        # Power-on reset: Keep reset active for a few cycles after power on.
+        self.reset = Signal()
+        por_cycles = 4096
+        por_counter = Signal(log2_int(por_cycles), reset=por_cycles - 1)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+        platform.add_period_constraint(self.cd_por.clk, 1e9 / sys_clk_freq)
+        self.sync.por += If(
+            por_counter != 0,
+            por_counter.eq(por_counter - 1),
+        )
+        self.comb += self.cd_sys.rst.eq(por_counter != 0)
+        self.specials += AsyncResetSynchronizer(self.cd_por, self.reset)
+
+
+class Leds(Module, AutoCSR, AutoDoc):
+    """Signaloid C0-microSD LED control"""
+
+    def __init__(self, platform: signaloid_c0_microsd.Platform) -> None:
+        self.intro = ModuleDoc(
+            """Signaloid C0-microSD LED control.
+            Set the LED bit to 1 to turn it on and 0 to turn it off.
+            """
+        )
+
+        self._out = CSRStorage(
+            size=2,
+            fields=[
+                CSRField(
+                    name="red",
+                    description="""The Red LED on the Signaloid C0-microSD.
+                    On when 1, off when 0.""",
+                ),
+                CSRField(
+                    name="green",
+                    description="""The Green LED on the Signaloid C0-microSD.
+                    On when 1, off when 0.""",
+                ),
+            ],
+        )
+
+        # Drive the LEDs directly.
+        #
+        # Driving the LEDs directly from the FPGA is SAFE on
+        # the Signaloid C0-microSD, since the LEDs are hard-wired to external
+        # current limiting resistors.
+        # Hence, for simplicity, the SB_RGBA_DRV hard IP can be omitted.
+        #
+        # In general, direct drive can lead to overvoltage, and damage to the
+        # LEDs and/or the board. Lattice iCE40 mitigates this issue by
+        # incorporating the SB_RGBA_DRV hard IP on LEDs without external
+        # current limiting resistors.
+        #
+        # LED driver pins are in an open-drain configuration so they should
+        # be inverted to be intuitively controlled through software.
+        #
+        self.comb += platform.request("led_red").eq(~self._out.storage[0])
+        self.comb += platform.request("led_green").eq(~self._out.storage[1])
+
+
+class BaseSoC(SoCCore):
+    """Base SoC for Signaloid C0-microSD"""
+
+    # Statically define the memory map, to prevent it from shifting
+    # across various litex versions.
+    SoCCore.mem_map = {
+        "sram": 0x10000000,
+        "spiflash": 0x20000000,
+        "csr": 0xF0000000,
+        "vexriscv_debug": 0xF00F0000,
+    }
+
+    def __init__(
+        self,
+        platform: signaloid_c0_microsd.Platform,
+        sys_clk_cfg: str,
+        flash_offset: int,
+        add_uart: bool,
+        **kwargs
+    ) -> None:
+        """Extends the SoCCore class to create a BaseSoC with configuration
+        for the Signaloid C0-microSD.
+
+        :param sys_clk_cfg: The system clock frequency to use.
+        Possible values are defined on the _CRG.SYS_FREQ dict:
+        ["48MHz", "24MHz", "12MHz", "6MHz"]
+        :type sys_clk_cfg: str
+
+        :param flash_offset: The offset on the SPI Flash's address space where
+        the first byte of the firmware binary can be found.
+        :type flash_offset: int
+
+        :param add_uart: If set, creates a UART interface on the Signaloid
+        C0-microSD's platform serial pins.
+        :type add_uart: bool
+        """
+
+        self.platform = platform
+
+        # Set cpu name and variant defaults when none are provided
+        if "cpu_variant" not in kwargs:
+            kwargs["cpu_variant"] = "lite"
+
+        # Force the SRAM size to 0, because we add our own SRAM with SPRAM
+        kwargs["integrated_sram_size"] = 0
+        kwargs["integrated_rom_size"] = 0
+
+        kwargs["csr_data_width"] = 32
+
+        # Set CPU reset address
+        kwargs["cpu_reset_address"] = self.mem_map["spiflash"] + flash_offset
+
+        # If debug is enabled, add a serial port on the Signaloid C0-microSD's
+        # platform serial pins.
+        if add_uart:
+            kwargs["uart_name"] = "serial"
+
+        # SoCCore
+        SoCCore.__init__(
+            self,
+            platform=self.platform,
+            clk_freq=_CRG.SYS_FREQ[sys_clk_cfg]["sys_clk_freq"],
+            **kwargs
+        )
+
+        self.submodules.crg = _CRG(
+            sys_clk_cfg=sys_clk_cfg,
+            platform=self.platform
+        )
+
+        # iCE40-UP5K has a single port RAM, which is a dedicated 128kB block.
+        # Use this as CPU RAM.
+        spram_size = 128 * kB
+        self.submodules.spram = Up5kSPRAM(size=spram_size)
+        self.bus.add_slave(
+            name="sram",
+            slave=self.spram.bus,
+            region=SoCRegion(
+                origin=self.mem_map["sram"],
+                size=spram_size,
+                linker=True,
+            ),
+        )
+
+        # SPI Flash
+        # Signaloid C0-microSD uses the AT25QL128A SPI flash with the QPI mode
+        # disabled. Hence, the AT25SL128A module is used instead, which is
+        # compatible with Signaloid C0-microSD's AT25QL128A with the QPI mode
+        # disabled.
+        self.add_spi_flash(
+            mode="1x",
+            module=AT25SL128A(SpiNorFlashOpCodes.READ_1_1_1),
+            with_master=False,
+        )
+
+        # Add ROM linker region
+        self.bus.add_region(
+            name="rom",
+            region=SoCRegion(
+                origin=self.mem_map["spiflash"] + flash_offset,
+                size=8 * MB,
+                linker=True,
+            ),
+        )
+
+        # Peripherals
+        self.submodules.leds = Leds(self.platform)
+        self.add_csr("leds")
+
+
+class SignaloidC0MicroSDBuilder:
+    def __init__(self, platform: signaloid_c0_microsd.Platform) -> None:
+        self.platform = platform
+
+        self.parser = argparse.ArgumentParser(
+            description="LiteX SoC on Signaloid C0-microSD"
+        )
+
+        builder_args(self.parser)
+        soc_core_args(self.parser)
+
+        self.parser_target_group = self.parser.add_argument_group(
+            title="Target options"
+        )
+        self.parser_target_group.add_argument(
+            "--build", action="store_true", help="Build design."
+        )
+        self.parser_target_group.add_argument(
+            "--sys-clk-cfg",
+            default=list(_CRG.SYS_FREQ.keys())[0],
+            help="The system clock frequency to use. Possible values are:\n"
+            + ", ".join(_CRG.SYS_FREQ.keys()),
+        )
+        self.parser_target_group.add_argument(
+            "--flash-offset",
+            default=USER_DATA_OFFSET,
+            help="Boot offset in SPI Flash.",
+        )
+        self.parser_target_group.add_argument(
+            "--add-uart",
+            action="store_true",
+            help="Enable UART interface.",
+        )
+
+    @property
+    def args(self) -> argparse.Namespace:
+        return self.parser.parse_args()
+
+    @property
+    def builder_kwargs(self) -> dict:
+        return builder_argdict(self.args)
+
+    def get_base_soc(self) -> BaseSoC:
+        return BaseSoC(
+            platform=self.platform,
+            sys_clk_cfg=self.args.sys_clk_cfg,
+            flash_offset=int(self.args.flash_offset, 0),
+            add_uart=self.args.add_uart,
+            **soc_core_argdict(self.args)
+        )
+
+    def build(self, soc: BaseSoC) -> None:
+        # Create and run the builder
+        builder = Builder(soc, **self.builder_kwargs)
+        if self.args.build:
+            builder.build()
+
+        docs_builder.generate_docs(
+            soc,
+            "build/documentation/",
+            project_name="Signaloid C0-microSD LiteX RISC-V Example SoC",
+            author="Signaloid",
+        )
+
+
+def main() -> None:
+    builder = SignaloidC0MicroSDBuilder(
+        platform=signaloid_c0_microsd.Platform()
+    )
+
+    soc = builder.get_base_soc()
+
+    builder.build(soc)
+
+
+if __name__ == "__main__":
+    main()

--- a/litex_boards/targets/signaloid_c0_microsd.py
+++ b/litex_boards/targets/signaloid_c0_microsd.py
@@ -123,10 +123,15 @@ class BaseSoC(SoCCore):
 # Flash --------------------------------------------------------------------------------------------
 
 def flash(build_dir, build_name, bios_flash_offset):
-    from litex.build.lattice.programmer import IceStormProgrammer
-    prog = IceStormProgrammer()
-    prog.flash(bios_flash_offset, f"{build_dir}/software/bios/bios.bin")
-    prog.flash(0x00000000,        f"{build_dir}/gateware/{build_name}.bin")
+    print("\033[93m")
+    print("-------------------------------------------------------------------------------")
+    print("Programming is not supported for this platform.")
+    print("Please use the official Signaloid C0-microSD utilities for flashing the device.")
+    print("https://github.com/signaloid/C0-microSD-utilities")
+    print(f"Bitstream path: {build_dir}/gateware/{build_name}.bin")
+    print(f"Binary path   : {build_dir}/software/bios/bios.bin")
+    print("-------------------------------------------------------------------------------")
+    print("\033[0m")
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -152,8 +157,13 @@ def main():
         builder.build(**parser.toolchain_argdict)
 
     if args.load:
-        prog = soc.platform.create_programmer()
-        prog.load_bitstream(builder.get_bitstream_filename(mode="sram", ext=".bin")) # FIXME
+        print("\033[93m")
+        print("-------------------------------------------------------------------------------")
+        print("Loading is not supported for this platform.")
+        print("Please use the official Signaloid C0-microSD utilities for flashing the device.")
+        print("https://github.com/signaloid/C0-microSD-utilities")
+        print("-------------------------------------------------------------------------------")
+        print("\033[0m")
 
     if args.flash:
         flash(builder.output_dir, soc.build_name, args.bios_flash_offset)

--- a/litex_boards/targets/signaloid_c0_microsd.py
+++ b/litex_boards/targets/signaloid_c0_microsd.py
@@ -2,7 +2,7 @@
 
 #
 # This file is part of LiteX-Boards.
-# Copyright (c) 2024, Signaloid <a.vailakis@gmail.com>
+# Copyright (c) 2024, Signaloid <developer-support@signaloid.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *

--- a/litex_boards/targets/signaloid_c0_microsd.py
+++ b/litex_boards/targets/signaloid_c0_microsd.py
@@ -18,6 +18,8 @@ from litex.soc.integration.soc import SoCRegion
 from litex.soc.integration.builder import *
 from litex.soc.cores.led import LedChaser
 
+KILOBYTE = 1024
+
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(LiteXModule):


### PR DESCRIPTION
This PR adds support for the Signaloid C0-microSD FPGA SoM, which is based on the Lattice iCE40 chip.
For more details on the device please refer to:
- [Documentation Page](https://c0-microsd-docs.signaloid.io/)
- [GitHub home page](https://github.com/signaloid/C0-microSD-Hardware)