### PR TITLE
Add efinix Ti375 c529 dev kit support

### DIFF
--- a/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
@@ -63,7 +63,16 @@ _connectors = [
 
 def raw_pmod_io(pmod):
     return [(pmod, 0, Pins(" ".join([f"{pmod}:{i:d}" for i in range(8)])), IOStandard("3.3_V_LVTTL_/_LVCMOS"))]
-
+def jtag_pmod_io(pmod):
+    return [
+        ("usb_uart", 0,
+            Subsignal("tck", Pins(f"{pmod}:0")),
+            Subsignal("tdi", Pins(f"{pmod}:1")),
+            Subsignal("tdo", Pins(f"{pmod}:2")),
+            Subsignal("tms", Pins(f"{pmod}:3")),
+            IOStandard("3.3_V_LVCMOS")
+        ),
+    ]
 # Platform -----------------------------------------------------------------------------------------
 
 class Platform(EfinixPlatform):

--- a/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
@@ -28,6 +28,21 @@ _io = [
 
     # DRAM.
     ("dram_pll_refclk", 0, Pins("XXX"), IOStandard("3.3_V_LVTTL_/_LVCMOS")),
+
+    # SD-Card
+    ("spisdcard", 0,
+     Subsignal("clk", Pins("C9")),
+     Subsignal("mosi", Pins("C10"), Misc("WEAK_PULLUP")),
+     Subsignal("cs_n", Pins("A9"), Misc("WEAK_PULLUP")),
+     Subsignal("miso", Pins("B9"), Misc("WEAK_PULLUP")),
+     IOStandard("3.3_V_LVCMOS"),
+     ),
+    ("sdcard", 0,
+     Subsignal("data", Pins("B9 B10 A8 A9"), Misc("WEAK_PULLUP")),
+     Subsignal("cmd", Pins("C10"), Misc("WEAK_PULLUP")),
+     Subsignal("clk", Pins("C9")),
+     IOStandard("3.3_V_LVCMOS"),
+     ),
 ]
 
 

--- a/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
@@ -32,17 +32,27 @@ _io = [
     # SD-Card
     ("spisdcard", 0,
      Subsignal("clk", Pins("C9")),
-     Subsignal("mosi", Pins("C10"), Misc("WEAK_PULLUP")),
-     Subsignal("cs_n", Pins("A9"), Misc("WEAK_PULLUP")),
-     Subsignal("miso", Pins("B9"), Misc("WEAK_PULLUP")),
+     Subsignal("mosi", Pins("C10")),
+     Subsignal("cs_n", Pins("A9")),
+     Subsignal("miso", Pins("B9")),
      IOStandard("3.3_V_LVCMOS"),
      ),
     ("sdcard", 0,
-     Subsignal("data", Pins("B9 B10 A8 A9"), Misc("WEAK_PULLUP")),
-     Subsignal("cmd", Pins("C10"), Misc("WEAK_PULLUP")),
-     Subsignal("clk", Pins("C9")),
-     IOStandard("3.3_V_LVCMOS"),
+     Subsignal("data", Pins("B9 B10 A8 A9")),
+     Subsignal("cmd", Pins("C10")),
+     Subsignal("clk", Pins("C9")) , #, Misc("SLEWRATE=1"), Misc("DRIVE_STRENGTH=16")
+     IOStandard("3.3_V_LVTTL"),
      ),
+
+    # SD-Card through PMOD2
+    # ("sdcard", 0,
+    #  Subsignal("data", Pins("F13 F14 E11 E14"), Misc("WEAK_PULLUP")),
+    #  Subsignal("cmd", Pins("E16"), Misc("WEAK_PULLUP")),
+    #  Subsignal("clk", Pins("E15")),
+    #  IOStandard("3.3_V_LVCMOS"),
+    #  ),
+
+    ("fan_speed_control", 0, Pins("T19"), IOStandard("3.3_V_LVCMOS")),
 ]
 
 

--- a/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
@@ -72,6 +72,16 @@ _bank_info = [
 _connectors = [
     ("pmod0", "G15 G16 F16 F17 G17 A11 A13 A12"),
     ("pmod1", "B12 C14 C13 C12 D12 F12 D13 E13"),
+    ("pmod2", "E14 E16 F13 E15 F14 E11 F11 D11"),
+    ["p1",
+        "---", # 0
+     # 3V3      5V     GND GND                 GND GND                 GND GND         ↓
+     "--- B21 --- A21 --- --- C22 E21 B22 D21 --- --- B23 F21 A22 F22 --- --- D22 G21",
+     #  1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20 ↑
+     # 21  22  23  24  25  26  27  28  28  30  31  32  33  34  35  36  37  38  39  40 ↓
+     "D23 G22 --- --- F23 H20 E23 G20 --- --- H22 K23 H23 L23 --- --- L19 M21 M19 M22",
+     #        GND GND                 GND GND                 GND GND                 ↑
+    ],
 ]
 
 # PMODS --------------------------------------------------------------------------------------------
@@ -86,6 +96,25 @@ def jtag_pmod_io(pmod):
             Subsignal("tdo", Pins(f"{pmod}:2")),
             Subsignal("tms", Pins(f"{pmod}:3")),
             IOStandard("3.3_V_LVCMOS")
+        ),
+    ]
+def hdmi_px(px):
+    return [
+        ("hdmi_i2c", 0,
+            Subsignal("sda", Pins(f"{px}:26")),
+            Subsignal("scl", Pins(f"{px}:28")),
+            IOStandard("1.8_V_LVCMOS"), Misc("WEAK_PULLUP"), Misc("SCHMITT_TRIGGER")
+        ),
+        ("hdmi_data", 0,
+            Subsignal("clk", Pins(f"{px}:4")),
+            Subsignal("de", Pins(f"{px}:33")),
+            Subsignal("d", Pins(f"{px}:31 {px}:27 {px}:25 {px}:21 {px}:19 {px}:15 {px}:13 {px}:9 {px}:7 {px}:2 {px}:8 {px}:10 {px}:14 {px}:16 {px}:20 {px}:22")),
+            IOStandard("1.8_V_LVCMOS")
+        ),
+        ("hdmi_sync", 0,
+            Subsignal("hsync", Pins(f"{px}:37")),
+            Subsignal("vsync", Pins(f"{px}:39")),
+            IOStandard("1.8_V_LVCMOS")
         ),
     ]
 # Platform -----------------------------------------------------------------------------------------

--- a/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
@@ -13,8 +13,8 @@ from litex.build.efinix import EfinixProgrammer
 
 _io = [
     # Clk
-    ("clk25", 0, Pins("L17"), IOStandard("1.8_V_LVCMOS")),
-    ("clk100", 0, Pins("U4"), IOStandard("3.3_V_LVCMOS")),
+    ("clk25", None, Pins("L17"), IOStandard("1.8_V_LVCMOS")),
+    ("clk100", None, Pins("U4"), IOStandard("3.3_V_LVCMOS")),
 
     # Serial
     ("serial", 0,
@@ -25,6 +25,9 @@ _io = [
 
     # Buttons
     ("user_btn", 0, Pins("U19"), IOStandard("3.3_V_LVCMOS")),
+
+    # DRAM.
+    ("dram_pll_refclk", 0, Pins("XXX"), IOStandard("3.3_V_LVTTL_/_LVCMOS")),
 ]
 
 
@@ -64,8 +67,8 @@ def raw_pmod_io(pmod):
 # Platform -----------------------------------------------------------------------------------------
 
 class Platform(EfinixPlatform):
-    default_clk_name   = "clk25"
-    default_clk_period = 1e9/25e6
+    default_clk_name   = "clk100"
+    default_clk_period = 1e9/100e6
 
     def __init__(self, toolchain="efinity"):
         EfinixPlatform.__init__(self, "Ti375C529C4", _io, _connectors, iobank_info=_bank_info, toolchain=toolchain)
@@ -75,4 +78,4 @@ class Platform(EfinixPlatform):
 
     def do_finalize(self, fragment):
         EfinixPlatform.do_finalize(self, fragment)
-        self.add_period_constraint(self.lookup_request("clk25", loose=True), 1e9/25e6)
+        self.add_period_constraint(self.lookup_request("clk100", loose=True), 1e9/100e6)

--- a/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
@@ -1,0 +1,78 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2021 Franck Jullien <franck.jullien@collshade.fr>
+# Copyright (c) 2021 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.efinix.platform import EfinixPlatform
+from litex.build.efinix import EfinixProgrammer
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk
+    ("clk25", 0, Pins("L17"), IOStandard("1.8_V_LVCMOS")),
+    ("clk100", 0, Pins("U4"), IOStandard("3.3_V_LVCMOS")),
+
+    # Serial
+    ("serial", 0,
+     Subsignal("tx", Pins("E9")),
+     Subsignal("rx", Pins("E10")),
+     IOStandard("3.3_V_LVTTL"), Misc("WEAK_PULLUP")
+     ),
+
+    # Buttons
+    ("user_btn", 0, Pins("U19"), IOStandard("3.3_V_LVCMOS")),
+]
+
+
+
+# Bank voltage ---------------------------------------------------------------------------------------
+
+_bank_info = [
+            ("2A"      , "1.8 V LVCMOS"), # is_dyn_voltage="false" mode_sel_name="2A_MODE_SEL"/>
+            ("2B"      , "1.8 V LVCMOS"), # is_dyn_voltage="false" mode_sel_name="2B_MODE_SEL"/>
+            ("2C"      , "1.8 V LVCMOS"), # is_dyn_voltage="false" mode_sel_name="2C_MODE_SEL"/>
+            ("2D"      , "1.8 V LVCMOS"), # is_dyn_voltage="false" mode_sel_name="2D_MODE_SEL"/>
+            ("2E"      , "1.8 V LVCMOS"), # is_dyn_voltage="false" mode_sel_name="2E_MODE_SEL"/>
+            ("4A_4B"   , "1.8 V LVCMOS"), # is_dyn_voltage="false" mode_sel_name="4A_4B_MODE_SEL"/>
+            ("4C"      , "1.8 V LVCMOS"), # is_dyn_voltage="false" mode_sel_name="4C_MODE_SEL"/>
+            ("4D"      , "1.8 V LVCMOS"), # is_dyn_voltage="false" mode_sel_name="4D_MODE_SEL"/>
+            ("BL2_BL3" , "3.3 V LVCMOS"), # is_dyn_voltage="false">
+            ("BR0"     , "3.3 V LVCMOS"), # is_dyn_voltage="false" mode_sel_name="BR0_MODE_SEL"/>
+            ("BR3_BR4" , "3.3 V LVCMOS"), # is_dyn_voltage="false">
+            ("TL1_TL5" , "3.3 V LVCMOS"), # is_dyn_voltage="false">
+            ("TR0"     , "3.3 V LVCMOS"), # is_dyn_voltage="false" mode_sel_name="TR0_MODE_SEL"/>
+            ("TR1"     , "3.3 V LVCMOS"), # is_dyn_voltage="false" mode_sel_name="TR1_MODE_SEL"/>
+            ("TR2"     , "3.3 V LVCMOS"), # is_dyn_voltage="false" mode_sel_name="TR2_MODE_SEL"/>
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = [
+    ("pmod0", "G15 G16 F16 F17 G17 A11 A13 A12"),
+    ("pmod1", "B12 C14 C13 C12 D12 F12 D13 E13"),
+]
+
+# PMODS --------------------------------------------------------------------------------------------
+
+def raw_pmod_io(pmod):
+    return [(pmod, 0, Pins(" ".join([f"{pmod}:{i:d}" for i in range(8)])), IOStandard("3.3_V_LVTTL_/_LVCMOS"))]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(EfinixPlatform):
+    default_clk_name   = "clk25"
+    default_clk_period = 1e9/25e6
+
+    def __init__(self, toolchain="efinity"):
+        EfinixPlatform.__init__(self, "Ti375C529C4", _io, _connectors, iobank_info=_bank_info, toolchain=toolchain)
+
+    def create_programmer(self):
+        return EfinixProgrammer()
+
+    def do_finalize(self, fragment):
+        EfinixPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk25", loose=True), 1e9/25e6)

--- a/litex_boards/platforms/efinix_titanium_ti60_f225_dev_kit.py
+++ b/litex_boards/platforms/efinix_titanium_ti60_f225_dev_kit.py
@@ -23,7 +23,7 @@ _io = [
         Subsignal("mosi", Pins("C12"), Misc("WEAK_PULLUP")),
         Subsignal("cs_n", Pins("A12"), Misc("WEAK_PULLUP")),
         Subsignal("miso", Pins("B14"), Misc("WEAK_PULLUP")),
-        IOStandard("1.8_V_LVCMOS"),
+        IOStandard("3.3_V_LVCMOS"),
     ),
     ("sdcard", 0,
         Subsignal("data", Pins("B14 A14 D12 A12"), Misc("WEAK_PULLUP")),

--- a/litex_boards/targets/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/targets/efinix_ti375_c529_dev_kit.py
@@ -399,6 +399,7 @@ class BaseSoC(SoCCore):
                 Subsignal("r_id",       Pins(6)), #5:0] 
                 Subsignal("r_resp",     Pins(2)), #1:0] 
                 Subsignal("r_last",     Pins(1)), #
+                Subsignal("resetn",     Pins(1)),
             )]
 
             io   = platform.add_iface_ios(ios)
@@ -441,6 +442,7 @@ class BaseSoC(SoCCore):
                 axi_bus.r.id.eq(io.r_id),
                 axi_bus.r.resp.eq(io.r_resp),
                 axi_bus.r.last.eq(io.r_last),
+                io.resetn.eq(~self.crg.cd_sys.rst),
             ]
 
             if hasattr(self.cpu, "add_memory_buses"):

--- a/litex_boards/targets/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/targets/efinix_ti375_c529_dev_kit.py
@@ -32,17 +32,17 @@ class _CRG(LiteXModule):
 
         # # #
 
-        clk25 = platform.request("clk25")
+        clk100 = platform.request("clk100")
         rst_n = platform.request("user_btn", 0)
 
         # PLL
         self.pll = pll = TITANIUMPLL(platform)
         self.comb += pll.reset.eq(~rst_n)
-        pll.register_clkin(clk25, 25e6)
+        pll.register_clkin(clk100, 100e6)
         # You can use CLKOUT0 only for clocks with a maximum frequency of 4x
         # (integer) of the reference clock. If all your system clocks do not fall within
         # this range, you should dedicate one unused clock for CLKOUT0.
-        pll.create_clkout(None, 25e6)
+        pll.create_clkout(None, 100e6)
         pll.create_clkout(self.cd_sys, sys_clk_freq, with_reset=True)
 
 
@@ -60,30 +60,30 @@ class BaseSoC(SoCCore):
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Efinix Ti375 C529 Dev Kit", **kwargs)
 
         # LPDDR4 SDRAM -----------------------------------------------------------------------------
-        if not self.integrated_main_ram_size:
+        if None and not self.integrated_main_ram_size:
             # DRAM / PLL Blocks.
             # ------------------
             dram_pll_refclk = platform.request("dram_pll_refclk")
             platform.toolchain.excluded_ios.append(dram_pll_refclk)
-            self.platform.toolchain.additional_sdc_commands.append(f"create_clock -period {1e9/50e6} dram_pll_refclk")
+            self.platform.toolchain.additional_sdc_commands.append(f"create_clock -period {1e9/100e6} dram_pll_refclk")
 
             from litex.build.efinix import InterfaceWriterBlock, InterfaceWriterXMLBlock
             import xml.etree.ElementTree as et
 
-            class PLLDRAMBlock(InterfaceWriterBlock):
-                @staticmethod
-                def generate():
-                    return """
-design.create_block("dram_pll", block_type="PLL")
-design.set_property("dram_pll", {"REFCLK_FREQ":"50.0"}, block_type="PLL")
-design.gen_pll_ref_clock("dram_pll", pll_res="PLL_BR0", refclk_src="EXTERNAL", refclk_name="dram_pll_clkin", ext_refclk_no="0")
-design.set_property("dram_pll","LOCKED_PIN","dram_pll_locked", block_type="PLL")
-design.set_property("dram_pll","RSTN_PIN","dram_pll_rst_n", block_type="PLL")
-design.set_property("dram_pll", {"CLKOUT0_PIN" : "dram_pll_CLKOUT0"}, block_type="PLL")
-design.set_property("dram_pll","CLKOUT0_PHASE","0","PLL")
-calc_result = design.auto_calc_pll_clock("dram_pll", {"CLKOUT0_FREQ": "400.0"})
-"""
-            platform.toolchain.ifacewriter.blocks.append(PLLDRAMBlock())
+#             class PLLDRAMBlock(InterfaceWriterBlock):
+#                 @staticmethod
+#                 def generate():
+#                     return """
+# design.create_block("dram_pll", block_type="PLL")
+# design.set_property("dram_pll", {"REFCLK_FREQ":"100.0"}, block_type="PLL")
+# design.gen_pll_ref_clock("dram_pll", pll_res="PLL_BL0", refclk_src="EXTERNAL", refclk_name="dram_pll_clkin", ext_refclk_no="0")
+# design.set_property("dram_pll","LOCKED_PIN","dram_pll_locked", block_type="PLL")
+# design.set_property("dram_pll","RSTN_PIN","dram_pll_rst_n", block_type="PLL")
+# design.set_property("dram_pll", {"CLKOUT0_PIN" : "dram_pll_CLKOUT0"}, block_type="PLL")
+# design.set_property("dram_pll","CLKOUT0_PHASE","0","PLL")
+# calc_result = design.auto_calc_pll_clock("dram_pll", {"CLKOUT0_FREQ": "400.0"})
+# """
+#             platform.toolchain.ifacewriter.blocks.append(PLLDRAMBlock())
 
             class DRAMXMLBlock(InterfaceWriterXMLBlock):
                 @staticmethod
@@ -94,82 +94,84 @@ calc_result = design.auto_calc_pll_clock("dram_pll", {"CLKOUT0_FREQ": "400.0"})
                     ddr = et.SubElement(ddr_info, "efxpt:ddr",
                         name            = "ddr_inst1",
                         ddr_def         = "DDR_0",
-                        cs_preset_id    = "173",
-                        cs_mem_type     = "LPDDR3",
-                        cs_ctrl_width   = "x32",
-                        cs_dram_width   = "x32",
-                        cs_dram_density = "8G",
-                        cs_speedbin     = "800",
-                        target0_enable  = "true",
-                        target1_enable  = "true",
-                        ctrl_type       = "none"
+                                        clkin_sel="0",
+                                        data_width="32",
+                                        physical_rank="1",
+                                        mem_type="LPDDR4x",
+                                        mem_density="8G"
+                        # cs_preset_id    = "173",
+                        # cs_mem_type     = "LPDDR3",
+                        # cs_ctrl_width   = "x32",
+                        # cs_dram_width   = "x32",
+                        # cs_dram_density = "8G",
+                        # cs_speedbin     = "800",
+                        # target0_enable  = "true",
+                        # target1_enable  = "true",
+                        # ctrl_type       = "none"
                     )
 
-                    gen_pin_target0 = et.SubElement(ddr, "efxpt:gen_pin_target0")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wdata",  type_name=f"WDATA_0",  is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wready", type_name=f"WREADY_0", is_bus="false")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wid",    type_name=f"WID_0",    is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_bready", type_name=f"BREADY_0", is_bus="false")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_rdata",  type_name=f"RDATA_0",  is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_aid",    type_name=f"AID_0",    is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_bvalid", type_name=f"BVALID_0", is_bus="false")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_rlast",  type_name=f"RLAST_0",  is_bus="false")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_bid",    type_name=f"BID_0",    is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_asize",  type_name=f"ASIZE_0",  is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_atype",  type_name=f"ATYPE_0",  is_bus="false")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_aburst", type_name=f"ABURST_0", is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wvalid", type_name=f"WVALID_0", is_bus="false")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wlast",  type_name=f"WLAST_0",  is_bus="false")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_aaddr",  type_name=f"AADDR_0",  is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_rid",    type_name=f"RID_0",    is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_avalid", type_name=f"AVALID_0", is_bus="false")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_rvalid", type_name=f"RVALID_0", is_bus="false")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_alock",  type_name=f"ALOCK_0",  is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_rready", type_name=f"RREADY_0", is_bus="false")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_rresp",  type_name=f"RRESP_0",  is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wstrb",  type_name=f"WSTRB_0",  is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_aready", type_name=f"AREADY_0", is_bus="false")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_alen",   type_name=f"ALEN_0",   is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi_clk",     type_name=f"ACLK_0",   is_bus="false", is_clk="true", is_clk_invert="false")
+                    axi_target0 = et.SubElement(ddr, "efxpt:axi_target0",is_axi_width_256="false", is_axi_enable="true")
+                    gen_pin_target0 = et.SubElement(axi_target0, "efxpt:gen_pin_axi")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_clk",     type_name=f"ACLK_0",   is_bus="false", is_clk="true", is_clk_invert="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_ar_apcmd", type_name="ARAPCMD_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_ar_ready", type_name="ARREADY_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_ar_valid", type_name="ARVALID_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_ar_qos", type_name="ARQOS_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_aw_apcmd", type_name="AWAPCMD_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_aw_allstrb", type_name="AWALLSTRB_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_awcobuf", type_name="AWCOBUF_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_aw_ready", type_name="AWREADY_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_aw_valid", type_name="AWVALID_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_aw_lock", type_name="AWLOCK_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_aw_qos", type_name="AWQOS_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_b_ready", type_name="BREADY_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_b_valid", type_name="BVALID_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_r_last", type_name="RLAST_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_r_ready", type_name="RREADY_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_r_valid", type_name="RVALID_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_w_last", type_name="WLAST_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_w_ready", type_name="WREADY_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_w_valid", type_name="WVALID_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_ar_addr", type_name="ARADDR_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_ar_burst", type_name="ARBURST_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_ar_id", type_name="ARID_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_ar_len", type_name="ARLEN_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_ar_size", type_name="ARSIZE_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_ar_lock", type_name="ARLOCK_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_aw_addr", type_name="AWADDR_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_aw_burst", type_name="AWBURST_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_aw_id", type_name="AWID_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_aw_len", type_name="AWLEN_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_aw_size", type_name="AWSIZE_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_aw_cache", type_name="AWCACHE_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_b_id", type_name="BID_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_b_resp", type_name="BRESP_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_r_data", type_name="RDATA_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_r_id", type_name="RID_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_r_resp", type_name="RRESP_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_w_data", type_name="WDATA_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_w_strb", type_name="WSTRB_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="ddr0_resetn", type_name="ARSTN_0", is_bus="false")
 
-                    gen_pin_target1 = et.SubElement(ddr, "efxpt:gen_pin_target1")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wdata",  type_name=f"WDATA_1",  is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wready", type_name=f"WREADY_1", is_bus="false")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wid",    type_name=f"WID_1",    is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_bready", type_name=f"BREADY_1", is_bus="false")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_rdata",  type_name=f"RDATA_1",  is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_aid",    type_name=f"AID_1",    is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_bvalid", type_name=f"BVALID_1", is_bus="false")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_rlast",  type_name=f"RLAST_1",  is_bus="false")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_bid",    type_name=f"BID_1",    is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_asize",  type_name=f"ASIZE_1",  is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_atype",  type_name=f"ATYPE_1",  is_bus="false")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_aburst", type_name=f"ABURST_1", is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wvalid", type_name=f"WVALID_1", is_bus="false")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wlast",  type_name=f"WLAST_1",  is_bus="false")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_aaddr",  type_name=f"AADDR_1",  is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_rid",    type_name=f"RID_1",    is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_avalid", type_name=f"AVALID_1", is_bus="false")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_rvalid", type_name=f"RVALID_1", is_bus="false")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_alock",  type_name=f"ALOCK_1",  is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_rready", type_name=f"RREADY_1", is_bus="false")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_rresp",  type_name=f"RRESP_1",  is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wstrb",  type_name=f"WSTRB_1",  is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_aready", type_name=f"AREADY_1", is_bus="false")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_alen",   type_name=f"ALEN_1",   is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi_clk",     type_name=f"ACLK_1",   is_bus="false", is_clk="true", is_clk_invert="false")
+                    gen_pin_config = et.SubElement(ddr, "efxpt:gen_pin_controller")
+                    et.SubElement(gen_pin_config, name="", type_name="CTRL_CLK", is_bus="false", is_clk="true", is_clk_invert="false")
+                    et.SubElement(gen_pin_config, name="", type_name="CTRL_INT", is_bus="false")
+                    et.SubElement(gen_pin_config, name="", type_name="CTRL_MEM_RST_VALID", is_bus="false")
+                    et.SubElement(gen_pin_config, name="", type_name="CTRL_REFRESH", is_bus="false")
+                    et.SubElement(gen_pin_config, name="", type_name="CTRL_BUSY", is_bus="false")
+                    et.SubElement(gen_pin_config, name="", type_name="CTRL_CMD_Q_ALMOST_FULL", is_bus="false")
+                    et.SubElement(gen_pin_config, name="", type_name="CTRL_DP_IDLE", is_bus="false")
+                    et.SubElement(gen_pin_config, name="", type_name="CTRL_CKE", is_bus="true")
+                    et.SubElement(gen_pin_config, name="", type_name="CTRL_PORT_BUSY", is_bus="true")
 
-                    gen_pin_config = et.SubElement(ddr, "efxpt:gen_pin_config")
-                    et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="CFG_SEQ_RST",   is_bus="false")
-                    et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="CFG_SCL_IN",    is_bus="false")
-                    et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="CFG_SEQ_START", is_bus="false")
-                    et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="RSTN",          is_bus="false")
-                    et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="CFG_SDA_IN",    is_bus="false")
-                    et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="CFG_SDA_OEN",   is_bus="false")
+                    gen_pin_cfg_ctrl = et.SubElement(ddr, "efxpt:gen_pin_cfg_ctrl")
+                    et.SubElement(gen_pin_cfg_ctrl, name="cfg_done", type_name="CFG_DONE", is_bus="false")
+                    et.SubElement(gen_pin_cfg_ctrl, name="cfg_start", type_name="CFG_START", is_bus="false")
+                    et.SubElement(gen_pin_cfg_ctrl, name="cfg_reset", type_name="CFG_RESET", is_bus="false")
+                    et.SubElement(gen_pin_cfg_ctrl, name="cfg_sel", type_name="CFG_SEL", is_bus="false")
 
-                    cs_fpga = et.SubElement(ddr, "efxpt:cs_fpga")
-                    et.SubElement(cs_fpga, "efxpt:param", name="FPGA_ITERM", value="120", value_type="str")
-                    et.SubElement(cs_fpga, "efxpt:param", name="FPGA_OTERM", value="34",  value_type="str")
+                    ctrl_reg_inf = et.SubElement(ddr, "efxpt:ctrl_reg_inf")
+
 
                     cs_memory = et.SubElement(ddr, "efxpt:cs_memory")
                     et.SubElement(cs_memory, "efxpt:param", name="RTT_NOM",   value="RZQ/2",     value_type="str")

--- a/litex_boards/targets/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/targets/efinix_ti375_c529_dev_kit.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2021 Franck Jullien <franck.jullien@collshade.fr>
+# Copyright (c) 2021 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.gen import *
+
+from litex_boards.platforms import efinix_ti375_c529_dev_kit
+
+from litex.soc.cores.clock import *
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+from litex.soc.interconnect import axi
+
+from liteeth.phy.trionrgmii import LiteEthPHYRGMII
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq):
+        #self.rst    = Signal()
+        self.cd_sys = ClockDomain()
+
+        # # #
+
+        clk25 = platform.request("clk25")
+        rst_n = platform.request("user_btn", 0)
+
+        # PLL
+        self.pll = pll = TITANIUMPLL(platform)
+        self.comb += pll.reset.eq(~rst_n)
+        pll.register_clkin(clk25, 25e6)
+        # You can use CLKOUT0 only for clocks with a maximum frequency of 4x
+        # (integer) of the reference clock. If all your system clocks do not fall within
+        # this range, you should dedicate one unused clock for CLKOUT0.
+        pll.create_clkout(None, 25e6)
+        pll.create_clkout(self.cd_sys, sys_clk_freq, with_reset=True)
+
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=100e6,
+        **kwargs):
+        platform = efinix_ti375_c529_dev_kit.Platform()
+
+        # CRG --------------------------------------------------------------------------------------
+        self.crg = _CRG(platform, sys_clk_freq)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Efinix Ti375 C529 Dev Kit", **kwargs)
+
+        # LPDDR4 SDRAM -----------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            # DRAM / PLL Blocks.
+            # ------------------
+            dram_pll_refclk = platform.request("dram_pll_refclk")
+            platform.toolchain.excluded_ios.append(dram_pll_refclk)
+            self.platform.toolchain.additional_sdc_commands.append(f"create_clock -period {1e9/50e6} dram_pll_refclk")
+
+            from litex.build.efinix import InterfaceWriterBlock, InterfaceWriterXMLBlock
+            import xml.etree.ElementTree as et
+
+            class PLLDRAMBlock(InterfaceWriterBlock):
+                @staticmethod
+                def generate():
+                    return """
+design.create_block("dram_pll", block_type="PLL")
+design.set_property("dram_pll", {"REFCLK_FREQ":"50.0"}, block_type="PLL")
+design.gen_pll_ref_clock("dram_pll", pll_res="PLL_BR0", refclk_src="EXTERNAL", refclk_name="dram_pll_clkin", ext_refclk_no="0")
+design.set_property("dram_pll","LOCKED_PIN","dram_pll_locked", block_type="PLL")
+design.set_property("dram_pll","RSTN_PIN","dram_pll_rst_n", block_type="PLL")
+design.set_property("dram_pll", {"CLKOUT0_PIN" : "dram_pll_CLKOUT0"}, block_type="PLL")
+design.set_property("dram_pll","CLKOUT0_PHASE","0","PLL")
+calc_result = design.auto_calc_pll_clock("dram_pll", {"CLKOUT0_FREQ": "400.0"})
+"""
+            platform.toolchain.ifacewriter.blocks.append(PLLDRAMBlock())
+
+            class DRAMXMLBlock(InterfaceWriterXMLBlock):
+                @staticmethod
+                def generate(root, namespaces):
+                    # CHECKME: Switch to DDRDesignService?
+                    ddr_info = root.find("efxpt:ddr_info", namespaces)
+
+                    ddr = et.SubElement(ddr_info, "efxpt:ddr",
+                        name            = "ddr_inst1",
+                        ddr_def         = "DDR_0",
+                        cs_preset_id    = "173",
+                        cs_mem_type     = "LPDDR3",
+                        cs_ctrl_width   = "x32",
+                        cs_dram_width   = "x32",
+                        cs_dram_density = "8G",
+                        cs_speedbin     = "800",
+                        target0_enable  = "true",
+                        target1_enable  = "true",
+                        ctrl_type       = "none"
+                    )
+
+                    gen_pin_target0 = et.SubElement(ddr, "efxpt:gen_pin_target0")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wdata",  type_name=f"WDATA_0",  is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wready", type_name=f"WREADY_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wid",    type_name=f"WID_0",    is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_bready", type_name=f"BREADY_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_rdata",  type_name=f"RDATA_0",  is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_aid",    type_name=f"AID_0",    is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_bvalid", type_name=f"BVALID_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_rlast",  type_name=f"RLAST_0",  is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_bid",    type_name=f"BID_0",    is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_asize",  type_name=f"ASIZE_0",  is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_atype",  type_name=f"ATYPE_0",  is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_aburst", type_name=f"ABURST_0", is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wvalid", type_name=f"WVALID_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wlast",  type_name=f"WLAST_0",  is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_aaddr",  type_name=f"AADDR_0",  is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_rid",    type_name=f"RID_0",    is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_avalid", type_name=f"AVALID_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_rvalid", type_name=f"RVALID_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_alock",  type_name=f"ALOCK_0",  is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_rready", type_name=f"RREADY_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_rresp",  type_name=f"RRESP_0",  is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wstrb",  type_name=f"WSTRB_0",  is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_aready", type_name=f"AREADY_0", is_bus="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_alen",   type_name=f"ALEN_0",   is_bus="true")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi_clk",     type_name=f"ACLK_0",   is_bus="false", is_clk="true", is_clk_invert="false")
+
+                    gen_pin_target1 = et.SubElement(ddr, "efxpt:gen_pin_target1")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wdata",  type_name=f"WDATA_1",  is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wready", type_name=f"WREADY_1", is_bus="false")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wid",    type_name=f"WID_1",    is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_bready", type_name=f"BREADY_1", is_bus="false")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_rdata",  type_name=f"RDATA_1",  is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_aid",    type_name=f"AID_1",    is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_bvalid", type_name=f"BVALID_1", is_bus="false")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_rlast",  type_name=f"RLAST_1",  is_bus="false")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_bid",    type_name=f"BID_1",    is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_asize",  type_name=f"ASIZE_1",  is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_atype",  type_name=f"ATYPE_1",  is_bus="false")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_aburst", type_name=f"ABURST_1", is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wvalid", type_name=f"WVALID_1", is_bus="false")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wlast",  type_name=f"WLAST_1",  is_bus="false")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_aaddr",  type_name=f"AADDR_1",  is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_rid",    type_name=f"RID_1",    is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_avalid", type_name=f"AVALID_1", is_bus="false")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_rvalid", type_name=f"RVALID_1", is_bus="false")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_alock",  type_name=f"ALOCK_1",  is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_rready", type_name=f"RREADY_1", is_bus="false")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_rresp",  type_name=f"RRESP_1",  is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wstrb",  type_name=f"WSTRB_1",  is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_aready", type_name=f"AREADY_1", is_bus="false")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_alen",   type_name=f"ALEN_1",   is_bus="true")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi_clk",     type_name=f"ACLK_1",   is_bus="false", is_clk="true", is_clk_invert="false")
+
+                    gen_pin_config = et.SubElement(ddr, "efxpt:gen_pin_config")
+                    et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="CFG_SEQ_RST",   is_bus="false")
+                    et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="CFG_SCL_IN",    is_bus="false")
+                    et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="CFG_SEQ_START", is_bus="false")
+                    et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="RSTN",          is_bus="false")
+                    et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="CFG_SDA_IN",    is_bus="false")
+                    et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="CFG_SDA_OEN",   is_bus="false")
+
+                    cs_fpga = et.SubElement(ddr, "efxpt:cs_fpga")
+                    et.SubElement(cs_fpga, "efxpt:param", name="FPGA_ITERM", value="120", value_type="str")
+                    et.SubElement(cs_fpga, "efxpt:param", name="FPGA_OTERM", value="34",  value_type="str")
+
+                    cs_memory = et.SubElement(ddr, "efxpt:cs_memory")
+                    et.SubElement(cs_memory, "efxpt:param", name="RTT_NOM",   value="RZQ/2",     value_type="str")
+                    et.SubElement(cs_memory, "efxpt:param", name="MEM_OTERM", value="40",        value_type="str")
+                    et.SubElement(cs_memory, "efxpt:param", name="CL",        value="RL=6/WL=3", value_type="str")
+
+                    timing = et.SubElement(ddr, "efxpt:cs_memory_timing")
+                    et.SubElement(timing, "efxpt:param", name="tRAS",  value="42.000",  value_type="float")
+                    et.SubElement(timing, "efxpt:param", name="tRC",   value="60.000",  value_type="float")
+                    et.SubElement(timing, "efxpt:param", name="tRP",   value="18.000",  value_type="float")
+                    et.SubElement(timing, "efxpt:param", name="tRCD",  value="18.000",  value_type="float")
+                    et.SubElement(timing, "efxpt:param", name="tREFI", value="3.900",   value_type="float")
+                    et.SubElement(timing, "efxpt:param", name="tRFC",  value="210.000", value_type="float")
+                    et.SubElement(timing, "efxpt:param", name="tRTP",  value="10.000",  value_type="float")
+                    et.SubElement(timing, "efxpt:param", name="tWTR",  value="10.000",  value_type="float")
+                    et.SubElement(timing, "efxpt:param", name="tRRD",  value="10.000",  value_type="float")
+                    et.SubElement(timing, "efxpt:param", name="tFAW",  value="50.000",  value_type="float")
+
+                    cs_control = et.SubElement(ddr, "efxpt:cs_control")
+                    et.SubElement(cs_control, "efxpt:param", name="AMAP",             value="ROW-COL_HIGH-BANK-COL_LOW", value_type="str")
+                    et.SubElement(cs_control, "efxpt:param", name="EN_AUTO_PWR_DN",   value="Off",                       value_type="str")
+                    et.SubElement(cs_control, "efxpt:param", name="EN_AUTO_SELF_REF", value="No",                        value_type="str")
+
+                    cs_gate_delay = et.SubElement(ddr, "efxpt:cs_gate_delay")
+                    et.SubElement(cs_gate_delay, "efxpt:param", name="EN_DLY_OVR", value="No", value_type="str")
+                    et.SubElement(cs_gate_delay, "efxpt:param", name="GATE_C_DLY", value="3",  value_type="int")
+                    et.SubElement(cs_gate_delay, "efxpt:param", name="GATE_F_DLY", value="0",  value_type="int")
+
+            platform.toolchain.ifacewriter.xml_blocks.append(DRAMXMLBlock())
+
+            # DRAM Rst.
+            # ---------
+            dram_pll_rst_n = platform.add_iface_io("dram_pll_rst_n")
+            self.comb += dram_pll_rst_n.eq(platform.request("user_btn", 1))
+
+            # DRAM AXI-Ports.
+            # --------------
+            for n, data_width in {
+                0: 256, # target0: 256-bit.
+                1: 128, # target1: 128-bit
+            }.items():
+                axi_port = axi.AXIInterface(data_width=data_width, address_width=28, id_width=8) # 256MB.
+                ios = [(f"axi{n}", 0,
+                    Subsignal("wdata",   Pins(data_width)),
+                    Subsignal("wready",  Pins(1)),
+                    Subsignal("wid",     Pins(8)),
+                    Subsignal("bready",  Pins(1)),
+                    Subsignal("rdata",   Pins(data_width)),
+                    Subsignal("aid",     Pins(8)),
+                    Subsignal("bvalid",  Pins(1)),
+                    Subsignal("rlast",   Pins(1)),
+                    Subsignal("bid",     Pins(8)),
+                    Subsignal("asize",   Pins(3)),
+                    Subsignal("atype",   Pins(1)),
+                    Subsignal("aburst",  Pins(2)),
+                    Subsignal("wvalid",  Pins(1)),
+                    Subsignal("aaddr",   Pins(32)),
+                    Subsignal("rid",     Pins(8)),
+                    Subsignal("avalid",  Pins(1)),
+                    Subsignal("rvalid",  Pins(1)),
+                    Subsignal("alock",   Pins(2)),
+                    Subsignal("rready",  Pins(1)),
+                    Subsignal("rresp",   Pins(2)),
+                    Subsignal("wstrb",   Pins(data_width//8)),
+                    Subsignal("aready",  Pins(1)),
+                    Subsignal("alen",    Pins(8)),
+                    Subsignal("wlast",   Pins(1)),
+                )]
+                io   = platform.add_iface_ios(ios)
+                rw_n = axi_port.ar.valid
+                self.comb += [
+                    # Pseudo AW/AR Channels.
+                    io.atype.eq(~rw_n),
+                    io.aaddr.eq(  Mux(rw_n,   axi_port.ar.addr,  axi_port.aw.addr)),
+                    io.aid.eq(    Mux(rw_n,     axi_port.ar.id,    axi_port.aw.id)),
+                    io.alen.eq(   Mux(rw_n,    axi_port.ar.len,   axi_port.aw.len)),
+                    io.asize.eq(  Mux(rw_n,   axi_port.ar.size,  axi_port.aw.size)),
+                    io.aburst.eq( Mux(rw_n,  axi_port.ar.burst, axi_port.aw.burst)),
+                    io.alock.eq(  Mux(rw_n,   axi_port.ar.lock,  axi_port.aw.lock)),
+                    io.avalid.eq( Mux(rw_n,  axi_port.ar.valid, axi_port.aw.valid)),
+                    axi_port.aw.ready.eq(~rw_n & io.aready),
+                    axi_port.ar.ready.eq( rw_n & io.aready),
+
+                    # R Channel.
+                    axi_port.r.id.eq(io.rid),
+                    axi_port.r.data.eq(io.rdata),
+                    axi_port.r.last.eq(io.rlast),
+                    axi_port.r.resp.eq(io.rresp),
+                    axi_port.r.valid.eq(io.rvalid),
+                    io.rready.eq(axi_port.r.ready),
+
+                    # W Channel.
+                    io.wid.eq(axi_port.w.id),
+                    io.wstrb.eq(axi_port.w.strb),
+                    io.wdata.eq(axi_port.w.data),
+                    io.wlast.eq(axi_port.w.last),
+                    io.wvalid.eq(axi_port.w.valid),
+                    axi_port.w.ready.eq(io.wready),
+
+                    # B Channel.
+                    axi_port.b.id.eq(io.bid),
+                    axi_port.b.valid.eq(io.bvalid),
+                    io.bready.eq(axi_port.b.ready),
+                ]
+
+                # Connect AXI interface to the main bus of the SoC.
+                axi_lite_port = axi.AXILiteInterface(data_width=data_width, address_width=28)
+                self.submodules += axi.AXILite2AXI(axi_lite_port, axi_port)
+                self.bus.add_slave(f"target{n}", axi_lite_port, SoCRegion(origin=0x4000_0000 + 0x1000_0000*n, size=0x1000_0000)) # 256MB.
+
+            # Use DRAM's target0 port as Main Ram  -----------------------------------------------------
+            self.bus.add_region("main_ram", SoCRegion(
+                origin = 0x4000_0000,
+                size   = 0x1000_0000, # 256MB.
+                linker = True)
+            )
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=efinix_ti375_c529_dev_kit.Platform, description="LiteX SoC on Efinix Ti375 C529 Dev Kit.")
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        **parser.soc_argdict)
+    builder = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+    # if args.flash:
+    #     from litex.build.openfpgaloader import OpenFPGALoader
+    #     prog = OpenFPGALoader("titanium_ti375_c529")
+    #     prog.flash(0, builder.get_bitstream_filename(mode="flash", ext=".hex")) # FIXME
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Don't merge before : 
- https://github.com/enjoy-digital/litex/pull/2060
- https://github.com/enjoy-digital/litex/pull/2059

This is the port i'm using mostly to run VexiiRiscv + Debian.

Typicaly with : 
--cpu-type=vexiiriscv --cpu-variant=debian --update-repo=no --with-jtag-tap --with-sdcard --with-coherent-dma --with-ohci --vexii-video "name=video" --vexii-args="--fetch-l1-hardware-prefetch=nl --fetch-l1-refill-count=2 --fetch-l1-mem-data-width-min=128 --lsu-l1-mem-data-width-min=128 --lsu-software-prefetch --lsu-hardware-prefetch rpt --performance-counters 9 --lsu-l1-store-buffer-ops=32 --lsu-l1-refill-count 4 --lsu-l1-writeback-count 4 --lsu-l1-store-buffer-slots=4 --relaxed-div" --l2-bytes=524288 --sys-clk-freq 100000000 --cpu-clk-freq 200000000 --with-cpu-clk --bus-standard axi-lite --cpu-count=4 --build

It assums :
- debug jtag on PMOD0
- usb pmod on PMOD1
- Efinix HDMI extentions board  on PMOD2

Note that it is fast <3
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 562.2MiB/s
   Read speed: 732.0MiB/s