### PR TITLE
Initial support for Kintex-7 Base C board.

### DIFF
--- a/litex_boards/platforms/bochenjingxin_kintex7_basec.py
+++ b/litex_boards/platforms/bochenjingxin_kintex7_basec.py
@@ -1,0 +1,68 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Yuji Yamada <yamada@arch.cs.titech.ac.jp>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import Xilinx7SeriesPlatform
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("clk50",       0, Pins("G22"), IOStandard("LVCMOS33")),
+    ("cpu_reset",   0, Pins("D26"), IOStandard("LVCMOS33")),
+
+    # Leds
+    ("user_led", 0, Pins("A23"), IOStandard("LVCMOS33")),
+    ("user_led", 1, Pins("A24"), IOStandard("LVCMOS33")),
+    ("user_led", 2, Pins("D23"), IOStandard("LVCMOS33")),
+    ("user_led", 3, Pins("C24"), IOStandard("LVCMOS33")),
+    ("user_led", 4, Pins("C26"), IOStandard("LVCMOS33")),
+    ("user_led", 5, Pins("D24"), IOStandard("LVCMOS33")),
+    ("user_led", 6, Pins("D25"), IOStandard("LVCMOS33")),
+    ("user_led", 7, Pins("E25"), IOStandard("LVCMOS33")),
+
+    # Serial
+    ("serial", 0,
+        Subsignal("tx", Pins("C22")),
+        Subsignal("rx", Pins("B20")),
+        IOStandard("LVCMOS33"),
+    ),
+
+    # OLED
+    ("oled", 0,
+        Subsignal("scl", Pins("J24")),
+        Subsignal("sda", Pins("J25")),
+        Subsignal("dc", Pins("H22")),
+        Subsignal("rst", Pins("J21")),
+        IOStandard("LVCMOS33"),
+    ),
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = []
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(Xilinx7SeriesPlatform):
+    default_clk_name = "clk50"
+    default_clk_period = 1e9/50e6
+
+    def __init__(self, toolchain="vivado"):
+        device = "xc7k325tffg676-1" # FIXME: Should be xc7k325tffg676-2
+        Xilinx7SeriesPlatform.__init__(self, device, _io, _connectors, toolchain=toolchain)
+
+    def create_programmer(self):
+        return VivadoProgrammer() # Correct?
+
+    def do_finalize(self, fragment):
+        Xilinx7SeriesPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)
+        self.add_platform_command("set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.CONFIGRATE 50 [current_design]")
+        self.add_platform_command("set_property CONFIG_VOLTAGE 3.3 [current_design]")
+        self.add_platform_command("set_property CFGBVS VCCO [current_design]")
+        self.add_platform_command("set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]")

--- a/litex_boards/targets/bochenjingxin_kintex7_basec.py
+++ b/litex_boards/targets/bochenjingxin_kintex7_basec.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Yuji Yamada <yamada@arch.cs.titech.ac.jp>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+from litex.gen import *
+
+from litex_boards.platforms import bochenjingxin_kintex7_basec
+
+from litex.soc.cores.clock import *
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst       = Signal()
+        self.cd_sys    = ClockDomain()
+
+        # # #
+
+        # Clk/Rst.
+        clk50 = platform.request("clk50")
+        rst   = ~platform.request("cpu_reset")
+
+        # PLL.
+        self.pll  = pll = S7PLL(speedgrade=-1)
+        self.comb += pll.reset.eq(rst | self.rst)
+        pll.register_clkin(clk50, 50e6)
+        pll.create_clkout(self.cd_sys, sys_clk_freq)
+
+        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=125e6, toolchain="vivado",
+        with_led_chaser = True,
+        **kwargs):
+        platform = bochenjingxin_kintex7_basec.Platform(toolchain)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.crg = _CRG(platform, sys_clk_freq)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, clk_freq=sys_clk_freq, ident="LiteX SoC on Kintex-7 Base C", **kwargs)
+
+        # Leds --------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.led_chaser = LedChaser(
+                pads     = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=bochenjingxin_kintex7_basec.Platform, description="LiteX SoC on Kintex-7 Base C.")
+    parser.add_target_argument("--sys-clk-freq", default=125e6, type=float, help="System clock frequency.")
+
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq = args.sys_clk_freq,
+        toolchain    = args.toolchain,
+        **parser.soc_argdict
+    )
+    builder = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds an initial support for Kintex-7 Base C board, mentioned in #648.

Current status:
- I use openxc7 as the toolchain, because I don't have a paid Vivado license for xc7k325t.
- While the board has xc7k325tffg676-2, I use -1 speed grade to adapt openxc7's constraint.
- The SoC lacks several peripherals, such as DRAM, for now.

Thank you.