### PR TITLE
targets/efinix_trion_t120_bga576_dev_kit.py: added argument to select between RMII PMOD (default) or onboard RGMII Phy

### DIFF
--- a/litex_boards/targets/efinix_trion_t120_bga576_dev_kit.py
+++ b/litex_boards/targets/efinix_trion_t120_bga576_dev_kit.py
@@ -53,7 +53,7 @@ class BaseSoC(SoCCore):
         with_ethernet   = False,
         with_etherbone  = False,
         eth_phy         = 0,
-        eth_rmii_pmod   = True,
+        eth_rgmii_phy   = False,
         eth_ip          = "192.168.1.50",
         remote_ip       = None,
         with_led_chaser = True,
@@ -95,7 +95,7 @@ class BaseSoC(SoCCore):
         # Ethernet / Etherbone ---------------------------------------------------------------------
         if with_ethernet or with_etherbone:
             # Use board's Ethernet PHYs.
-            if not eth_rmii_pmod:
+            if eth_rgmii_phy:
                 msg =  "\n"
                 msg += "rx_ctl/tx_ctl pads location aren't compatible with DDIO mode.\n"
                 msg += "An hardware modification must be done:\n"
@@ -377,11 +377,12 @@ def main():
     parser.add_target_argument("--sys-clk-freq",   default=75e6, type=float, help="System clock frequency.")
     parser.add_target_argument("--with-spi-flash", action="store_true",      help="Enable SPI Flash (MMAPed).")
     ethopts = parser.target_group.add_mutually_exclusive_group()
-    ethopts.add_argument("--with-ethernet",   action="store_true",     help="Enable Ethernet support.")
-    ethopts.add_argument("--with-etherbone",  action="store_true",     help="Enable Etherbone support.")
-    parser.add_target_argument("--eth-ip",    default="192.168.1.50",  help="Ethernet/Etherbone IP address.")
-    parser.add_target_argument("--remote-ip", default="192.168.1.100", help="Remote IP address of TFTP server.")
-    parser.add_target_argument("--eth-phy",   default=0, type=int,     help="Ethernet PHY: 0 (default) or 1.")
+    ethopts.add_argument("--with-ethernet",       action="store_true",     help="Enable Ethernet support.")
+    ethopts.add_argument("--with-etherbone",      action="store_true",     help="Enable Etherbone support.")
+    parser.add_target_argument("--eth-ip",        default="192.168.1.50",  help="Ethernet/Etherbone IP address.")
+    parser.add_target_argument("--remote-ip",     default="192.168.1.100", help="Remote IP address of TFTP server.")
+    parser.add_target_argument("--eth-rgmii-phy", action="store_true",     help="Uses onboard RGMII Phy instead of RMII PMOD.")
+    parser.add_target_argument("--eth-phy",       default=0, type=int,     help="Ethernet PHY: 0 (default) or 1. (Only available with --eth-rgmii-phy")
     args = parser.parse_args()
 
     soc = BaseSoC(
@@ -392,6 +393,7 @@ def main():
         eth_ip         = args.eth_ip,
         remote_ip      = args.remote_ip,
         eth_phy        = args.eth_phy,
+        eth_rgmii_phy  = args.eth_rgmii_phy,
         **parser.soc_argdict)
     builder = Builder(soc, **parser.builder_argdict)
     if args.build:


### PR DESCRIPTION
With commit https://github.com/litex-hub/litex-boards/commit/7f26f3940f78fb804fa3295ac79bec40e8e945f6 a workaround has been applied for efinix_trion_t120_bga576_dev_kit.py target board to use onboard RGMII 0.
Currently users must modify target to switch between PMOD RMII and onboard RGMII.

This PR adds an argument to let user select the phy without having to modify target file.