### PR TITLE
add board support for Berkeley lab Obsidian A35 board

### DIFF
--- a/litex_boards/platforms/berkeleylab_obsidian.py
+++ b/litex_boards/platforms/berkeleylab_obsidian.py
@@ -1,0 +1,247 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Michael Betz <michael@betz-engineering.ch>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Obsidian A35 is a low cost FPGA carrier board with several SFP ports,
+# many PMOD IOs and Arduino shield compatibility.
+# It was developed at Berkeley Lab as a kind of smart IO extender.
+# It facilitates interfacing ADCs, DACs, sensors, UI elements or other
+# peripherals to a central larger FPGA board or a PC.
+
+
+from litex.build.generic_platform import Subsignal, Pins, IOStandard, Misc
+from litex.build.xilinx import Xilinx7SeriesPlatform
+from litex.build.openocd import OpenOCD
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # WR_CLK0 (125 MHz, DAC-tunable), MGTREFCLK0
+    (
+        "clk125",
+        0,
+        Subsignal("p", Pins("D6")),
+        Subsignal("n", Pins("D5")),
+    ),
+    # CLK20_VCXO (20 MHz, DAC-tunable), PAD NOT CLOCK-CAPABLE!
+    ("clk20", 0, Pins("D13"), IOStandard("LVCMOS33")),
+    # REF_CLK0 (Si5351A, channel 0 and 1, I2C-tunable, 2.5 kHz - 200 MHz), MGTREFCLK1
+    # Note: the Si5351 needs to be configured to get HCSL compatible outputs.
+    # See Section 6.7 in the datasheet and register setting CLKx_INV.
+    (
+        "clkmgt",
+        0,
+        Subsignal("p", Pins("B6")),
+        Subsignal("n", Pins("B5")),
+    ),
+    # CLK2 (Si5351A, channel 2, I2C-tunable, 2.5 kHz - 200 MHz)
+    ("clk2", 0, Pins("E15"), IOStandard("LVCMOS33")),
+    # Gigabit Ethernet transceiver (RTL8211F-CG)
+    (
+        "eth",
+        0,
+        Subsignal("rst_n", Pins("A13")),
+        Subsignal("mdio", Pins("E18")),
+        Subsignal("mdc", Pins("H14")),
+        Subsignal("rx_ctl", Pins("D16")),
+        Subsignal("rx_data", Pins("B16 C16 D14 C13")),
+        Subsignal("tx_ctl", Pins("A17")),
+        Subsignal("tx_data", Pins("B17 E16 E17 D18")),
+        IOStandard("LVCMOS33"),
+    ),
+    (
+        "eth_clocks",
+        0,
+        Subsignal("tx", Pins("D15")),
+        Subsignal("rx", Pins("E13")),
+        IOStandard("LVCMOS33"),
+    ),
+    # USB UART (FT2232HQ)
+    (
+        "serial",
+        0,
+        # FT2232 --> FPGA
+        Subsignal("rx", Pins("H18")),
+        # FT2232 <-- FPGA
+        Subsignal("tx", Pins("F17")),
+        IOStandard("LVCMOS33"),
+    ),
+    # FT2232 --> FPGA. To use the RTS signal, SW2 must be ON
+    ("serial_rts", 0, Pins("B10"), IOStandard("LVCMOS33")),
+    # SPI Boot Flash (S25FL128SAGMFI001)
+    # use STARTUPE2 primitive to access the clock pin
+    (
+        "spiflash",
+        0,
+        Subsignal("cs_n", Pins("L15")),
+        Subsignal("mosi", Pins("K16")),
+        Subsignal("miso", Pins("L17")),
+        IOStandard("LVCMOS33"),
+    ),
+    # I2C system bus, connected to:
+    #   0x40: IO-extender for SFP0 and SFP1 status pins (TCA9535RTWR)
+    #   0x42: IO-extender for SFP2 and SFP3 status pins (TCA9535RTWR)
+    #   0xC0: Clock synthesizer (Si5351A)
+    #   0xA0: 256Kb I2C Serial EEPROM with Pre-Programmed Serial Number (24AA256UID)
+    #   0xE0: I2C-switch for the 4 SFP ports (PCA9546ARGV)
+    (
+        "i2c_fpga",
+        0,
+        Subsignal("scl", Pins("H17")),
+        Subsignal("sda", Pins("F14")),
+        IOStandard("LVCMOS33"),
+    ),
+    # I2C pins of the Arduino host
+    (
+        "i2c_arduino",
+        0,
+        Subsignal("scl", Pins("J18")),
+        Subsignal("sda", Pins("C12")),
+        IOStandard("LVCMOS33"),
+    ),
+    # 2x DAC for White Rabbit VCXO frequency control (DAC8550IDGK)
+    # clk and din is shared between the 2 DACs
+    # synca updates the clk125 tuning voltage
+    # syncb updates the clk20 tuning voltage
+    (
+        "wr_dac",
+        0,
+        Subsignal("clk", Pins("C11")),
+        Subsignal("din", Pins("B11")),
+        Subsignal("synca", Pins("D11")),
+        Subsignal("syncb", Pins("D10")),
+        IOStandard("LVCMOS33"),
+    ),
+    # DDR3 DRAM chip (AS4C256M16D3)
+    (
+        "ddram",
+        0,
+        Subsignal("a", Pins(r"U2 V3 R7 P6 V2 V4 V7 T7 V8 U4 U1 U7 U6 U5 R6 M5"), IOStandard("SSTL15")),
+        Subsignal("ba", Pins(r"T3 V6 R2"), IOStandard("SSTL15")),
+        Subsignal("ras_n", Pins(r"R3"), IOStandard("SSTL15")),
+        Subsignal("cas_n", Pins(r"T2"), IOStandard("SSTL15")),
+        Subsignal("we_n", Pins(r"T4"), IOStandard("SSTL15")),
+        Subsignal("cs_n", Pins(r"P5"), IOStandard("SSTL15")),
+        Subsignal("dm", Pins(r"L5 M6"), IOStandard("SSTL15")),
+        Subsignal("dq", Pins(r"K3 L4 K5 K6 J4 L2 J5 L3 N3 M1 N2 M4 N6 M2 P4 N4"), IOStandard("SSTL15")),
+        Subsignal("dqs_p", Pins(r"K2 N1"), IOStandard("DIFF_SSTL15")),
+        Subsignal("dqs_n", Pins(r"K1 P1"), IOStandard("DIFF_SSTL15")),
+        Subsignal("clk_p", Pins(r"R5"), IOStandard("DIFF_SSTL15")),
+        Subsignal("clk_n", Pins(r"T5"), IOStandard("DIFF_SSTL15")),
+        Subsignal("cke", Pins(r"R1"), IOStandard("SSTL15")),
+        Subsignal("odt", Pins(r"P3"), IOStandard("SSTL15")),
+        Subsignal("reset_n", Pins(r"J6"), IOStandard("LVCMOS15")),
+        Misc("SLEW=FAST"),
+    ),
+    (
+        "sfp_tx",
+        0,
+        Subsignal("p", Pins("H2")),
+        Subsignal("n", Pins("H1")),
+    ),
+    (
+        "sfp_tx",
+        1,
+        Subsignal("p", Pins("F2")),
+        Subsignal("n", Pins("F1")),
+    ),
+    (
+        "sfp_tx",
+        2,
+        Subsignal("p", Pins("D2")),
+        Subsignal("n", Pins("D1")),
+    ),
+    (
+        "sfp_tx",
+        3,
+        Subsignal("p", Pins("B2")),
+        Subsignal("n", Pins("B1")),
+    ),
+    (
+        "sfp_rx",
+        0,
+        Subsignal("p", Pins("E4")),
+        Subsignal("n", Pins("E3")),
+    ),
+    (
+        "sfp_rx",
+        1,
+        Subsignal("p", Pins("A4")),
+        Subsignal("n", Pins("A3")),
+    ),
+    (
+        "sfp_rx",
+        2,
+        Subsignal("p", Pins("C4")),
+        Subsignal("n", Pins("C3")),
+    ),
+    (
+        "sfp_rx",
+        3,
+        Subsignal("p", Pins("G4")),
+        Subsignal("n", Pins("G3")),
+    ),
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = [
+    ("pmoda", r"M16 N17 R18 U16 M17 N18 P18 V17"),
+    ("pmodb", r"T18 U17 U15 V14 R17 T17 V16 U14"),
+    ("pmodc", r"M15 N16 P15 K18 N14 P16 K17 L18"),
+    ("pmodd", r"J16 K15 F15 J14 J15 M14 G15 L14"),
+    ("pmode", r"U10 U9 V9 V11 V12 U12 V13 U11"),
+    ("pmodf", r"T13 T12 R13 T14 T15 P14 R16 R15"),
+    # digital Arduino host pins
+    ("arduino_d", r"G14 H16 A12 B12 C14 G17 G16 A15 C18 F18 C17 B15 B14 A14"),
+    # Analog capable Arduino host pins connected to XADC
+    # the order is: A0_P, A0_N, A2_P, A2_N, A1_P, A1_N, A3_P, A3_N
+    ("arduino_a", r"C8 D8 A9 B9 C9 D9 A10 B10"),
+]
+
+
+def raw_pmod_io(pmod="pmoda", iostd="LVCMOS33"):
+    """use with platform.add_extension() to expose a PMOD as GPIO pins"""
+    return [
+        (
+            pmod,
+            0,
+            Pins(" ".join([f"{pmod}:{i:d}" for i in range(8)])),
+            IOStandard(iostd),
+        )
+    ]
+
+
+# Platform -----------------------------------------------------------------------------------------
+
+
+class Platform(Xilinx7SeriesPlatform):
+    default_clk_name = "clk125"
+    default_clk_period = 1e9 / 125e6
+
+    def __init__(self, toolchain="vivado"):
+        # TODO verify part number
+        Xilinx7SeriesPlatform.__init__(self, "xc7a35t-csg325", _io, _connectors, toolchain=toolchain)
+        self.toolchain.bitstream_commands = ["set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]"]
+        self.toolchain.additional_commands = [
+            (
+                "write_cfgmem -force -format bin -interface spix4 -size 16 -loadbit "
+                + '"up 0x0 {build_name}.bit" -file {build_name}.bin'
+            )
+        ]
+
+        # from pin_map.csv: This is a frequency source, not a phase source, so having it enter on a non-CC pin is OK.
+        self.add_platform_command("set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets clk20_IBUF]")
+        self.add_platform_command("set_property CONFIG_VOLTAGE 3.3 [current_design]")
+        self.add_platform_command("set_property CFGBVS VCCO [current_design]")
+        self.add_platform_command("set_property INTERNAL_VREF 0.75 [get_iobanks 34]")
+
+    def create_programmer(self):
+        return OpenOCD("openocd_xc7_ft2232.cfg")
+
+    def do_finalize(self, fragment):
+        Xilinx7SeriesPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk20", loose=True), 1e9 / 20e6)
+        self.add_period_constraint(self.lookup_request("clk125", loose=True), 1e9 / 125e6)

--- a/litex_boards/targets/berkeleylab_obsidian.py
+++ b/litex_boards/targets/berkeleylab_obsidian.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+---------------------------
+ LiteX SoC on Obsidian A35
+---------------------------
+with support for DDR3 RAM chip, ethernet, SPI flash and UART.
+To synthesize, add --build, to configure the FPGA over jtag, add --load.
+
+-----------------
+ Example configs
+-----------------
+lightweight config
+  ./berkeleylab_obsidian.py --integrated-main-ram-size 1024 --cpu-type serv
+
+with ethernet and DDR3 (including self test), default IP: 192.168.1.50/24
+  ./berkeleylab_obsidian.py --with-ethernet --with-ddr3 --with-bist
+
+etherbone: access wishbone over ethernet
+  ./berkeleylab_obsidian.py --with-etherbone --csr-csv build/csr.csv
+
+make sure reset is not asserted (RTS signal), set PC IP to 192.168.1.100/24,
+then test and benchmark the etherbone link:
+  cd build
+  litex/liteeth/bench/test_etherbone.py --udp --ident --access --sram --speed
+"""
+from migen import Signal, Instance, ClockDomain, reduce, or_
+from litex.gen import LiteXModule
+from litex.soc.cores.clock import S7MMCM, S7IDELAYCTRL
+from litex.soc.integration.soc_core import SoCCore
+from litex.soc.integration.builder import Builder
+from litex.soc.cores.led import LedChaser
+from litex.soc.cores.bitbang import I2CMaster
+from litedram.modules import AS4C256M16D3A
+from litedram.phy.s7ddrphy import A7DDRPHY
+from liteeth.phy.s7rgmii import LiteEthPHYRGMII
+from liteiclink.serdes.gtp_7series import GTPQuadPLL, GTP
+from litex_obsidian.platforms import berkeleylab_obsidian
+from litex_obsidian.platforms.berkeleylab_obsidian import raw_pmod_io
+
+
+# ---------------------------
+#  Clock and reset generator
+# ---------------------------
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq, resets=[]):
+        self.rst = Signal()
+        self.cd_sys = ClockDomain()
+        self.cd_sys4x = ClockDomain()
+        self.cd_sys4x_dqs = ClockDomain()
+        self.cd_idelay = ClockDomain()
+
+        # # #
+
+        # Transceiver clock routing. See UG482.
+        clk125 = platform.request("clk125")
+
+        # GTP reference clock to be used with GTPQuadPLL
+        self.clk125_gtp = Signal()
+        clk125_bufh = Signal()
+
+        self.specials += Instance("IBUFDS_GTE2", i_I=clk125.p, i_IB=clk125.n, i_CEB=0, o_O=self.clk125_gtp)
+        self.specials += Instance("BUFH", i_I=self.clk125_gtp, o_O=clk125_bufh)
+
+        self.pll = pll = S7MMCM(speedgrade=-2)
+        pll.register_clkin(clk125_bufh, 125e6)
+
+        resets.append(self.rst)
+        self.comb += pll.reset.eq(reduce(or_, resets))
+
+        pll.create_clkout(self.cd_sys, sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x, 4 * sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x_dqs, 4 * sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_idelay, 200e6)
+
+        # Ignore sys_clk to pll.clkin path created by SoC's rst.
+        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin)
+
+        self.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
+
+
+# ---------------------------
+#  BaseSoC
+# ---------------------------
+class BaseSoC(SoCCore):
+    def __init__(
+        self,
+        sys_clk_freq=125e6,
+        with_ethernet=False,
+        with_etherbone=False,
+        with_rts_reset=False,
+        with_ddr3=False,
+        with_bist=False,
+        with_led_chaser=False,
+        with_spi_flash=False,
+        **kwargs,
+    ):
+        self.n_serdes = 0
+        platform = berkeleylab_obsidian.Platform()
+
+        # CRG, resettable over USB serial RTS signal
+        resets = []
+        if with_rts_reset:
+            resets.append(platform.request("serial_rts"))
+        self.crg = _CRG(platform, sys_clk_freq, resets)
+
+        SoCCore.__init__(
+            self,
+            platform,
+            sys_clk_freq,
+            ident="LiteX SoC on Berkeley-Lab Obsidian",
+            **kwargs,
+        )
+
+        # DDR3 SDRAM
+        if with_ddr3:
+            self.ddrphy = A7DDRPHY(
+                platform.request("ddram"),
+                memtype="DDR3",
+                sys_clk_freq=sys_clk_freq,
+            )
+
+            self.add_sdram(
+                "sdram",
+                phy=self.ddrphy,
+                module=AS4C256M16D3A(sys_clk_freq, "1:4"),
+                l2_cache_size=kwargs.get("l2_size", 8192),
+                with_bist=with_bist,
+            )
+
+        # Ethernet
+        if with_ethernet or with_etherbone:
+            self.ethphy = LiteEthPHYRGMII(
+                clock_pads=self.platform.request("eth_clocks"),
+                pads=self.platform.request("eth"),
+                rx_delay=0.4e-9,  # These values were determined empirically,
+                tx_delay=2e-9,  # see utils/board_test/eth_test.py
+                hw_reset_cycles=2000000,  # 10 ms
+            )
+
+        if with_ethernet:
+            self.add_ethernet(phy=self.ethphy, dynamic_ip=True, software_debug=False)
+
+        if with_etherbone:
+            self.add_etherbone(phy=self.ethphy, buffer_depth=255)
+
+        # SPI Flash
+        # 4x mode is not possible on this board since WP and HOLD pins are not connected to the FPGA
+        if with_spi_flash:
+            from litespi.modules import S25FL128L
+            from litespi.opcodes import SpiNorFlashOpCodes as Codes
+
+            self.add_spi_flash(
+                mode="1x", clk_freq=40e6, module=S25FL128L(Codes.READ_1_1_1), rate="1:1", with_master=True
+            )
+
+        # System I2C (4x SFPs, Si5351A and 24AA256UID)
+        i2c_pads = platform.request("i2c_fpga")
+        self.i2c = I2CMaster(i2c_pads, default_dev=True)
+
+        # Led chaser on PMODF (add LED extension board)
+        if with_led_chaser:
+            self.platform.add_extension(raw_pmod_io("pmodf"))
+            self.leds = LedChaser(
+                pads=platform.request("pmodf"),
+                sys_clk_freq=sys_clk_freq,
+            )
+
+    def add_gtp_sfp(self, sfp_id_tx=0, sfp_id_rx=0, gtp_quad_pll=None, linerate=2.5e9, **kwargs):
+        """Adds a GTP transceiver (connected to one of the SFP ports) to the design
+
+        Function can be called multiple times to add multiple transceivers.
+
+        sfp_id_tx / _rx selects the SFP port to connect to (0 - 4)
+
+        gtp_quad_pll can be the `GTPQuadPLL` object to use for clocking or None to internally add one
+
+        linerate is the raw bit-rate in [bits / s] for the internally generated GTPQuadPLL
+            (only used if gtp_quad_pll is None)
+
+        All other keyword arguments are forwarded to the liteiclink.serdes.gtp_7series.GTP object
+
+        returns the GTP object, which is also added as a litex submodule
+
+        Defines the `rx` and `tx` clock-domains.
+        If there are multiple transceivers, the clock domains are called
+        `serdes{i}_rx` and `serdes{i}_tx`, where {i} is the transceiver index
+        """
+        # GTP PLL ----------------------------------------------------------------------------------
+        if gtp_quad_pll is None:
+            if not hasattr(self, "gtp_quad_pll"):
+                self.submodules.gtp_quad_pll = GTPQuadPLL(self.crg.clk125_gtp, 125e6, linerate)
+                print(self.gtp_quad_pll)
+            gtp_quad_pll = self.gtp_quad_pll
+
+        # GTP --------------------------------------------------------------------------------------
+        tx_pads = self.platform.request("sfp_tx", sfp_id_tx)
+        rx_pads = self.platform.request("sfp_rx", sfp_id_rx)
+
+        serdes = GTP(
+            gtp_quad_pll,
+            tx_pads,
+            rx_pads,
+            self.sys_clk_freq,
+            **kwargs,
+        )
+
+        # Add the serdes<N> submodule
+        setattr(self.submodules, f"serdes{self.n_serdes}", serdes)
+        self.n_serdes += 1
+
+        self.platform.add_period_constraint(serdes.cd_tx.clk, 1e9 / serdes.tx_clk_freq)
+        self.platform.add_period_constraint(serdes.cd_rx.clk, 1e9 / serdes.rx_clk_freq)
+        self.platform.add_false_path_constraints(self.crg.cd_sys.clk, serdes.cd_tx.clk, serdes.cd_rx.clk)
+
+        return serdes
+
+
+# ---------------------------
+#  CLI examples
+# ---------------------------
+def main():
+    from litex.build.parser import LiteXArgumentParser
+
+    parser = LiteXArgumentParser(
+        platform=berkeleylab_obsidian.Platform,
+        description="LiteX SoC on LBL Obsidian.",
+    )
+    parser.add_target_argument("--sys-clk-freq", default=125e6, type=float, help="System clock frequency.")
+    parser.add_target_argument("--with-ethernet", action="store_true", help="Enable Ethernet support.")
+    parser.add_target_argument("--with-etherbone", action="store_true", help="Enable Etherbone support.")
+    parser.add_target_argument("--with-rts-reset", action="store_true", help="Connect UART RTS line to sys_clk reset.")
+    parser.add_target_argument("--with-ddr3", action="store_true", help="Add DDR3 dynamic RAM to the SOC")
+    parser.add_target_argument("--with-bist", action="store_true", help="Add DDR3 BIST Generator/Checker.")
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq=args.sys_clk_freq,
+        with_ethernet=args.with_ethernet,
+        with_etherbone=args.with_etherbone,
+        with_rts_reset=args.with_rts_reset,
+        with_ddr3=args.with_ddr3,
+        with_bist=args.with_bist,
+        **parser.soc_argdict,
+    )
+    builder = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Obsidian A35 is a low cost FPGA carrier board with several SFP ports, many PMOD IOs and Arduino shield compatibility.
It was developed as a kind of smart IO extender. It facilitates interfacing ADCs, DACs, sensors, UI elements or other peripherals to a central larger FPGA board or a PC.

The SFP link is daisy chainable and provides high-speed data, timing, ethernet compatibility (to connect directly to a PC) and even galvanic isolation if fibers are used.

The hardware design (Kicad) and documentation will be published on [LBLs github](https://github.com/BerkeleyLab) under the terms of the CERN Open Hardware Licence