### PR TITLE
Add in colorlight v8.2 board support

### DIFF
--- a/litex_boards/platforms/colorlight_5a_75b.py
+++ b/litex_boards/platforms/colorlight_5a_75b.py
@@ -312,11 +312,11 @@ class Platform(LatticeECP5Platform):
     default_clk_period = 1e9/25e6
 
     def __init__(self, revision="7.0", toolchain="trellis"):
-        assert revision in ["6.1", "7.0", "8.0"]
+        assert revision in ["6.1", "7.0", "8.0", "8.2"]
         self.revision = revision
-        device     = {"6.1": "LFE5U-25F-6BG381C", "7.0": "LFE5U-25F-6BG256C", "8.0": "LFE5U-25F-6BG256C"}[revision]
-        io         = {"6.1": _io_v6_1,            "7.0": _io_v7_0,            "8.0": _io_v8_0}[revision]
-        connectors = {"6.1": _connectors_v6_1,    "7.0": _connectors_v7_0,    "8.0": _connectors_v8_0}[revision]
+        device     = {"6.1": "LFE5U-25F-6BG381C", "7.0": "LFE5U-25F-6BG256C", "8.0": "LFE5U-25F-6BG256C", "8.2": "LFE5U-25F-7BG256I"}[revision]
+        io         = {"6.1": _io_v6_1,            "7.0": _io_v7_0,            "8.0": _io_v8_0,            "8.2": _io_v8_0}[revision]
+        connectors = {"6.1": _connectors_v6_1,    "7.0": _connectors_v7_0,    "8.0": _connectors_v8_0,    "8.2": _connectors_v8_0}[revision]
         LatticeECP5Platform.__init__(self, device, io, connectors=connectors, toolchain=toolchain)
 
     def create_programmer(self):

--- a/litex_boards/targets/colorlight_5a_75x.py
+++ b/litex_boards/targets/colorlight_5a_75x.py
@@ -165,7 +165,7 @@ class BaseSoC(SoCCore):
         if not self.integrated_main_ram_size:
             sdrphy_cls = HalfRateGENSDRPHY if sdram_rate == "1:2" else GENSDRPHY
             self.sdrphy = sdrphy_cls(platform.request("sdram"), sys_clk_freq)
-            if board == "5a-75e" and revision == "6.0":
+            if (board == "5a-75e" and revision == "6.0") or (board == "5a-75b" and (revision == "8.0" or revision == "8.2")):
                 sdram_cls  = M12L64322A
             else:
                 sdram_cls  = M12L16161A
@@ -222,7 +222,7 @@ def main():
     from litex.build.parser import LiteXArgumentParser
     parser = LiteXArgumentParser(platform=colorlight_5a_75b.Platform, description="LiteX SoC on Colorlight 5A-75X.")
     parser.add_target_argument("--board",             default="5a-75b",         help="Board type (5a-75b, 5a-75e or i5a-907).")
-    parser.add_target_argument("--revision",          default="7.0",            help="Board revision (6.0, 6.1, 7.0 or 8.0).")
+    parser.add_target_argument("--revision",          default="7.0",            help="Board revision (6.0, 6.1, 7.0, 8.0, or 8.2).")
     parser.add_target_argument("--sys-clk-freq",      default=60e6, type=float, help="System clock frequency.")
     ethopts = parser.target_group.add_mutually_exclusive_group()
     ethopts.add_argument("--with-ethernet",           action="store_true",    help="Enable Ethernet support.")


### PR DESCRIPTION
Based on https://github.com/q3k/chubby75/blob/master/5a-75b/hardware_V8.2.md it appears that the pinout v8.0 is the same as the v8.2, the only difference is the FPGA - a Lattice ECP5 LFE5U-25F-7BG256I

The SDRAM for the 8.0 and 8.2 is the same, but the CLS was not being correctly set, this commit also corrects this.

Tested on a v8.2 board using https://github.com/enjoy-digital/colorlite

Fixes #574 