### PR TITLE
Add mlkpai-fs01-dr1v90m board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Some of the suported boards, see yours? Give LiteX-Boards a try!
     ├── marble
     ├── micronova_mercury2
     ├── mist
+    ├── mlkpai_fs01_dr1v90m
     ├── mnt_rkx7
     ├── muselab_icesugar_pro
     ├── muselab_icesugar

--- a/litex_boards/platforms/mlkpai_fs01_dr1v90m.py
+++ b/litex_boards/platforms/mlkpai_fs01_dr1v90m.py
@@ -1,0 +1,64 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Junhui Liu <junhui.liu@pigmoral.tech>
+# SPDX-License-Identifier: BSD-2-Clause
+
+#
+# Board Info:
+# https://www.milianke.com/product-item-104.html
+
+from migen import *
+
+from litex.build.generic_platform import *
+from litex.build.anlogic.platform import AnlogicPlatform
+from litex.build.anlogic.programmer import TangDynastyProgrammer
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("clk25",  0, Pins("L18"), IOStandard("LVCMOS33")),
+
+    # Leds
+    ("user_led", 0, Pins("L21"), IOStandard("LVCMOS33")),
+    ("user_led", 1, Pins("L22"), IOStandard("LVCMOS33")),
+    ("user_led", 2, Pins("M21"), IOStandard("LVCMOS33")),
+    ("user_led", 3, Pins("M22"), IOStandard("LVCMOS33")),
+    ("user_led", 4, Pins("N22"), IOStandard("LVCMOS33")),
+    ("user_led", 5, Pins("P20"), IOStandard("LVCMOS33")),
+    ("user_led", 6, Pins("P22"), IOStandard("LVCMOS33")),
+    ("user_led", 7, Pins("P21"), IOStandard("LVCMOS33")),
+
+    # Buttons.
+    ("user_btn", 0, Pins("U22"),  IOStandard("LVCMOS18")),
+    ("user_btn", 1, Pins("T22"),  IOStandard("LVCMOS18")),
+    ("user_btn", 2, Pins("T21"),  IOStandard("LVCMOS18")),
+
+    # Serial
+    ("serial", 0,
+        Subsignal("tx", Pins("V18")),
+        Subsignal("rx", Pins("V19")),
+        IOStandard("LVCMOS18")
+    ),
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = []
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(AnlogicPlatform):
+    default_clk_name   = "clk25"
+    default_clk_period = 1e9/25e6
+
+    def __init__(self, toolchain="td"):
+        AnlogicPlatform.__init__(self, "DR1V90MEG484", _io, _connectors, toolchain=toolchain)
+
+    def create_programmer(self):
+        return TangDynastyProgrammer()
+
+    def do_finalize(self, fragment):
+        AnlogicPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk25", loose=True), 1e9/25e6)

--- a/litex_boards/targets/mlkpai_fs01_dr1v90m.py
+++ b/litex_boards/targets/mlkpai_fs01_dr1v90m.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Junhui Liu <junhui.liu@pigmoral.tech>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.gen import *
+
+from litex_boards.platforms import mlkpai_fs01_dr1v90m
+
+from litex.build.generic_platform import *
+
+from litex.soc.cores.clock import *
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst    = Signal()
+        self.cd_sys = ClockDomain()
+
+        # Clk / Rst.
+        clk25 = platform.request("clk25")
+        rst_n = platform.request("user_btn", 0)
+
+        self.comb += self.cd_sys.clk.eq(clk25)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~rst_n | self.rst)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=25e6, with_led_chaser=True, **kwargs):
+        platform = mlkpai_fs01_dr1v90m.Platform()
+
+        # CRG --------------------------------------------------------------------------------------
+        self.crg = _CRG(platform, sys_clk_freq)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on MLKPAI FS01 DR1V90M", **kwargs)
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq,
+                polarity     = 1)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=mlkpai_fs01_dr1v90m.Platform, description="LiteX SoC on MLKPAI FS01 DR1V90M.")
+    parser.add_target_argument("--sys-clk-freq", default=25e6, type=float, help="System clock frequency.")
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq = args.sys_clk_freq,
+        **parser.soc_argdict
+    )
+
+    builder = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduce MLKPAI-FS01-DR1V90M, powered by DR1V90MEG484 from Anlogic, which has built-in FPGA with 94464 LUTs and a UX900 RISC-V CPU hardcore from Nuclei System Technology. The dr1_90 architecture is only supported in Tang Dynasty version 5.9 currently.

Peripherals support:
- 25M clk
- 8 leds
- 3 buttons
- 1 on-board USB-C serial

This depends on https://github.com/enjoy-digital/litex/pull/2242