### PR TITLE
targets/efinix_trion_t120_bga576_dev_kit.py: fix clock name to match sys_clk real name

### DIFF
--- a/litex_boards/targets/efinix_trion_t120_bga576_dev_kit.py
+++ b/litex_boards/targets/efinix_trion_t120_bga576_dev_kit.py
@@ -186,6 +186,8 @@ calc_result = design.auto_calc_pll_clock("dram_pll", {"CLKOUT0_FREQ": "400.0"})
                         ctrl_type       = "none"
                     )
 
+                    ddr_clk_name = self.crg.cd_sys.clk.name_override # FIXME: can't know this information otherwise
+
                     gen_pin_target0 = et.SubElement(ddr, "efxpt:gen_pin_target0")
                     et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wdata",  type_name=f"WDATA_0",  is_bus="true")
                     et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wready", type_name=f"WREADY_0", is_bus="false")
@@ -211,7 +213,7 @@ calc_result = design.auto_calc_pll_clock("dram_pll", {"CLKOUT0_FREQ": "400.0"})
                     et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_wstrb",  type_name=f"WSTRB_0",  is_bus="true")
                     et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_aready", type_name=f"AREADY_0", is_bus="false")
                     et.SubElement(gen_pin_target0, "efxpt:pin", name="axi0_alen",   type_name=f"ALEN_0",   is_bus="true")
-                    et.SubElement(gen_pin_target0, "efxpt:pin", name="axi_clk",     type_name=f"ACLK_0",   is_bus="false", is_clk="true", is_clk_invert="false")
+                    et.SubElement(gen_pin_target0, "efxpt:pin", name=ddr_clk_name,  type_name=f"ACLK_0",   is_bus="false", is_clk="true", is_clk_invert="false")
 
                     gen_pin_target1 = et.SubElement(ddr, "efxpt:gen_pin_target1")
                     et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wdata",  type_name=f"WDATA_1",  is_bus="true")
@@ -238,7 +240,7 @@ calc_result = design.auto_calc_pll_clock("dram_pll", {"CLKOUT0_FREQ": "400.0"})
                     et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_wstrb",  type_name=f"WSTRB_1",  is_bus="true")
                     et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_aready", type_name=f"AREADY_1", is_bus="false")
                     et.SubElement(gen_pin_target1, "efxpt:pin", name="axi1_alen",   type_name=f"ALEN_1",   is_bus="true")
-                    et.SubElement(gen_pin_target1, "efxpt:pin", name="axi_clk",     type_name=f"ACLK_1",   is_bus="false", is_clk="true", is_clk_invert="false")
+                    et.SubElement(gen_pin_target1, "efxpt:pin", name=ddr_clk_name,  type_name=f"ACLK_1",   is_bus="false", is_clk="true", is_clk_invert="false")
 
                     gen_pin_config = et.SubElement(ddr, "efxpt:gen_pin_config")
                     et.SubElement(gen_pin_config, "efxpt:pin", name="", type_name="CFG_SEQ_RST",   is_bus="false")

--- a/litex_boards/targets/efinix_trion_t20_bga256_dev_kit.py
+++ b/litex_boards/targets/efinix_trion_t20_bga256_dev_kit.py
@@ -53,7 +53,7 @@ class _CRG(LiteXModule):
         self.comb += pll.reset.eq(~rst_n | self.rst_pulse)
         pll.register_clkin(clk50, 50e6)
         pll.create_clkout(self.cd_sys, sys_clk_freq, with_reset=True)
-        pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=180, name="sdram_clk")
+        pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=180)
 
 # BaseSoC ------------------------------------------------------------------------------------------
 
@@ -69,7 +69,7 @@ class BaseSoC(SoCCore):
 
         # SDR SDRAM --------------------------------------------------------------------------------
         if not self.integrated_main_ram_size and sys_clk_freq <= 50e6 :
-            self.specials += ClkOutput("sdram_clk", platform.request("sdram_clock"))
+            self.specials += ClkOutput(ClockSignal(self.cd_sys_ps), platform.request("sdram_clock"))
 
             self.sdrphy = GENSDRPHY(platform.request("sdram"), sys_clk_freq)
             self.add_sdram("sdram",


### PR DESCRIPTION
With [PR]( https://github.com/enjoy-digital/litex/pull/2060) create_clkout's name parameter is not more used when a cd is provided: DDRAM clock name must be obtained by using name_override attribute from sys_clk clk signal.