### PR TITLE
Add Support for HyVision

### DIFF
--- a/litex_boards/platforms/aliexpress_xc7k70t.py
+++ b/litex_boards/platforms/aliexpress_xc7k70t.py
@@ -225,8 +225,8 @@ class Platform(Xilinx7SeriesPlatform):
     default_clk_name   = "clk50"
     default_clk_period = 1e9/50e6
 
-    def __init__(self):
-        Xilinx7SeriesPlatform.__init__(self, "xc7k70t-fbg676-1", _io, _connectors, toolchain="vivado")
+    def __init__(self, toolchain="vivado"):
+        Xilinx7SeriesPlatform.__init__(self, "xc7k70t-fbg676-1", _io, _connectors, toolchain=toolchain)
         self.add_platform_command("""
 set_property CFGBVS VCCO [current_design]
 set_property CONFIG_VOLTAGE 3.3 [current_design]

--- a/litex_boards/platforms/hyvision_pcie_opt01_revf.py
+++ b/litex_boards/platforms/hyvision_pcie_opt01_revf.py
@@ -1,0 +1,211 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Hans Baier <foss@hans-baier.de>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import Xilinx7SeriesPlatform, VivadoProgrammer
+from litex.build.openocd import OpenOCD
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("clk50",  0, Pins("D24"), IOStandard("LVCMOS33")),
+    ("clk200", 0,
+        Subsignal("p", Pins("AA10"), IOStandard("DIFF_SSTL18_II")),
+        Subsignal("n", Pins("AB10"), IOStandard("DIFF_SSTL18_II")),
+    ),
+
+    # fitted LEDs, active high
+    ("user_led",  0, Pins("D26"), IOStandard("LVCMOS33")), # D5
+    ("user_led",  1, Pins("D25"), IOStandard("LVCMOS33")), # D3
+    ("user_led",  2, Pins("C26"), IOStandard("LVCMOS33")), # D6
+    ("user_led",  3, Pins("C21"), IOStandard("LVCMOS33")), # D4
+    ("user_led",  4, Pins("G25"), IOStandard("LVCMOS33")), # D8
+    ("user_led",  5, Pins("F25"), IOStandard("LVCMOS33")), # D7
+    ("user_led",  6, Pins("E26"), IOStandard("LVCMOS33")), # D10
+    ("user_led",  7, Pins("E25"), IOStandard("LVCMOS33")), # D9
+
+    # outside facing LEDs on face plate
+    ("user_led",   8, Pins("E15"), IOStandard("LVCMOS33")), # red 1
+    ("user_led",   9, Pins("E16"), IOStandard("LVCMOS33")), # green 1
+    ("user_led",  10, Pins("E17"), IOStandard("LVCMOS33")), # red 2
+    ("user_led",  11, Pins("E18"), IOStandard("LVCMOS33")), # green 2
+
+    # not fitted LEDs
+    ("user_led",  12, Pins("J26"), IOStandard("LVCMOS33")), # D12
+    ("user_led",  13, Pins("J25"), IOStandard("LVCMOS33")), # D14
+    ("user_led",  14, Pins("H26"), IOStandard("LVCMOS33")), # D13
+    ("user_led",  15, Pins("G26"), IOStandard("LVCMOS33")), # D15
+
+    # Switches
+    ("user_sw", 0, Pins("D19"), IOStandard("LVCMOS33")),
+    ("user_sw", 1, Pins("C19"), IOStandard("LVCMOS33")),
+
+    # Testpoints
+    ("tp", 1, Pins("A15"), IOStandard("LVCMOS33")),
+    ("tp", 2, Pins("C16"), IOStandard("LVCMOS33")),
+    ("tp", 3, Pins("B15"), IOStandard("LVCMOS33")),
+    ("tp", 4, Pins("D16"), IOStandard("LVCMOS33")),
+    ("tp", 5, Pins("B14"), IOStandard("LVCMOS33")),
+    ("tp", 6, Pins("A14"), IOStandard("LVCMOS33")),
+    ("tp", 7, Pins("C17"), IOStandard("LVCMOS33")),
+    ("tp", 8, Pins("D18"), IOStandard("LVCMOS33")),
+    ("tp", 9, Pins("C18"), IOStandard("LVCMOS33")),
+
+    # Not sure about this, but the documentation says 2X SPI
+    # and these pins are the standard configuration pins
+    ("spiflash2x", 0,  # clock needs to be accessed through STARTUPE2
+        Subsignal("cs_n", Pins("C23")),
+        Subsignal("dq",   Pins("B24 A25")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # DDR2 SDRAM.
+    ("ddram", 0,
+        Subsignal("cke",   Pins("AC12"),        IOStandard("SSTL18_II")),
+        Subsignal("ras_n", Pins("AA9"),         IOStandard("SSTL18_II")),
+        Subsignal("cas_n", Pins("AB9"),         IOStandard("SSTL18_II")),
+        Subsignal("we_n",  Pins("AC9"),         IOStandard("SSTL18_II")),
+        Subsignal("ba",    Pins("AD8 AB7 AC7"), IOStandard("SSTL18_II")),
+        Subsignal("a",     Pins("AC8 AA7 AA8 AF7 AE7 W8 V9 Y10 Y11 Y7 Y8 W9 W10"),
+            IOStandard("SSTL18_II")),
+        Subsignal("dq",    Pins(
+            " U5  U2  U1  V3  W3 U7 V6  V4  Y2  V2  V1  W1  Y1 AB2 AC2 AA3 ",
+            "AA4 AB4 AC4 AC3 AC6 Y6 Y5 AD6 AD1 AE1 AE3 AE2 AE6 AE5 AF3 AF2"),
+            IOStandard("SSTL18_II")),
+        Subsignal("dqs_p", Pins("W6 AB1 AA5 AF5"), IOStandard("DIFF_SSTL18_II")),
+        Subsignal("dqs_n", Pins("W5 AC1 AB5 AF4"), IOStandard("DIFF_SSTL18_II")),
+        Subsignal("clk_p", Pins("V11 V8"),         IOStandard("DIFF_SSTL18_II")),
+        Subsignal("clk_n", Pins("W11 V7"),         IOStandard("DIFF_SSTL18_II")),
+        Subsignal("dm",    Pins("U6 Y3 AB6 AD4"),  IOStandard("SSTL18_II")),
+        Subsignal("odt",   Pins("AA13 AA12"),      IOStandard("SSTL18_II")),
+        Subsignal("cs_n",  Pins("AD9 AB12"),       IOStandard("SSTL18_II")),
+        Misc("SLEW=FAST"),
+    ),
+
+    ("pcie_x1", 0,
+        Subsignal("rst_n", Pins("D10"), IOStandard("LVCMOS33")),
+        Subsignal("clk_p", Pins("D6")),
+        Subsignal("clk_n", Pins("D5")),
+        Subsignal("rx_p",  Pins("B6")),
+        Subsignal("rx_n",  Pins("B5")),
+        Subsignal("tx_p",  Pins("A4")),
+        Subsignal("tx_n",  Pins("A3"))
+    ),
+    ("pcie_x2", 0,
+        Subsignal("rst_n", Pins("D10"), IOStandard("LVCMOS33")),
+        Subsignal("clk_p", Pins("D6")),
+        Subsignal("clk_n", Pins("D5")),
+        Subsignal("rx_p",  Pins("B6 C4")),
+        Subsignal("rx_n",  Pins("B5 C3")),
+        Subsignal("tx_p",  Pins("A4 B2")),
+        Subsignal("tx_n",  Pins("A3 B1"))
+    ),
+    ("pcie_x4", 0,
+        Subsignal("rst_n", Pins("D10"), IOStandard("LVCMOS33")),
+        Subsignal("clk_p", Pins("D6")),
+        Subsignal("clk_n", Pins("D5")),
+        Subsignal("rx_p",  Pins("B6 C4 E4 G4")),
+        Subsignal("rx_n",  Pins("B5 C3 E3 G3")),
+        Subsignal("tx_p",  Pins("A4 B2 D2 F2")),
+        Subsignal("tx_n",  Pins("A3 B1 D1 F1"))
+    ),
+
+    # SFP
+    ("sfp", 0,  # SFP CN1
+        Subsignal("txp", Pins("H2")),
+        Subsignal("txn", Pins("H1")),
+        Subsignal("rxp", Pins("J4")),
+        Subsignal("rxn", Pins("J3")),
+        Subsignal("sda", Pins("A10"), IOStandard("LVCMOS33")),
+        Subsignal("scl", Pins("B10"), IOStandard("LVCMOS33")),
+    ),
+    ("sfp_tx", 0,  # SFP CN1
+        Subsignal("p", Pins("H2")),
+        Subsignal("n", Pins("H1")),
+    ),
+    ("sfp_rx", 0,  # SFP CN1
+        Subsignal("p", Pins("J4")),
+        Subsignal("n", Pins("J3")),
+    ),
+    ("sfp_tx_fault",   0, Pins("A9"),  IOStandard("LVCMOS33")),
+    ("sfp_tx_disable", 0, Pins("B9"),  IOStandard("LVCMOS33")),
+    ("sfp_mod_abs",    0, Pins("C9"),  IOStandard("LVCMOS33")),
+    ("sfp_rs0",        0, Pins("D9"),  IOStandard("LVCMOS33")),
+    ("sfp_los",        0, Pins("C11"), IOStandard("LVCMOS33")),
+    ("sfp_rs1",        0, Pins("D11"), IOStandard("LVCMOS33")),
+
+    ("sfp", 1,  # SFP CN2
+        Subsignal("txp", Pins("K2")),
+        Subsignal("txn", Pins("K1")),
+        Subsignal("rxp", Pins("L4")),
+        Subsignal("rxn", Pins("L3")),
+        Subsignal("sda", Pins("E13"), IOStandard("LVCMOS33")),
+        Subsignal("scl", Pins("D13"), IOStandard("LVCMOS33")),
+    ),
+    ("sfp_tx", 1,  # SFP CN2
+        Subsignal("p", Pins("K2")),
+        Subsignal("n", Pins("K1")),
+    ),
+    ("sfp_rx", 1,  # SFP CN2
+        Subsignal("p", Pins("L4")),
+        Subsignal("n", Pins("L3")),
+    ),
+    ("sfp_tx_fault",   1, Pins("C12"), IOStandard("LVCMOS33")),
+    ("sfp_tx_disable", 1, Pins("E12"), IOStandard("LVCMOS33")),
+    ("sfp_mod_abs",    1, Pins("C13"), IOStandard("LVCMOS33")),
+    ("sfp_rs0",        1, Pins("F14"), IOStandard("LVCMOS33")),
+    ("sfp_los",        1, Pins("C14"), IOStandard("LVCMOS33")),
+    ("sfp_rs1",        1, Pins("D14"), IOStandard("LVCMOS33")),
+
+    # DVP
+    ("dvp", 0,
+        Subsignal("r",    Pins("H22 G22 F22 E21 D21 N19 P20 P21")),
+        Subsignal("g",    Pins("M19 C24 C22 N21 M21 L22 K22 J21")),
+        Subsignal("b",    Pins("J23 H24 L23 K23 G24 F24 F23 E23")),
+        Subsignal("cc_d", Pins("R22 T22 R21 T20")),
+        Subsignal("lval", Pins("U20")),
+        Subsignal("fval", Pins("T18")),
+        Subsignal("dval", Pins("M20")),
+        Subsignal("pclk", Pins("D23")),
+        Subsignal("dtx",  Pins("T19")),
+        Subsignal("drx",  Pins("U19")),
+        Subsignal("drx",  Pins("U19")),
+        IOStandard("LVCMOS33")
+    ),
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = [
+    ( "J9", {
+        1:  "L24",  2: "M22",
+        3:  "M24",  4: "N24",
+        5:  "N22",  6: "P23",
+        7:  "P24",  8: "R23",
+        9:  "T23", 10: "T24",
+        11: "K25", 12: "K26",
+        13: "M25", 14: "M26",
+        15: "N26", 16: "P26",
+        17: "N26", 18: "P26",
+    })
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(Xilinx7SeriesPlatform):
+    default_clk_name   = "clk200"
+    default_clk_period = 1e9/200e6
+
+    def __init__(self, toolchain="vivado"):
+        Xilinx7SeriesPlatform.__init__(self, "xc7k70t-fbg676-1", _io, toolchain=toolchain)
+
+    def create_programmer(self):
+        return OpenOCD("openocd_xc7_ft2232.cfg", "bscan_spi_xc7a70t.bit")
+
+    def do_finalize(self, fragment):
+        Xilinx7SeriesPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk200", loose=True), 1e9/200e6)

--- a/litex_boards/targets/hyvision_pcie_opt01_revf.py
+++ b/litex_boards/targets/hyvision_pcie_opt01_revf.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Hans Baier <foss@hans-baier.de>
+# SPDX-License-Identifier: BSD-2-Clause
+# Since this board has no uart, you want to build with JTAG UART:
+# python litex_boards/targets/hyvision_pcie_opt01_revf.py --build --uart-name=jtag_uart
+
+from migen import *
+
+from litex.gen import *
+
+from litex_boards.platforms import hyvision_pcie_opt01_revf
+
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+
+from litex.soc.cores.clock import *
+from litex.soc.cores.led import LedChaser
+
+from litedram.modules import K4T1G164QGBCE7
+from litedram.phy import s7ddrphy
+
+from litepcie.phy.s7pciephy import S7PCIEPHY
+from litepcie.software import generate_litepcie_software
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst          = Signal()
+        self.cd_sys       = ClockDomain()
+        self.cd_sys2x     = ClockDomain()
+        self.cd_sys2x_dqs = ClockDomain()
+        self.cd_idelay    = ClockDomain()
+
+        # Clk / Rst.
+        clk200 = platform.request("clk200")
+
+        # PLL.
+        self.pll = pll = S7MMCM(speedgrade=-1)
+        pll.register_clkin(clk200, 200e6)
+        pll.create_clkout(self.cd_sys,       sys_clk_freq)
+        pll.create_clkout(self.cd_sys2x,     2*sys_clk_freq)
+        pll.create_clkout(self.cd_sys2x_dqs, 2*sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_idelay,    200e6)
+        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
+
+        self.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=100e6,
+        with_led_chaser = True,
+        with_pcie       = False,
+        **kwargs):
+        platform = hyvision_pcie_opt01_revf.Platform()
+
+        # CRG --------------------------------------------------------------------------------------
+        self.crg = _CRG(platform, sys_clk_freq)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on HVS HyVision PCIe OPT01 revf", **kwargs)
+
+        # PCIe -------------------------------------------------------------------------------------
+        if with_pcie:
+            self.pcie_phy = S7PCIEPHY(platform, platform.request("pcie_x4"),
+                data_width = 128,
+                bar0_size  = 0x20000)
+            self.add_pcie(phy=self.pcie_phy, ndmas=1)
+
+        # DDR2 SDRAM -------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.ddrphy = s7ddrphy.K7DDRPHY(platform.request("ddram"),
+                memtype      = "DDR2",
+                nphases      = 2,
+                sys_clk_freq = sys_clk_freq)
+            self.add_sdram("sdram",
+                phy           = self.ddrphy,
+                module        = K4T1G164QGBCE7(sys_clk_freq, "1:2"),
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+
+# Build --------------------------------------------------------------------------------------------
+def main():
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=hyvision_pcie_opt01_revf.Platform, description="LiteX SoC on HyVision PCIe OPT01 refv.")
+    parser.add_target_argument("--sys-clk-freq", default=100e6, type=float, help="System clock frequency.")
+    parser.add_target_argument("--with-pcie",    action="store_true",       help="Enable PCIe support.")
+    parser.add_target_argument("--driver",       action="store_true",       help="Generate PCIe driver.")
+    parser.set_defaults(uart_name="jtag_uart")
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq = args.sys_clk_freq,
+        with_pcie    = args.with_pcie,
+        **parser.soc_argdict
+    )
+    builder = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+    if args.driver:
+        generate_litepcie_software(soc, os.path.join(builder.output_dir, "driver"))
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add support for these Kintex7 boards, which are cheaply available
on ebay:
https://www.ebay.com/sch/i.html?_nkw=hyvision+pcie

Question: When I try to build it, I get an obscure error when building the DDR software driver. Is that a litedram problem,
or did I get something wrong here?
```
INFO:S7MMCM:Creating S7MMCM, speedgrade -1.
INFO:S7MMCM:Registering Differential ClkIn of 200.00MHz.
INFO:S7MMCM:Creating ClkOut0 sys of 100.00MHz (+-10000.00ppm).
INFO:S7MMCM:Creating ClkOut1 sys2x of 200.00MHz (+-10000.00ppm).
INFO:S7MMCM:Creating ClkOut2 sys2x_dqs of 200.00MHz (+-10000.00ppm).
INFO:S7MMCM:Creating ClkOut3 idelay of 200.00MHz (+-10000.00ppm).
INFO:SoC:        __   _ __      _  __  
INFO:SoC:       / /  (_) /____ | |/_/  
INFO:SoC:      / /__/ / __/ -_)>  <    
INFO:SoC:     /____/_/\__/\__/_/|_|  
INFO:SoC:  Build your hardware, easily!
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:Creating SoC... (2025-04-11 04:05:10)
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:FPGA device : xc7k70t-fbg676-1.
INFO:SoC:System clock: 100.000MHz.
INFO:SoCBusHandler:Creating Bus Handler...
INFO:SoCBusHandler:32-bit wishbone Bus, 4.0GiB Address Space.
INFO:SoCBusHandler:Adding reserved Bus Regions...
INFO:SoCBusHandler:Bus Handler created.
INFO:SoCCSRHandler:Creating CSR Handler...
INFO:SoCCSRHandler:32-bit CSR Bus, 32-bit Aligned, 16.0KiB Address Space, 2048B Paging, big Ordering (Up to 32 Locations).
INFO:SoCCSRHandler:Adding reserved CSRs...
INFO:SoCCSRHandler:CSR Handler created.
INFO:SoCIRQHandler:Creating IRQ Handler...
INFO:SoCIRQHandler:IRQ Handler (up to 32 Locations).
INFO:SoCIRQHandler:Adding reserved IRQs...
INFO:SoCIRQHandler:IRQ Handler created.
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:Initial SoC:
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:32-bit wishbone Bus, 4.0GiB Address Space.
INFO:SoC:32-bit CSR Bus, 32-bit Aligned, 16.0KiB Address Space, 2048B Paging, big Ordering (Up to 32 Locations).
INFO:SoC:IRQ Handler (up to 32 Locations).
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:Controller ctrl added.
INFO:SoC:CPU vexriscv added.
INFO:SoC:CPU vexriscv adding IO Region 0 at 0x80000000 (Size: 0x80000000).
INFO:SoCBusHandler:io0 Region added at Origin: 0x80000000, Size: 0x80000000, Mode:  RW, Cached: False, Linker: False.
INFO:SoC:CPU vexriscv overriding sram mapping from 0x01000000 to 0x10000000.
INFO:SoC:CPU vexriscv setting reset address to 0x00000000.
INFO:SoC:CPU vexriscv adding Bus Master(s).
INFO:SoCBusHandler:cpu_bus0 added as Bus Master.
INFO:SoCBusHandler:cpu_bus1 added as Bus Master.
INFO:SoC:CPU vexriscv adding Interrupt(s).
INFO:SoC:CPU vexriscv adding SoC components.
INFO:SoCBusHandler:rom Region added at Origin: 0x00000000, Size: 0x00020000, Mode:  RX, Cached:  True, Linker: False.
INFO:SoCBusHandler:rom added as Bus Slave.
INFO:SoC:RAM rom added Origin: 0x00000000, Size: 0x00020000, Mode:  RX, Cached:  True, Linker: False.
INFO:SoCBusHandler:sram Region added at Origin: 0x10000000, Size: 0x00002000, Mode: RWX, Cached:  True, Linker: False.
INFO:SoCBusHandler:sram added as Bus Slave.
INFO:SoC:RAM sram added Origin: 0x10000000, Size: 0x00002000, Mode: RWX, Cached:  True, Linker: False.
INFO:SoCIRQHandler:uart IRQ allocated at Location 0.
INFO:SoCIRQHandler:timer0 IRQ allocated at Location 1.
INFO:SoCBusHandler:main_ram Region added at Origin: 0x40000000, Size: 0x20000000, Mode: RWX, Cached:  True, Linker: False.
INFO:SoCBusHandler:main_ram added as Bus Slave.
INFO:SoC:CSR Bridge csr added.
INFO:SoCBusHandler:csr Region added at Origin: 0xf0000000, Size: 0x00010000, Mode:  RW, Cached: False, Linker: False.
INFO:SoCBusHandler:csr added as Bus Slave.
INFO:SoCCSRHandler:csr added as CSR Master.
INFO:SoCBusHandler:Interconnect: InterconnectShared (2 <-> 4).
INFO:SoCCSRHandler:ctrl CSR allocated at Location 0.
INFO:SoCCSRHandler:ddrphy CSR allocated at Location 1.
INFO:SoCCSRHandler:identifier_mem CSR allocated at Location 2.
INFO:SoCCSRHandler:leds CSR allocated at Location 3.
INFO:SoCCSRHandler:sdram CSR allocated at Location 4.
INFO:SoCCSRHandler:timer0 CSR allocated at Location 5.
INFO:SoCCSRHandler:uart CSR allocated at Location 6.
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:Finalized SoC:
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:32-bit wishbone Bus, 4.0GiB Address Space.
IO Regions: (1)
io0                 : Origin: 0x80000000, Size: 0x80000000, Mode:  RW, Cached: False, Linker: False
Bus Regions: (4)
rom                 : Origin: 0x00000000, Size: 0x00020000, Mode:  RX, Cached:  True, Linker: False
sram                : Origin: 0x10000000, Size: 0x00002000, Mode: RWX, Cached:  True, Linker: False
main_ram            : Origin: 0x40000000, Size: 0x20000000, Mode: RWX, Cached:  True, Linker: False
csr                 : Origin: 0xf0000000, Size: 0x00010000, Mode:  RW, Cached: False, Linker: False
Bus Masters: (2)
- cpu_bus0
- cpu_bus1
Bus Slaves: (4)
- rom
- sram
- main_ram
- csr
INFO:SoC:32-bit CSR Bus, 32-bit Aligned, 16.0KiB Address Space, 2048B Paging, big Ordering (Up to 32 Locations).
CSR Locations: (7)
- ctrl           : 0
- ddrphy         : 1
- identifier_mem : 2
- leds           : 3
- sdram          : 4
- timer0         : 5
- uart           : 6
INFO:SoC:IRQ Handler (up to 32 Locations).
IRQ Locations: (2)
- uart   : 0
- timer0 : 1
INFO:SoC:--------------------------------------------------------------------------------
INFO:S7MMCM:Config:
divclk_divide : 1
clkout0_freq  : 100.00MHz
clkout0_divide: 12
clkout0_phase : 0.00°
clkout1_freq  : 200.00MHz
clkout1_divide: 6
clkout1_phase : 0.00°
clkout2_freq  : 200.00MHz
clkout2_divide: 6
clkout2_phase : 90.00°
clkout3_freq  : 200.00MHz
clkout3_divide: 6
clkout3_phase : 0.00°
vco           : 1200.00MHz
clkfbout_mult : 6
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:SoC Hierarchy:
INFO:SoC:--------------------------------------------------------------------------------
INFO:SoC:
BaseSoC
└─── crg (_CRG)
│    └─── pll (S7MMCM)
│    │    └─── [FDCE]
│    │    └─── [FDCE]
│    │    └─── [FDCE]
│    │    └─── [FDCE]
│    │    └─── [FDCE]
│    │    └─── [FDCE]
│    │    └─── [FDCE]
│    │    └─── [FDCE]
│    │    └─── [MMCME2_ADV]
│    │    └─── [BUFG]
│    │    └─── [BUFG]
│    │    └─── [BUFG]
│    │    └─── [BUFG]
│    └─── idelayctrl (S7IDELAYCTRL)
│    │    └─── [IDELAYCTRL]
└─── bus (SoCBusHandler)
│    └─── _interconnect (InterconnectShared)
│    │    └─── arbiter (Arbiter)
│    │    │    └─── rr (RoundRobin)
│    │    └─── decoder (Decoder)
│    │    └─── timeout (Timeout)
│    │    │    └─── waittimer_0* (WaitTimer)
└─── csr (SoCCSRHandler)
└─── irq (SoCIRQHandler)
└─── ctrl (SoCController)
└─── cpu (VexRiscv)
│    └─── [VexRiscv]
└─── rom (SRAM)
└─── sram (SRAM)
└─── identifier (Identifier)
└─── uart_phy (JTAGPHY)
│    └─── jtag (XilinxJTAG)
│    │    └─── [BSCANE2]
│    └─── tx_cdc (ClockDomainCrossing)
│    │    └─── asyncfifo_0* (AsyncFIFO)
│    │    │    └─── fifo (AsyncFIFO)
│    │    │    │    └─── graycounter_0* (GrayCounter)
│    │    │    │    └─── graycounter_1* (GrayCounter)
│    └─── rx_cdc (ClockDomainCrossing)
│    │    └─── asyncfifo_0* (AsyncFIFO)
│    │    │    └─── fifo (AsyncFIFO)
│    │    │    │    └─── graycounter_0* (GrayCounter)
│    │    │    │    └─── graycounter_1* (GrayCounter)
│    └─── fsm_0* (FSM)
└─── uart (UART)
│    └─── ev (EventManager)
│    │    └─── eventsourceprocess_0* (EventSourceProcess)
│    │    └─── eventsourceprocess_1* (EventSourceProcess)
│    └─── tx_fifo (SyncFIFO)
│    │    └─── fifo (SyncFIFOBuffered)
│    │    │    └─── fifo (SyncFIFO)
│    └─── rx_fifo (SyncFIFO)
│    │    └─── fifo (SyncFIFOBuffered)
│    │    │    └─── fifo (SyncFIFO)
└─── timer0 (Timer)
│    └─── ev (EventManager)
│    │    └─── eventsourceprocess_0* (EventSourceProcess)
└─── ddrphy (K7DDRPHY)
│    └─── tappeddelayline_0* (TappedDelayLine)
│    └─── dqspattern_0* (DQSPattern)
│    └─── bitslip_0* (BitSlip)
│    └─── bitslip_1* (BitSlip)
│    └─── bitslip_2* (BitSlip)
│    └─── bitslip_3* (BitSlip)
│    └─── bitslip_4* (BitSlip)
│    └─── bitslip_5* (BitSlip)
│    └─── bitslip_6* (BitSlip)
│    └─── bitslip_7* (BitSlip)
│    └─── tappeddelayline_1* (TappedDelayLine)
│    └─── bitslip_8* (BitSlip)
│    └─── bitslip_9* (BitSlip)
│    └─── bitslip_10* (BitSlip)
│    └─── bitslip_11* (BitSlip)
│    └─── bitslip_12* (BitSlip)
│    └─── bitslip_13* (BitSlip)
│    └─── bitslip_14* (BitSlip)
│    └─── bitslip_15* (BitSlip)
│    └─── bitslip_16* (BitSlip)
│    └─── bitslip_17* (BitSlip)
│    └─── bitslip_18* (BitSlip)
│    └─── bitslip_19* (BitSlip)
│    └─── bitslip_20* (BitSlip)
│    └─── bitslip_21* (BitSlip)
│    └─── bitslip_22* (BitSlip)
│    └─── bitslip_23* (BitSlip)
│    └─── bitslip_24* (BitSlip)
│    └─── bitslip_25* (BitSlip)
│    └─── bitslip_26* (BitSlip)
│    └─── bitslip_27* (BitSlip)
│    └─── bitslip_28* (BitSlip)
│    └─── bitslip_29* (BitSlip)
│    └─── bitslip_30* (BitSlip)
│    └─── bitslip_31* (BitSlip)
│    └─── bitslip_32* (BitSlip)
│    └─── bitslip_33* (BitSlip)
│    └─── bitslip_34* (BitSlip)
│    └─── bitslip_35* (BitSlip)
│    └─── bitslip_36* (BitSlip)
│    └─── bitslip_37* (BitSlip)
│    └─── bitslip_38* (BitSlip)
│    └─── bitslip_39* (BitSlip)
│    └─── bitslip_40* (BitSlip)
│    └─── bitslip_41* (BitSlip)
│    └─── bitslip_42* (BitSlip)
│    └─── bitslip_43* (BitSlip)
│    └─── bitslip_44* (BitSlip)
│    └─── bitslip_45* (BitSlip)
│    └─── bitslip_46* (BitSlip)
│    └─── bitslip_47* (BitSlip)
│    └─── bitslip_48* (BitSlip)
│    └─── bitslip_49* (BitSlip)
│    └─── bitslip_50* (BitSlip)
│    └─── bitslip_51* (BitSlip)
│    └─── bitslip_52* (BitSlip)
│    └─── bitslip_53* (BitSlip)
│    └─── bitslip_54* (BitSlip)
│    └─── bitslip_55* (BitSlip)
│    └─── bitslip_56* (BitSlip)
│    └─── bitslip_57* (BitSlip)
│    └─── bitslip_58* (BitSlip)
│    └─── bitslip_59* (BitSlip)
│    └─── bitslip_60* (BitSlip)
│    └─── bitslip_61* (BitSlip)
│    └─── bitslip_62* (BitSlip)
│    └─── bitslip_63* (BitSlip)
│    └─── bitslip_64* (BitSlip)
│    └─── bitslip_65* (BitSlip)
│    └─── bitslip_66* (BitSlip)
│    └─── bitslip_67* (BitSlip)
│    └─── bitslip_68* (BitSlip)
│    └─── bitslip_69* (BitSlip)
│    └─── bitslip_70* (BitSlip)
│    └─── bitslip_71* (BitSlip)
│    └─── tappeddelayline_2* (TappedDelayLine)
│    └─── tappeddelayline_3* (TappedDelayLine)
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [IOBUFDS]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [IOBUFDS]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [IOBUFDS]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [IOBUFDS]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [ISERDESE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [ODELAYE2]
│    └─── [ODELAYE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ISERDESE2]
│    └─── [IDELAYE2]
│    └─── [IOBUF]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OBUFDS]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OBUFDS]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
│    └─── [OSERDESE2]
│    └─── [ODELAYE2]
└─── sdram (LiteDRAMCore)
│    └─── dfii (DFIInjector)
│    │    └─── pi0 (PhaseInjector)
│    │    └─── pi1 (PhaseInjector)
│    └─── controller (LiteDRAMController)
│    │    └─── refresher (Refresher)
│    │    │    └─── timer (RefreshTimer)
│    │    │    └─── postponer (RefreshPostponer)
│    │    │    └─── sequencer (RefreshSequencer)
│    │    │    │    └─── refreshexecuter_0* (RefreshExecuter)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_0* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_1* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_2* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_3* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_4* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_5* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_6* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_7* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_8* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_9* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_10* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_11* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_12* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_13* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_14* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── bankmachine_15* (BankMachine)
│    │    │    └─── syncfifo_0* (SyncFIFO)
│    │    │    │    └─── fifo (SyncFIFO)
│    │    │    └─── buffer_0* (Buffer)
│    │    │    │    └─── pipe_valid (PipeValid)
│    │    │    │    └─── pipeline (Pipeline)
│    │    │    └─── twtpcon (tXXDController)
│    │    │    └─── trccon (tXXDController)
│    │    │    └─── trascon (tXXDController)
│    │    │    └─── fsm (FSM)
│    │    └─── multiplexer (Multiplexer)
│    │    │    └─── choose_cmd (_CommandChooser)
│    │    │    │    └─── roundrobin_0* (RoundRobin)
│    │    │    └─── choose_req (_CommandChooser)
│    │    │    │    └─── roundrobin_0* (RoundRobin)
│    │    │    └─── _steerer_0* (_Steerer)
│    │    │    │    └─── decoder_0* (Decoder)
│    │    │    │    └─── decoder_1* (Decoder)
│    │    │    └─── trrdcon (tXXDController)
│    │    │    └─── tfawcon (tFAWController)
│    │    │    └─── tccdcon (tXXDController)
│    │    │    └─── twtrcon (tXXDController)
│    │    │    └─── fsm (FSM)
│    └─── crossbar (LiteDRAMCrossbar)
│    │    └─── roundrobin_0* (RoundRobin)
│    │    └─── roundrobin_1* (RoundRobin)
│    │    └─── roundrobin_2* (RoundRobin)
│    │    └─── roundrobin_3* (RoundRobin)
│    │    └─── roundrobin_4* (RoundRobin)
│    │    └─── roundrobin_5* (RoundRobin)
│    │    └─── roundrobin_6* (RoundRobin)
│    │    └─── roundrobin_7* (RoundRobin)
│    │    └─── roundrobin_8* (RoundRobin)
│    │    └─── roundrobin_9* (RoundRobin)
│    │    └─── roundrobin_10* (RoundRobin)
│    │    └─── roundrobin_11* (RoundRobin)
│    │    └─── roundrobin_12* (RoundRobin)
│    │    └─── roundrobin_13* (RoundRobin)
│    │    └─── roundrobin_14* (RoundRobin)
│    │    └─── roundrobin_15* (RoundRobin)
└─── l2_cache (Cache)
│    └─── fsm (FSM)
└─── wishbone_bridge (LiteDRAMWishbone2Native)
│    └─── fsm (FSM)
└─── leds (LedChaser)
│    └─── waittimer_0* (WaitTimer)
└─── csr_bridge (Wishbone2CSR)
│    └─── fsm (FSM)
└─── csr_bankarray (CSRBankArray)
│    └─── csrbank_0* (CSRBank)
│    │    └─── csrstorage_0* (CSRStorage)
│    │    └─── csrstorage_1* (CSRStorage)
│    │    └─── csrstatus_0* (CSRStatus)
│    └─── csrbank_1* (CSRBank)
│    │    └─── csrstorage_0* (CSRStorage)
│    │    └─── csrstorage_1* (CSRStorage)
│    │    └─── csrstorage_2* (CSRStorage)
│    │    └─── csrstorage_3* (CSRStorage)
│    │    └─── csrstorage_4* (CSRStorage)
│    │    └─── csrstorage_5* (CSRStorage)
│    └─── sram_0* (SRAM)
│    └─── csrbank_2* (CSRBank)
│    │    └─── csrstorage_0* (CSRStorage)
│    └─── csrbank_3* (CSRBank)
│    │    └─── csrstorage_0* (CSRStorage)
│    │    └─── csrstorage_1* (CSRStorage)
│    │    └─── csrstorage_2* (CSRStorage)
│    │    └─── csrstorage_3* (CSRStorage)
│    │    └─── csrstorage_4* (CSRStorage)
│    │    └─── csrstatus_0* (CSRStatus)
│    │    └─── csrstorage_5* (CSRStorage)
│    │    └─── csrstorage_6* (CSRStorage)
│    │    └─── csrstorage_7* (CSRStorage)
│    │    └─── csrstorage_8* (CSRStorage)
│    │    └─── csrstatus_1* (CSRStatus)
│    └─── csrbank_4* (CSRBank)
│    │    └─── csrstorage_0* (CSRStorage)
│    │    └─── csrstorage_1* (CSRStorage)
│    │    └─── csrstorage_2* (CSRStorage)
│    │    └─── csrstorage_3* (CSRStorage)
│    │    └─── csrstatus_0* (CSRStatus)
│    │    └─── csrstatus_1* (CSRStatus)
│    │    └─── csrstatus_2* (CSRStatus)
│    │    └─── csrstorage_4* (CSRStorage)
│    └─── csrbank_5* (CSRBank)
│    │    └─── csrstatus_0* (CSRStatus)
│    │    └─── csrstatus_1* (CSRStatus)
│    │    └─── csrstatus_2* (CSRStatus)
│    │    └─── csrstatus_3* (CSRStatus)
│    │    └─── csrstorage_0* (CSRStorage)
│    │    └─── csrstatus_4* (CSRStatus)
│    │    └─── csrstatus_5* (CSRStatus)
└─── csr_interconnect (InterconnectShared)
* : Generated name.
[]: BlackBox.

INFO:SoC:--------------------------------------------------------------------------------
make: Entering directory '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/libc'
make: Nothing to be done for 'all'.
make: Leaving directory '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/libc'
make: Entering directory '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/libcompiler_rt'
make: Nothing to be done for 'all'.
make: Leaving directory '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/libcompiler_rt'
make: Entering directory '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/libbase'
 CC       console.o
 CC       system.o
 CC       memtest.o
 CC       uart.o
 CC       spiflash.o
 CC       i2c.o
 CC       isr.o
 CC       hyperram.o
 AR       libbase.a
make: Leaving directory '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/libbase'
make: Entering directory '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/libfatfs'
make: Nothing to be done for 'all'.
make: Leaving directory '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/libfatfs'
make: Entering directory '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/liblitespi'
 CC       spiflash.o
 CC       spiram.o
 AR       liblitespi.a
make: Leaving directory '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/liblitespi'
make: Entering directory '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/liblitedram'
 CC       sdram.o
 CC       bist.o
 CC       sdram_dbg.o
 CC       sdram_spd.o
 CC       utils.o
 CC       accessors.o
/devel/riscv/litex-root/litex/litex/soc/software/liblitedram/sdram.c: In function 'sdram_write_leveling_on':
/devel/riscv/litex-root/litex/litex/soc/software/liblitedram/sdram.c:552:28: error: 'DDRX_MR_WRLVL_ADDRESS' undeclared (first use in this function)
  552 |  sdram_mode_register_write(DDRX_MR_WRLVL_ADDRESS, DDRX_MR_WRLVL_RESET ^ (1 << DDRX_MR_WRLVL_BIT));
      |                            ^~~~~~~~~~~~~~~~~~~~~
/devel/riscv/litex-root/litex/litex/soc/software/liblitedram/sdram.c:552:28: note: each undeclared identifier is reported only once for each function it appears in
/devel/riscv/litex-root/litex/litex/soc/software/liblitedram/sdram.c:552:51: error: 'DDRX_MR_WRLVL_RESET' undeclared (first use in this function)
  552 |  sdram_mode_register_write(DDRX_MR_WRLVL_ADDRESS, DDRX_MR_WRLVL_RESET ^ (1 << DDRX_MR_WRLVL_BIT));
      |                                                   ^~~~~~~~~~~~~~~~~~~
/devel/riscv/litex-root/litex/litex/soc/software/liblitedram/sdram.c:552:79: error: 'DDRX_MR_WRLVL_BIT' undeclared (first use in this function)
  552 |  sdram_mode_register_write(DDRX_MR_WRLVL_ADDRESS, DDRX_MR_WRLVL_RESET ^ (1 << DDRX_MR_WRLVL_BIT));
      |                                                                               ^~~~~~~~~~~~~~~~~
/devel/riscv/litex-root/litex/litex/soc/software/liblitedram/sdram.c: In function 'sdram_write_leveling_off':
/devel/riscv/litex-root/litex/litex/soc/software/liblitedram/sdram.c:564:28: error: 'DDRX_MR_WRLVL_ADDRESS' undeclared (first use in this function)
  564 |  sdram_mode_register_write(DDRX_MR_WRLVL_ADDRESS, DDRX_MR_WRLVL_RESET);
      |                            ^~~~~~~~~~~~~~~~~~~~~
/devel/riscv/litex-root/litex/litex/soc/software/liblitedram/sdram.c:564:51: error: 'DDRX_MR_WRLVL_RESET' undeclared (first use in this function)
  564 |  sdram_mode_register_write(DDRX_MR_WRLVL_ADDRESS, DDRX_MR_WRLVL_RESET);
      |                                                   ^~~~~~~~~~~~~~~~~~~
make: *** [/devel/riscv/litex-root/litex/litex/soc/software/liblitedram/Makefile:15: sdram.o] Error 1
make: *** Waiting for unfinished jobs....
make: Leaving directory '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/liblitedram'
Traceback (most recent call last):
  File "/devel/riscv/litex-root/litex-boards/litex_boards/targets/hyvision_pcie_opt01_revf.py", line 119, in <module>
    main()
    ~~~~^^
  File "/devel/riscv/litex-root/litex-boards/litex_boards/targets/hyvision_pcie_opt01_revf.py", line 109, in main
    builder.build(**parser.toolchain_argdict)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/devel/riscv/litex-root/litex/litex/soc/integration/builder.py", line 395, in build
    self._generate_rom_software(compile_bios=use_bios)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/devel/riscv/litex-root/litex/litex/soc/integration/builder.py", line 329, in _generate_rom_software
    subprocess.check_call(["make", f"-j{cpu_count}", "-C", dst_dir, "-f", makefile])
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/subprocess.py", line 421, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['make', '-j24', '-C', '/devel/riscv/litex-root/litex-boards/build/hyvision_pcie_opt01_revf/software/liblitedram', '-f', '/devel/riscv/litex-root/litex/litex/soc/software/liblitedram/Makefile']' returned non-zero exit status 2.
```