### PR TITLE
targets/arrow_axe5000: fix call to Agilex5PLL after litex core changes

### DIFF
--- a/litex_boards/targets/arrow_axe5000.py
+++ b/litex_boards/targets/arrow_axe5000.py
@@ -43,7 +43,7 @@ class _CRG(LiteXModule):
         self.specials += Instance("altera_agilex_config_reset_release_endpoint", o_conf_reset = ninit_done)
 
         # PLL
-        self.pll = pll = Agilex5PLL(speedgrade="-6S")
+        self.pll = pll = Agilex5PLL(platform, speedgrade="-6S")
         self.comb += pll.reset.eq(ninit_done | ~rst_n)
         pll.register_clkin(clk25, 25e6)
         pll.create_clkout(self.cd_sys, sys_clk_freq)


### PR DESCRIPTION
Align with litex pull-request #2334 [1], Agilex5PLL now requires platform reference to correctly produce SDC constraints.

[1] https://github.com/enjoy-digital/litex/pull/2334