### PR TITLE
CI: update ubuntu to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Checkout Repository
       - name: Checkout


### PR DESCRIPTION
Since 2025-04-15, ubuntu 20.04 is removed and the run CI is cancelled.
This PR bump ubuntu version to 22.04, no others modifications (python is kept in 3.9 version).