### PR TITLE
efinix_trion_t120_bga576_dev_kit.py: fixed/rewire rx_ctl/tx_ctl (not compatible with DDIO mode), added message at build time

### DIFF
--- a/litex_boards/platforms/efinix_trion_t120_bga576_dev_kit.py
+++ b/litex_boards/platforms/efinix_trion_t120_bga576_dev_kit.py
@@ -66,9 +66,11 @@ _io = [
     ),
 
     ("eth", 0,
-        Subsignal("rx_ctl",  Pins("F24")),
+        #Subsignal("rx_ctl",  Pins("F24")), # Can't be used as DDIO
+        Subsignal("rx_ctl",  Pins("M22")),  # A wire must be soldered between R120 and R174
         Subsignal("rx_data", Pins("J20 K20 J19 H20")),
-        Subsignal("tx_ctl",  Pins("G24")),
+        #Subsignal("tx_ctl",  Pins("G24")), # Can't be used as DDIO
+        Subsignal("tx_ctl",  Pins("M21")),  # A wire must be soldered between ETH1_TXEN (Pad 30) and R173
         Subsignal("tx_data", Pins("L23 L22 K21 K19")),
         Subsignal("rst_n",   Pins("F21")),
         Subsignal("mdc",     Pins("G21")),

--- a/litex_boards/targets/efinix_trion_t120_bga576_dev_kit.py
+++ b/litex_boards/targets/efinix_trion_t120_bga576_dev_kit.py
@@ -7,6 +7,8 @@
 # Copyright (c) 2021 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+import time
+
 from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer
 
@@ -94,6 +96,13 @@ class BaseSoC(SoCCore):
         if with_ethernet or with_etherbone:
             # Use board's Ethernet PHYs.
             if not eth_rmii_pmod:
+                msg =  "\n"
+                msg += "rx_ctl/tx_ctl pads location aren't compatible with DDIO mode.\n"
+                msg += "An hardware modification must be done:\n"
+                msg += "- rx_ctl: a wire must be soldered between R120 and R174\n"
+                msg += "- tx_ctl: a wire must be soldered between ETH1_TXEN (Pad 30) and R173\n"
+                print(msg)
+                time.sleep(2)
                 self.ethphy = LiteEthPHYRGMII(
                     platform           = platform,
                     clock_pads         = platform.request("eth_clocks", eth_phy),


### PR DESCRIPTION
As mentioned in https://github.com/litex-hub/litex-boards/issues/394#issuecomment-1140483866 *tx_ctl* pin can't be used in DDIO mode. With recent (2024.1) efinity release, ifacewriter, also, complains about *rx_ctl* for the same reason.

This PR changes rx_ctl/tx_ctl pinout by using two, not to hard, to solder pins (available through resistors).
An message is added to warn user about this requirement.