### PR TITLE
efinix: fix reset

### DIFF
--- a/litex_boards/platforms/efinix_t8f81_dev_kit.py
+++ b/litex_boards/platforms/efinix_t8f81_dev_kit.py
@@ -52,6 +52,7 @@ _connectors = [
 
 class Platform(EfinixPlatform):
     default_clk_name = "clk33"
+    default_clk_freq = 33.333e6
     default_clk_period = 1e9/33.333e6
 
     def __init__(self, toolchain="efinity"):

--- a/litex_boards/platforms/efinix_titanium_ti60_f225_dev_kit.py
+++ b/litex_boards/platforms/efinix_titanium_ti60_f225_dev_kit.py
@@ -183,6 +183,7 @@ def rgmii_ethernet_qse_ios(con, n=""):
 
 class Platform(EfinixPlatform):
     default_clk_name   = "clk25"
+    default_clk_freq   = 25e6
     default_clk_period = 1e9/50e6
 
     def __init__(self, toolchain="efinity"):

--- a/litex_boards/platforms/efinix_trion_t120_bga576_dev_kit.py
+++ b/litex_boards/platforms/efinix_trion_t120_bga576_dev_kit.py
@@ -174,6 +174,7 @@ def usb_pmod_io(pmod):
 
 class Platform(EfinixPlatform):
     default_clk_name   = "clk40"
+    default_clk_freq   = 40e6
     default_clk_period = 1e9/40e6
 
     def __init__(self, toolchain="efinity"):

--- a/litex_boards/platforms/efinix_trion_t20_bga256_dev_kit.py
+++ b/litex_boards/platforms/efinix_trion_t20_bga256_dev_kit.py
@@ -113,6 +113,7 @@ _connectors = [
 
 class Platform(EfinixPlatform):
     default_clk_name   = "clk50"
+    default_clk_freq   = 50e6
     default_clk_period = 1e9/50e6
 
     def __init__(self, toolchain="efinity"):

--- a/litex_boards/platforms/efinix_trion_t20_mipi_dev_kit.py
+++ b/litex_boards/platforms/efinix_trion_t20_mipi_dev_kit.py
@@ -64,6 +64,7 @@ _connectors = []
 
 class Platform(EfinixPlatform):
     default_clk_name   = "clk50"
+    default_clk_freq   = 50e6
     default_clk_period = 1e9/50e6
 
     def __init__(self, toolchain="efinity"):

--- a/litex_boards/platforms/efinix_xyloni_dev_kit.py
+++ b/litex_boards/platforms/efinix_xyloni_dev_kit.py
@@ -71,6 +71,7 @@ _connectors = [
 
 class Platform(EfinixPlatform):
     default_clk_name = "clk33"
+    default_clk_freq = 33.333e6
     default_clk_period = 1e9/33.333e6
 
     def __init__(self, toolchain="efinity"):

--- a/litex_boards/platforms/jungle_electronics_fireant.py
+++ b/litex_boards/platforms/jungle_electronics_fireant.py
@@ -49,6 +49,7 @@ _connectors = [
 
 class Platform(EfinixPlatform):
     default_clk_name   = "clk33"
+    default_clk_freq   = 33.33e6
     default_clk_period = 1e9/33.33e6
 
     def __init__(self, toolchain="efinity"):

--- a/litex_boards/targets/efinix_t8f81_dev_kit.py
+++ b/litex_boards/targets/efinix_t8f81_dev_kit.py
@@ -13,6 +13,7 @@ from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.gen import *
+from litex.gen.genlib.misc import WaitTimer
 
 from litex_boards.platforms import efinix_t8f81_dev_kit
 
@@ -28,16 +29,25 @@ class _CRG(LiteXModule):
     def __init__(self, platform, sys_clk_freq):
         self.rst    = Signal()
         self.cd_sys = ClockDomain()
+        self.cd_rst = ClockDomain(reset_less=True)
 
         # # #
 
         clk33 = platform.request("clk33")
         rst_n = platform.request("user_btn", 0)
 
+        self.comb += self.cd_rst.clk.eq(clk33)
+
+        # A pulse is necessary to do a reset.
+        self.rst_pulse = Signal()
+        self.reset_timer = reset_timer = ClockDomainsRenamer("rst")(WaitTimer(25e-6*platform.default_clk_freq))
+        self.comb += self.rst_pulse.eq(self.rst ^ reset_timer.done)
+        self.comb += reset_timer.wait.eq(self.rst)
+
         # PLL.
         self.pll = pll = TRIONPLL(platform)
-        self.comb += pll.reset.eq(~rst_n | self.rst)
-        pll.register_clkin(clk33, 33.333e6)
+        self.comb += pll.reset.eq(~rst_n | self.rst_pulse)
+        pll.register_clkin(clk33, platform.default_clk_freq)
         pll.create_clkout(self.cd_sys, sys_clk_freq, with_reset=True)
 
 # BaseSoC ------------------------------------------------------------------------------------------

--- a/litex_boards/targets/efinix_trion_t20_bga256_dev_kit.py
+++ b/litex_boards/targets/efinix_trion_t20_bga256_dev_kit.py
@@ -35,6 +35,7 @@ class _CRG(LiteXModule):
         self.rst       = Signal()
         self.cd_sys    = ClockDomain()
         self.cd_sys_ps = ClockDomain()
+        self.cd_rst    = ClockDomain(reset_less=True)
 
         # # #
 
@@ -42,16 +43,18 @@ class _CRG(LiteXModule):
         clk50 = platform.request("clk50")
         rst_n = platform.request("user_btn", 0)
 
+        self.comb += self.cd_rst.clk.eq(clk50)
+
         # A pulse is necessary to do a reset.
         self.rst_pulse = Signal()
-        reset_timer = WaitTimer(25e-6*sys_clk_freq)
+        self.reset_timer = reset_timer = ClockDomainsRenamer("rst")(WaitTimer(25e-6*platform.default_clk_freq))
         self.comb += self.rst_pulse.eq(self.rst ^ reset_timer.done)
         self.comb += reset_timer.wait.eq(self.rst)
 
         # PLL.
         self.pll = pll = TRIONPLL(platform)
         self.comb += pll.reset.eq(~rst_n | self.rst_pulse)
-        pll.register_clkin(clk50, 50e6)
+        pll.register_clkin(clk50, platform.default_clk_freq)
         pll.create_clkout(self.cd_sys, sys_clk_freq, with_reset=True)
         pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=180)
 

--- a/litex_boards/targets/efinix_trion_t20_bga256_dev_kit.py
+++ b/litex_boards/targets/efinix_trion_t20_bga256_dev_kit.py
@@ -69,7 +69,7 @@ class BaseSoC(SoCCore):
 
         # SDR SDRAM --------------------------------------------------------------------------------
         if not self.integrated_main_ram_size and sys_clk_freq <= 50e6 :
-            self.specials += ClkOutput(ClockSignal(self.cd_sys_ps), platform.request("sdram_clock"))
+            self.specials += ClkOutput(ClockSignal("sys_ps"), platform.request("sdram_clock"))
 
             self.sdrphy = GENSDRPHY(platform.request("sdram"), sys_clk_freq)
             self.add_sdram("sdram",

--- a/litex_boards/targets/efinix_trion_t20_mipi_dev_kit.py
+++ b/litex_boards/targets/efinix_trion_t20_mipi_dev_kit.py
@@ -10,6 +10,7 @@ from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.gen import *
+from litex.gen.genlib.misc import WaitTimer
 
 from litex_boards.platforms import efinix_trion_t20_mipi_dev_kit
 
@@ -26,16 +27,25 @@ class _CRG(LiteXModule):
     def __init__(self, platform, sys_clk_freq):
         self.rst    = Signal()
         self.cd_sys = ClockDomain()
+        self.cd_rst = ClockDomain(reset_less=True)
 
         # # #
 
         clk50 = platform.request("clk50")
         rst_n = platform.request("user_btn", 0)
 
+        self.comb += self.cd_rst.clk.eq(clk50)
+
+         # A pulse is necessary to do a reset.
+        self.rst_pulse = Signal()
+        self.reset_timer = reset_timer = ClockDomainsRenamer("rst")(WaitTimer(25e-6*platform.default_clk_freq))
+        self.comb += self.rst_pulse.eq(self.rst ^ reset_timer.done)
+        self.comb += reset_timer.wait.eq(self.rst)
+
         # PLL
         self.pll = pll = TRIONPLL(platform)
-        self.comb += pll.reset.eq(~rst_n | self.rst)
-        pll.register_clkin(clk50, 50e6)
+        self.comb += pll.reset.eq(~rst_n | self.rst_pulse)
+        pll.register_clkin(clk50, platform.default_clk_freq)
         pll.create_clkout(self.cd_sys, sys_clk_freq, with_reset=True)
 
 # BaseSoC ------------------------------------------------------------------------------------------

--- a/litex_boards/targets/efinix_xyloni_dev_kit.py
+++ b/litex_boards/targets/efinix_xyloni_dev_kit.py
@@ -12,6 +12,7 @@ from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.gen import *
+from litex.gen.genlib.misc import WaitTimer
 
 from litex_boards.platforms import efinix_xyloni_dev_kit
 
@@ -27,16 +28,25 @@ class _CRG(LiteXModule):
     def __init__(self, platform, sys_clk_freq):
         self.rst    = Signal()
         self.cd_sys = ClockDomain()
+        self.cd_rst = ClockDomain(reset_less=True)
 
         # # #
 
         clk33 = platform.request("clk33")
         rst_n = platform.request("user_btn", 0)
 
+        self.comb += self.cd_rst.clk.eq(clk33)
+
+        # A pulse is necessary to do a reset.
+        self.rst_pulse = Signal()
+        self.reset_timer = reset_timer = ClockDomainsRenamer("rst")(WaitTimer(25e-6*platform.default_clk_freq))
+        self.comb += self.rst_pulse.eq(self.rst ^ reset_timer.done)
+        self.comb += reset_timer.wait.eq(self.rst)
+
         # PLL.
         self.pll = pll = TRIONPLL(platform)
-        self.comb += pll.reset.eq(~rst_n | self.rst)
-        pll.register_clkin(clk33, 33.333e6)
+        self.comb += pll.reset.eq(~rst_n | self.rst_pulse)
+        pll.register_clkin(clk33, platform.default_clk_freq)
         pll.create_clkout(self.cd_sys, sys_clk_freq, with_reset=True)
 
 # BaseSoC ------------------------------------------------------------------------------------------


### PR DESCRIPTION
fix reset on all efinix boards.
To reset the PLL a pulse is needed, which
has to be driven by a clock that is
not generated by the PLL.