### PR TITLE
targets: try to have ethernet coherent between targets

### DIFF
--- a/litex_boards/targets/alibaba_vu13p.py
+++ b/litex_boards/targets/alibaba_vu13p.py
@@ -73,7 +73,7 @@ class BaseSoC(SoCCore):
                 with_etherbone         = False,
                 ethernet_port          = "qsfp0_sfp0",
                 etherbone_port         = "qsfp0_sfp0", 
-                ethernet_ip            = "192.168.1.50",
+                eth_ip                 = "192.168.1.50",
                 eth_dynamic_ip         = True,
                 remote_ip              = None,
                 etherbone_ip           = "192.168.1.50",
@@ -128,7 +128,7 @@ class BaseSoC(SoCCore):
                 data_pads    = self.platform.request("qsfp{}_sfp".format(qsfp_id), sfp_lane),
                 sys_clk_freq = self.clk_freq,
                 refclk_from_fabric = True)
-            self.add_ethernet(phy=self.ethphy, local_ip=ethernet_ip if not eth_dynamic_ip else None, dynamic_ip=eth_dynamic_ip, remote_ip=remote_ip)
+            self.add_ethernet(phy=self.ethphy, local_ip=eth_ip if not eth_dynamic_ip else None, dynamic_ip=eth_dynamic_ip, remote_ip=remote_ip)
             qsfp_in_use[qsfp_id] = True
 
         if with_etherbone:
@@ -202,7 +202,7 @@ def main():
         with_etherbone = args.with_etherbone,
         ethernet_port  = args.ethernet_port,
         etherbone_port  = args.etherbone_port,
-        ethernet_ip    = args.ethernet_ip,
+        eth_ip         = args.ethernet_ip,
         remote_ip      = args.remote_ip,
         eth_dynamic_ip = args.eth_dynamic_ip,
         etherbone_ip  = args.etherbone_ip,

--- a/litex_boards/targets/colorlight_5a_75x.py
+++ b/litex_boards/targets/colorlight_5a_75x.py
@@ -124,6 +124,8 @@ class BaseSoC(SoCCore):
         with_etherbone   = False,
         eth_ip           = "192.168.1.50",
         eth_phy          = 0,
+        remote_ip        = None,
+        eth_dynamic_ip   = False,
         with_led_chaser  = True,
         use_internal_osc = False,
         sdram_rate       = "1:1",
@@ -183,10 +185,10 @@ class BaseSoC(SoCCore):
                 clock_pads = self.platform.request("eth_clocks", eth_phy),
                 pads       = self.platform.request("eth", eth_phy),
                 tx_delay   = 0e-9)
-            if with_ethernet:
-                self.add_ethernet(phy=self.ethphy, data_width=32)
             if with_etherbone:
-                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip, data_width=32)
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip, with_ethmac=with_ethernet, data_width=32)
+            if with_ethernet:
+                self.add_ethernet(phy=self.ethphy, data_width=32, dynamic_ip=eth_dynamic_ip, local_ip=eth_ip, remote_ip=remote_ip)
 
         # Leds -------------------------------------------------------------------------------------
         # Disable leds when serial is used.

--- a/litex_boards/targets/digilent_netfpga_sume.py
+++ b/litex_boards/targets/digilent_netfpga_sume.py
@@ -55,10 +55,13 @@ class _CRG(LiteXModule):
 
 class BaseSoC(SoCCore):
     def __init__(self, sys_clk_freq=125e6,
-        with_ethernet          = False,
-        with_etherbone         = False,
-        with_led_chaser        = True,
-        with_i2c               = False,
+        with_ethernet   = False,
+        with_etherbone  = False,
+        eth_ip          = "192.168.1.50",
+        remote_ip       = None,
+        eth_dynamic_ip  = False,
+        with_led_chaser = True,
+        with_i2c        = False,
         **kwargs):
         platform = digilent_netfpga_sume.Platform()
 
@@ -93,10 +96,10 @@ class BaseSoC(SoCCore):
             self.comb += self.platform.request("sfp_tx_disable_n").eq(1)
             platform.add_platform_command("set_property SEVERITY {{Warning}} [get_drc_checks UCIO-1]")
             platform.add_platform_command("set_property SEVERITY {{Warning}} [get_drc_checks REQP-44]")
-        if with_ethernet:
-                self.add_ethernet(phy=self.ethphy)
         if with_etherbone:
-                self.add_etherbone(phy=self.ethphy)
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip, with_ethmac=with_ethernet)
+        if with_ethernet:
+                self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip, local_ip=eth_ip, remote_ip=remote_ip)
                 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:

--- a/litex_boards/targets/xilinx_kc705.py
+++ b/litex_boards/targets/xilinx_kc705.py
@@ -61,6 +61,10 @@ class _CRG(LiteXModule):
 class BaseSoC(SoCCore):
     def __init__(self, sys_clk_freq=125e6,
         with_ethernet   = False,
+        with_etherbone  = False,
+        eth_ip          = "192.168.1.50",
+        remote_ip       = None,
+        eth_dynamic_ip  = False,
         with_led_chaser = True,
         with_spi_flash  = False,
         with_pcie       = False,
@@ -92,7 +96,7 @@ class BaseSoC(SoCCore):
                 clock_pads = self.platform.request("eth_clocks"),
                 pads       = self.platform.request("eth"),
                 clk_freq   = self.clk_freq)
-            self.add_ethernet(phy=self.ethphy)
+            self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip, local_ip=eth_ip, remote_ip=remote_ip)
 
         # SPI Flash --------------------------------------------------------------------------------
         if with_spi_flash:

--- a/litex_boards/targets/xilinx_kcu105.py
+++ b/litex_boards/targets/xilinx_kcu105.py
@@ -66,6 +66,8 @@ class BaseSoC(SoCCore):
         with_ethernet   = False,
         with_etherbone  = False,
         eth_ip          = "192.168.1.50",
+        remote_ip       = None,
+        eth_dynamic_ip  = False,
         with_led_chaser = True,
         with_pcie       = False,
         with_sata       = False,
@@ -98,10 +100,10 @@ class BaseSoC(SoCCore):
                 sys_clk_freq = self.clk_freq)
             self.comb += self.platform.request("sfp_tx_disable_n", 0).eq(1)
             self.platform.add_platform_command("set_property SEVERITY {{Warning}} [get_drc_checks REQP-1753]")
-            if with_ethernet:
-                self.add_ethernet(phy=self.ethphy)
             if with_etherbone:
-                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip, with_ethmac=with_ethernet)
+            if with_ethernet:
+                self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip, local_ip=eth_ip, remote_ip=remote_ip)
 
         # PCIe -------------------------------------------------------------------------------------
         if with_pcie:


### PR DESCRIPTION
As observed in https://github.com/litex-hub/linux-on-litex-vexriscv/pull/425 ethernet integration may vary target per target:
- some targets like `digilent_arty.py` have `eth_ip`/`remote_ip`/`eth_dynamic_ip`
- some targets have a subset of these parameters
- some targets have no parameters to configure ethernet

It's true for `BaseSoC` constructor but it's also true for `add_ethernet` and `add_etherbone`

This PR is a draft to modify constructor parameters and method call to have the same structure for all targets:
- CLI arguments may or not be updated to allows users to configure target
- for some targets only `add_ethernet` is implemented: required to also adds `add_etherbone`?

Note: Since not all targets have been updated this PR is firstly to evaluate the approach before updating remaining targets.

cc @enjoy-digital @ryanhaus 