### PR TITLE
sipeed_tang_nano_20k: add SPI flash and HDMI support

### DIFF
--- a/litex_boards/platforms/sipeed_tang_nano_20k.py
+++ b/litex_boards/platforms/sipeed_tang_nano_20k.py
@@ -48,6 +48,23 @@ _io = [
         IOStandard("LVCMOS33"),
     ),
 
+    # HDMI
+    ("hdmi", 0,
+        Subsignal("clk_p",   Pins("33")),
+        Subsignal("clk_n",   Pins("34")),
+        Subsignal("data0_p", Pins("35")),
+        Subsignal("data0_n", Pins("36")),
+        Subsignal("data1_p", Pins("37")),
+        Subsignal("data1_n", Pins("38")),
+        Subsignal("data2_p", Pins("39")),
+        Subsignal("data2_n", Pins("40")),
+        Subsignal("hdp", Pins("26"), IOStandard("LVCMOS18")),
+        Subsignal("cec", Pins("25"), IOStandard("LVCMOS18")),
+        Subsignal("sda", Pins("53")),
+        Subsignal("scl", Pins("52")),
+        Misc("PULL_MODE=NONE"),
+    ),
+
     # Leds
     ("led_n", 0,  Pins("15"), IOStandard("LVCMOS33")),
     ("led_n", 1,  Pins("16"), IOStandard("LVCMOS33")),


### PR DESCRIPTION
- SPI flash support, using compatible IC
- HDMI support
- `--with-rgb-led` is fixed in <https://github.com/enjoy-digital/litex/pull/2142>

SPI flash log:

```text
Initializing w25q64 SPI Flash @0x00800000...
First SPI Flash block erased, unable to perform freq test.
Memspeed at 0x800000 (Sequential, 4.0KiB)...
   Read speed: 1.1MiB/s
Memspeed at 0x800000 (Random, 4.0KiB)...
   Read speed: 674.3KiB/s
```
