### PR TITLE
Hyvision pcie opt01 revf fix update

### DIFF
--- a/litex_boards/platforms/hyvision_pcie_opt01_revf.py
+++ b/litex_boards/platforms/hyvision_pcie_opt01_revf.py
@@ -69,7 +69,7 @@ _io = [
         Subsignal("ras_n", Pins("AA9"),         IOStandard("SSTL18_II")),
         Subsignal("cas_n", Pins("AB9"),         IOStandard("SSTL18_II")),
         Subsignal("we_n",  Pins("AC9"),         IOStandard("SSTL18_II")),
-        Subsignal("ba",    Pins("AD8 AB7 AC7"), IOStandard("SSTL18_II")),
+        Subsignal("ba",    Pins("AC7 AB7 AD8"), IOStandard("SSTL18_II")),
         Subsignal("a",     Pins("AC8 AA7 AA8 AF7 AE7 W8 V9 Y10 Y11 Y7 Y8 W9 W10"),
             IOStandard("SSTL18_II")),
         Subsignal("dq",    Pins(

--- a/litex_boards/platforms/hyvision_pcie_opt01_revf.py
+++ b/litex_boards/platforms/hyvision_pcie_opt01_revf.py
@@ -81,8 +81,8 @@ _io = [
         Subsignal("clk_p", Pins("V11 V8"),         IOStandard("DIFF_SSTL18_II")),
         Subsignal("clk_n", Pins("W11 V7"),         IOStandard("DIFF_SSTL18_II")),
         Subsignal("dm",    Pins("U6 Y3 AB6 AD4"),  IOStandard("SSTL18_II")),
-        Subsignal("odt",   Pins("AA13 AA12"),      IOStandard("SSTL18_II")),
-        Subsignal("cs_n",  Pins("AD9 AB12"),       IOStandard("SSTL18_II")),
+        Subsignal("odt",   Pins("AA13"),           IOStandard("SSTL18_II")), # FIXME: re-adds AA12 when 2nd chip working
+        Subsignal("cs_n",  Pins("AD9"),            IOStandard("SSTL18_II")), # FIXME: re-adds AB12 when 2nd chip working
         Misc("SLEW=FAST"),
     ),
 

--- a/litex_boards/targets/hyvision_pcie_opt01_revf.py
+++ b/litex_boards/targets/hyvision_pcie_opt01_revf.py
@@ -27,6 +27,7 @@ from litex.soc.integration.builder import *
 from litex.soc.cores.clock import *
 from litex.soc.cores.led import LedChaser
 
+from litedram.common  import PHYPadsReducer
 from litedram.modules import K4T1G164QGBCE7
 from litedram.phy import s7ddrphy
 
@@ -94,7 +95,8 @@ class BaseSoC(SoCCore):
 
         # DDR2 SDRAM -------------------------------------------------------------------------------
         if not self.integrated_main_ram_size:
-            self.ddrphy = s7ddrphy.K7DDRPHY(platform.request("ddram"),
+            self.ddrphy = s7ddrphy.K7DDRPHY(
+                pads         = PHYPadsReducer(platform.request("ddram"), [0, 1]),
                 memtype      = "DDR2",
                 nphases      = 2,
                 sys_clk_freq = sys_clk_freq)

--- a/litex_boards/targets/hyvision_pcie_opt01_revf.py
+++ b/litex_boards/targets/hyvision_pcie_opt01_revf.py
@@ -23,13 +23,15 @@ from litex.soc.cores.led import LedChaser
 from litedram.modules import K4T1G164QGBCE7
 from litedram.phy import s7ddrphy
 
+from liteeth.phy.k7_1000basex import K7_1000BASEX
+
 from litepcie.phy.s7pciephy import S7PCIEPHY
 from litepcie.software import generate_litepcie_software
 
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(LiteXModule):
-    def __init__(self, platform, sys_clk_freq):
+    def __init__(self, platform, sys_clk_freq, with_eth=False):
         self.rst          = Signal()
         self.cd_sys       = ClockDomain()
         self.cd_sys2x     = ClockDomain()
@@ -48,6 +50,11 @@ class _CRG(LiteXModule):
         pll.create_clkout(self.cd_idelay,    200e6)
         platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
 
+        # Eth Clk.
+        if with_eth:
+            self.cd_eth  = ClockDomain()
+            pll.create_clkout(self.cd_eth, 200e6, margin=0)
+
         self.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
 
 # BaseSoC ------------------------------------------------------------------------------------------
@@ -56,11 +63,17 @@ class BaseSoC(SoCCore):
     def __init__(self, sys_clk_freq=100e6,
         with_led_chaser = True,
         with_pcie       = False,
+        with_ethernet   = False,
+        with_etherbone  = False,
+        eth_sfp         = 0,
+        eth_ip          = "192.168.1.50",
+        remote_ip       = None,
+        eth_dynamic_ip  = False,
         **kwargs):
         platform = hyvision_pcie_opt01_revf.Platform()
 
         # CRG --------------------------------------------------------------------------------------
-        self.crg = _CRG(platform, sys_clk_freq)
+        self.crg = _CRG(platform, sys_clk_freq, with_eth=(with_ethernet or with_etherbone))
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on HVS HyVision PCIe OPT01 revf", **kwargs)
@@ -84,6 +97,22 @@ class BaseSoC(SoCCore):
                 l2_cache_size = kwargs.get("l2_size", 8192)
             )
 
+        # Ethernet / Etherbone ---------------------------------------------------------------------
+        if with_ethernet or with_etherbone:
+            self.ethphy = K7_1000BASEX(
+                refclk_or_clk_pads = self.crg.cd_eth.clk,
+                data_pads          = self.platform.request("sfp", eth_sfp),
+                sys_clk_freq       = self.clk_freq,
+                with_csr           = False
+            )
+            self.comb += self.platform.request("sfp_tx_disable", eth_sfp).eq(0)
+            self.comb += self.platform.request("sfp_rs0",        eth_sfp).eq(1)
+            platform.add_platform_command("set_property SEVERITY {{Warning}} [get_drc_checks REQP-52]")
+            if with_etherbone:
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip, with_ethmac=with_ethernet)
+            elif with_ethernet:
+                self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip, local_ip=eth_ip, remote_ip=remote_ip)
+
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:
             self.leds = LedChaser(
@@ -94,15 +123,32 @@ class BaseSoC(SoCCore):
 def main():
     from litex.build.parser import LiteXArgumentParser
     parser = LiteXArgumentParser(platform=hyvision_pcie_opt01_revf.Platform, description="LiteX SoC on HyVision PCIe OPT01 refv.")
-    parser.add_target_argument("--sys-clk-freq", default=100e6, type=float, help="System clock frequency.")
-    parser.add_target_argument("--with-pcie",    action="store_true",       help="Enable PCIe support.")
-    parser.add_target_argument("--driver",       action="store_true",       help="Generate PCIe driver.")
+    parser.add_target_argument("--sys-clk-freq",   default=100e6, type=float, help="System clock frequency.")
+
+    # PCIe parameters.
+    parser.add_target_argument("--with-pcie",      action="store_true",       help="Enable PCIe support.")
+    parser.add_target_argument("--driver",         action="store_true",       help="Generate PCIe driver.")
+
+    # Ethernet parameters.
+    parser.add_target_argument("--with-ethernet",  action="store_true",       help="Enable Ethernet support.")
+    parser.add_target_argument("--with-etherbone", action="store_true",       help="Enable Etherbone support.")
+    parser.add_argument("--eth-sfp",               default=0, type=int,       help="Ethernet SFP.", choices=[0, 1])
+    parser.add_target_argument("--eth-ip",         default="192.168.1.50",    help="Ethernet/Etherbone IP address.")
+    parser.add_target_argument("--remote-ip",      default="192.168.1.100",   help="Remote IP address of TFTP server.")
+    parser.add_target_argument("--eth-dynamic-ip", action="store_true",       help="Enable dynamic Ethernet IP addresses setting.")
+
     parser.set_defaults(uart_name="jtag_uart")
     args = parser.parse_args()
 
     soc = BaseSoC(
-        sys_clk_freq = args.sys_clk_freq,
-        with_pcie    = args.with_pcie,
+        sys_clk_freq   = args.sys_clk_freq,
+        with_pcie      = args.with_pcie,
+        with_ethernet  = args.with_ethernet,
+        with_etherbone = args.with_etherbone,
+        eth_sfp        = args.eth_sfp,
+        eth_ip         = args.eth_ip,
+        remote_ip      = args.remote_ip,
+        eth_dynamic_ip = args.eth_dynamic_ip,
         **parser.soc_argdict
     )
     builder = Builder(soc, **parser.builder_argdict)

--- a/litex_boards/targets/hyvision_pcie_opt01_revf.py
+++ b/litex_boards/targets/hyvision_pcie_opt01_revf.py
@@ -7,6 +7,13 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Since this board has no uart, you want to build with JTAG UART:
 # python litex_boards/targets/hyvision_pcie_opt01_revf.py --build --uart-name=jtag_uart
+#
+# JTAG Connectors: j11 or j13
+# Pinout:
+#
+# | Pins |  1  |  2  |  3  |  4  |  5  |  6  |
+# |------|-----|-----|-----|-----|-----|-----|
+# | Pins | TMS | TDI | TDO | TCK | GND | VCC |
 
 from migen import *
 


### PR DESCRIPTION
It's a WIP to fix / updates some peripherals:
- Fixed *DDR2* `BA` pins order
- Added `SFP`/`ethernet`/`etherbone` support in the target

Notes:
- a 156.26M oscillator is available for SFP via pin `H6` but `K7_1000BASEX` PHY only support 200MHz clock frequency

Tests:
- PCIe tested: OK
- SFP 0/1 tested: OK
- DDR2: KO (When only the first chip is used memtest result is OK)