### PR TITLE
platforms/sqrl_acorn.py: fixed pcie_x4 rst_n IOStandard: BANK35 is 3.3V (conflict with LEDs)

### DIFF
--- a/litex_boards/platforms/sqrl_acorn.py
+++ b/litex_boards/platforms/sqrl_acorn.py
@@ -46,7 +46,7 @@ _io = [
     # PCIe.
     ("pcie_clkreq_n", 0, Pins("G1"), IOStandard("LVCMOS33")),
     ("pcie_x4", 0,
-        Subsignal("rst_n", Pins("J1"), IOStandard("LVCMOS15"), Misc("PULLUP=TRUE")),
+        Subsignal("rst_n", Pins("J1"), IOStandard("LVCMOS33"), Misc("PULLUP=TRUE")),
         Subsignal("clk_p", Pins("F6")),
         Subsignal("clk_n", Pins("E6")),
         Subsignal("rx_p",  Pins("B10 B8 D11 D9")),


### PR DESCRIPTION
Commit 1b22061e93b2add0132cfbcd10ca0e9977a163b2 has changed PCIe `rst_n` IOStandard: before 3.3V, now 1.5V.
But the BANK35 is 3.3V, LEDs are configured in 3.3V and Vivado fails due to a conflict between IOs.
This is true for `pcie_x4` but baseboard `pcie_x1` is correctly set to 3.3V

This PR changes `pcie_x4` definition to avoid build failure.