### PR TITLE
make Gowin boards work with Apicula

### DIFF
--- a/litex_boards/targets/sipeed_tang_nano.py
+++ b/litex_boards/targets/sipeed_tang_nano.py
@@ -62,8 +62,8 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCMini):
-    def __init__(self, sys_clk_freq=48e6, with_led_chaser=True, **kwargs):
-        platform = sipeed_tang_nano.Platform()
+    def __init__(self, toolchain="gowin", sys_clk_freq=48e6, with_led_chaser=True, **kwargs):
+        platform = sipeed_tang_nano.Platform(toolchain=toolchain)
 
         # CRG --------------------------------------------------------------------------------------
         self.crg = _CRG(platform, sys_clk_freq)
@@ -90,6 +90,7 @@ def main():
     args = parser.parse_args()
 
     soc = BaseSoC(
+        toolchain    = args.toolchain,
         sys_clk_freq = args.sys_clk_freq,
         **parser.soc_argdict
     )

--- a/litex_boards/targets/sipeed_tang_nano_20k.py
+++ b/litex_boards/targets/sipeed_tang_nano_20k.py
@@ -53,13 +53,13 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=48e6,
-        with_led_chaser     = True,
-        with_rgb_led        = False,
-        with_buttons        = True,
+    def __init__(self, toolchain="gowin", sys_clk_freq=48e6,
+        with_led_chaser = True,
+        with_rgb_led    = False,
+        with_buttons    = True,
         **kwargs):
 
-        platform = sipeed_tang_nano_20k.Platform(toolchain="gowin")
+        platform = sipeed_tang_nano_20k.Platform(toolchain=toolchain)
 
         # CRG --------------------------------------------------------------------------------------
         self.crg = _CRG(platform, sys_clk_freq)
@@ -131,7 +131,8 @@ def main():
     args = parser.parse_args()
 
     soc = BaseSoC(
-        sys_clk_freq        = args.sys_clk_freq,
+        toolchain    = args.toolchain,
+        sys_clk_freq = args.sys_clk_freq,
         **parser.soc_argdict
     )
     if args.with_spi_sdcard:

--- a/litex_boards/targets/sipeed_tang_nano_4k.py
+++ b/litex_boards/targets/sipeed_tang_nano_4k.py
@@ -59,12 +59,12 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=27e6,
+    def __init__(self, toolchain="gowin", sys_clk_freq=27e6,
         with_hyperram       = False,
         with_led_chaser     = True,
         with_video_terminal = True,
         **kwargs):
-        platform = sipeed_tang_nano_4k.Platform()
+        platform = sipeed_tang_nano_4k.Platform(toolchain=toolchain)
 
         # CRG --------------------------------------------------------------------------------------
         self.crg = _CRG(platform, sys_clk_freq, with_video_pll=with_video_terminal)
@@ -151,6 +151,7 @@ def main():
     args = parser.parse_args()
 
     soc = BaseSoC(
+        toolchain           = args.toolchain,
         sys_clk_freq        = args.sys_clk_freq,
         with_hyperram       = args.with_hyperram,
         with_video_terminal = args.with_video_terminal,

--- a/litex_boards/targets/sipeed_tang_nano_9k.py
+++ b/litex_boards/targets/sipeed_tang_nano_9k.py
@@ -59,11 +59,11 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=27e6, bios_flash_offset=0x0,
+    def __init__(self, toolchain="gowin", sys_clk_freq=27e6, bios_flash_offset=0x0,
         with_led_chaser     = True,
         with_video_terminal = False,
         **kwargs):
-        platform = sipeed_tang_nano_9k.Platform()
+        platform = sipeed_tang_nano_9k.Platform(toolchain=toolchain)
 
         # CRG --------------------------------------------------------------------------------------
         self.crg = _CRG(platform, sys_clk_freq, with_video_pll=with_video_terminal)
@@ -141,6 +141,7 @@ def main():
     args = parser.parse_args()
 
     soc = BaseSoC(
+        toolchain           = args.toolchain,
         sys_clk_freq        = args.sys_clk_freq,
         bios_flash_offset   = int(args.bios_flash_offset, 0),
         with_video_terminal = args.with_video_terminal,

--- a/litex_boards/targets/sipeed_tang_primer_20k.py
+++ b/litex_boards/targets/sipeed_tang_primer_20k.py
@@ -31,13 +31,14 @@ from litedram.phy import GW2DDRPHY
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(LiteXModule):
-    def __init__(self, platform, sys_clk_freq, with_video_pll=False):
+    def __init__(self, platform, sys_clk_freq, with_video_pll=False, with_dram=False):
         self.rst        = Signal()
         self.cd_sys     = ClockDomain()
         self.cd_por     = ClockDomain()
-        self.cd_init    = ClockDomain()
-        self.cd_sys2x   = ClockDomain()
-        self.cd_sys2x_i = ClockDomain()
+        if with_dram:
+            self.cd_init    = ClockDomain()
+            self.cd_sys2x   = ClockDomain()
+            self.cd_sys2x_i = ClockDomain()
 
         # # #
 
@@ -58,24 +59,29 @@ class _CRG(LiteXModule):
         self.pll = pll = GW2APLL(devicename=platform.devicename, device=platform.device)
         self.comb += pll.reset.eq(~por_done)
         pll.register_clkin(clk27, 27e6)
-        pll.create_clkout(self.cd_sys2x_i, 2*sys_clk_freq)
-        self.specials += [
-            Instance("DHCEN",
-                i_CLKIN  = self.cd_sys2x_i.clk,
-                i_CE     = self.stop,
-                o_CLKOUT = self.cd_sys2x.clk),
-            Instance("CLKDIV",
-                p_DIV_MODE = "2",
-                i_CALIB    = 0,
-                i_HCLKIN   = self.cd_sys2x.clk,
-                i_RESETN   = ~self.reset,
-                o_CLKOUT   = self.cd_sys.clk),
-            AsyncResetSynchronizer(self.cd_sys, ~pll.locked | self.rst | self.reset),
-        ]
+        if with_dram:
+            # 2:1 clock needed for DDR
+            pll.create_clkout(self.cd_sys2x_i, 2*sys_clk_freq)
+            self.specials += [
+                Instance("DHCEN",
+                    i_CLKIN  = self.cd_sys2x_i.clk,
+                    i_CE     = self.stop,
+                    o_CLKOUT = self.cd_sys2x.clk),
+                Instance("CLKDIV",
+                    p_DIV_MODE = "2",
+                    i_CALIB    = 0,
+                    i_HCLKIN   = self.cd_sys2x.clk,
+                    i_RESETN   = ~self.reset,
+                    o_CLKOUT   = self.cd_sys.clk),
+            ]
 
-        # Init clock domain
-        self.comb += self.cd_init.clk.eq(clk27)
-        self.comb += self.cd_init.rst.eq(pll.reset)
+            # Init clock domain
+            self.comb += self.cd_init.clk.eq(clk27)
+            self.comb += self.cd_init.rst.eq(pll.reset)
+        else:
+            pll.create_clkout(self.cd_sys, sys_clk_freq)
+        
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll.locked | self.rst | self.reset)
 
         # Video PLL
         if with_video_pll:
@@ -95,7 +101,7 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=48e6,
+    def __init__(self, toolchain="gowin", sys_clk_freq=48e6,
         with_spi_flash      = False,
         with_led_chaser     = True,
         with_rgb_led        = False,
@@ -110,19 +116,21 @@ class BaseSoC(SoCCore):
 
         assert dock in ["standard", "lite"]
 
-        platform = sipeed_tang_primer_20k.Platform(dock, toolchain="gowin")
+        platform = sipeed_tang_primer_20k.Platform(dock, toolchain=toolchain)
 
         if dock == "lite":
             with_led_chaser = False # No leds on core board nor on dock lite.
 
         # CRG --------------------------------------------------------------------------------------
-        self.crg = _CRG(platform, sys_clk_freq, with_video_pll=with_video_terminal)
+        with_dram = (kwargs.get("integrated_main_ram_size", 0) == 0)
+        assert not (toolchain == "apicula" and with_dram)
+        self.crg  = _CRG(platform, sys_clk_freq, with_video_pll=with_video_terminal, with_dram=with_dram)
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Tang Primer 20K", **kwargs)
 
         # DDR3 SDRAM -------------------------------------------------------------------------------
-        if not self.integrated_main_ram_size:
+        if with_dram:
             self.ddrphy = GW2DDRPHY(
                 pads         = platform.request("ddram"),
                 sys_clk_freq = sys_clk_freq
@@ -208,6 +216,7 @@ def main():
     args = parser.parse_args()
 
     soc = BaseSoC(
+        toolchain           = args.toolchain,
         sys_clk_freq        = args.sys_clk_freq,
         with_spi_flash      = args.with_spi_flash,
         with_video_terminal = args.with_video_terminal,

--- a/litex_boards/targets/sipeed_tang_primer_25k.py
+++ b/litex_boards/targets/sipeed_tang_primer_25k.py
@@ -71,7 +71,7 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=50e6,
+    def __init__(self, toolchain="gowin", sys_clk_freq=50e6,
         with_spi_flash      = False,
         with_led_chaser     = True,
         with_buttons        = True,
@@ -80,7 +80,7 @@ class BaseSoC(SoCCore):
         sdram_rate          = "1:2",
         **kwargs):
 
-        platform = sipeed_tang_primer_25k.Platform(toolchain="gowin")
+        platform = sipeed_tang_primer_25k.Platform(toolchain=toolchain)
 
         assert not with_sdram or (sdram_model in ["sipeed", "mister"])
 
@@ -147,6 +147,7 @@ def main():
     args = parser.parse_args()
 
     soc = BaseSoC(
+        toolchain      = args.toolchain,
         sys_clk_freq   = args.sys_clk_freq,
         with_spi_flash = args.with_spi_flash,
         with_sdram     = args.with_sdram,


### PR DESCRIPTION
Thanks to https://github.com/enjoy-digital/litex/pull/2036 by @Mai-Lapyst LiteX supports Apicula with the Himaechel target now, but it appears that the boards do not yet work correctly.

This is a WIP PR to try and fix those. I figured I'd put it out there to avoid duplicating work with Mai.

So far I've been mostly threading `toolchain`  through to the platform. Currently it fails to connect the RAM chips with their SERDES and SiP IO stuff. Some of that may be a more long-term project.

Depends on https://github.com/enjoy-digital/litex/pull/2042