### PR TITLE
Fix ZCU106 user button pin: properly handle SW_C assignment based on official user guide

### DIFF
--- a/litex_boards/platforms/xilinx_zcu106.py
+++ b/litex_boards/platforms/xilinx_zcu106.py
@@ -28,7 +28,7 @@ _io = [
     ("user_led", 7, Pins("AM11"), IOStandard("LVCMOS12")),
 
     # Buttons
-    ("user_btn_c", 0, Pins("AL11"), IOStandard("LVCMOS12")),
+    ("user_btn_c", 0, Pins("AL10"), IOStandard("LVCMOS12")),
     ("user_btn_n", 0, Pins("AG13"), IOStandard("LVCMOS12")),
     ("user_btn_s", 0, Pins("AP20"), IOStandard("LVCMOS12")),
     ("user_btn_w", 0, Pins("AK12"), IOStandard("LVCMOS12")),


### PR DESCRIPTION
Fix incorrect pin assignment for the ZCU106 user button (SW_C) to match the official board documentation.

<img width="703" height="151" alt="image" src="https://github.com/user-attachments/assets/934e034d-dd3c-489c-9951-7d93bc128033" />


Reference (page 88): [UG1244 - ZCU106 Evaluation Board User Guide](https://docs.amd.com/v/u/en-US/ug1244-zcu106-eval-bd).