### PR TITLE
targets/litex_acorn_baseboard_mini.py: removed obsolete Platform override. Added parameter to select programmer tool

### DIFF
--- a/litex_boards/platforms/sqrl_acorn.py
+++ b/litex_boards/platforms/sqrl_acorn.py
@@ -217,7 +217,7 @@ class Platform(Xilinx7SeriesPlatform):
             "cle-215+": "xc7a200t"
         }[self.variant]
         if name == "openfpgaloader":
-            return OpenFPGALoader(cable=ftdi_chip, fpga_part="{device}fbg484", freq=10e6)
+            return OpenFPGALoader(cable=ftdi_chip, fpga_part=f"{device}fbg484", freq=10e6)
         elif name == "openocd":
             return OpenOCD(f"openocd_xc7_{ftdi_chip}.cfg", f"bscan_spi_{device}.bit")
 


### PR DESCRIPTION
The *litex_acorn_baseboard_mini* target provides a custom `Platform` inheriting from *platforms/sqrl_acorn.py* to re-implement the `create_programmer` method. But, unlike *sqrl_acorn* this variant only suppport CLE-215(+), CLE-101 is not supported.

This PR:
- removes the custom Platform to directly uses `sqrl_acorn/Platform`
- `sqrl_acorn.py` platform supports both `OpenOCD` and `OpenFPGALoader` as programmer tool. A new argument is added to allows user selecting the tool (`OpenOCD` is the default value to keep original behavior)