### PR TITLE
efinix_ti375_c529_dev_kit: add flash function

### DIFF
--- a/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
@@ -247,7 +247,7 @@ class Platform(EfinixPlatform):
         EfinixPlatform.__init__(self, "Ti375C529C4", _io, _connectors, iobank_info=_bank_info, toolchain=toolchain)
 
     def create_programmer(self):
-        return EfinixProgrammer()
+        return EfinixProgrammer(family=self.family)
 
     def do_finalize(self, fragment):
         EfinixPlatform.do_finalize(self, fragment)

--- a/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
@@ -69,6 +69,13 @@ _io = [
      
     # FAN.
     ("fan_speed_control", 0, Pins("T19"), IOStandard("3.3_V_LVCMOS")),
+
+    # Leds
+    ("user_led", 0, Pins("R20")),
+    ("user_led", 1, Pins("V4"), IOStandard("3.3_V_LVCMOS")),
+    ("user_led", 2, Pins("U6"), IOStandard("3.3_V_LVCMOS")),
+    ("user_led", 3, Pins("L18")),
+    ("user_led", 4, Pins("E19")),
 ]
 
     

--- a/litex_boards/targets/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/targets/efinix_ti375_c529_dev_kit.py
@@ -546,6 +546,7 @@ class BaseSoC(SoCCore):
 def main():
     from litex.build.parser import LiteXArgumentParser
     parser = LiteXArgumentParser(platform=efinix_ti375_c529_dev_kit.Platform, description="LiteX SoC on Efinix Ti375 C529 Dev Kit.")
+    parser.add_target_argument("--flash",         action="store_true",       help="Flash bitstream.")
     parser.add_target_argument("--sys-clk-freq",  default=100e6, type=float, help="System clock frequency.")
     parser.add_target_argument("--cpu-clk-freq",  default=100e6, type=float, help="System clock frequency.")
     parser.add_target_argument("--with-ohci",     action="store_true",       help="Enable USB OHCI.")
@@ -580,6 +581,10 @@ def main():
     if args.load:
         prog = soc.platform.create_programmer()
         prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+    if args.flash:
+        prog = soc.platform.create_programmer()
+        prog.flash(0, builder.get_bitstream_filename(mode="flash", ext=".hex"), device_id=0x006A0A79)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Platform Updates:
* Added definitions for five user LEDs to the `efinix_ti375_c529_dev_kit.py` platform file.

### Target Updates:
* Added a `--flash` argument to the `generate` method in the `efinix_ti375_c529_dev_kit.py` target file to support flashing the bitstream.