### PR TITLE
add Puzhi FPGA Artix-7 A7xxT Development Board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Some of the suported boards, see yours? Give LiteX-Boards a try!
     ├── olimex_gatemate_a1_evb
     ├── opalkelly_xem8320
     ├── pano_logic_g2
+    ├── puzhi_pz_a7xxt_kfb
     ├── qmtech_10cl006
     ├── qmtech_5cefa2
     ├── qmtech_artix7_fbg484

--- a/litex_boards/platforms/puzhi_pz_a7xxt_kfb.py
+++ b/litex_boards/platforms/puzhi_pz_a7xxt_kfb.py
@@ -1,0 +1,313 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Denis Bodor <lefinnois@lefinnois.net>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# PZ-A775T-KFB : https://www.puzhi.com/en/detail/442.html
+# Also available with XC7A35T, XC7A75T, XC7A100T, or XC7A200T core module, the PCIe card is always the same.
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import Xilinx7SeriesPlatform
+from litex.build.openfpgaloader import OpenFPGALoader
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("clk200", 0,
+        Subsignal("p", Pins("R4"), IOStandard("DIFF_SSTL135")),
+        Subsignal("n", Pins("T4"), IOStandard("DIFF_SSTL135"))
+    ),
+    # From chinese PDF tutorial: "the 125MHz clock supplies differential timing for the GTX interface"
+    # But there is no GTX transceivers in Artix-7. It's GTP (GTPE2).
+    # In the same PDF, the package name is also incorrectly used as "FFG484" but it should be "FGG484". So "GTX" may actually mean "GTx".
+    ("clk125", 0,
+        Subsignal("p", Pins("F10")),
+        Subsignal("n", Pins("E10"))
+    ),
+    ("cpu_reset", 0, Pins("R14"), IOStandard("LVCMOS33")),
+
+    # Leds - active high
+    ("user_led", 0, Pins("P15"),  IOStandard("LVCMOS33")),
+    ("user_led", 1, Pins("R16"),  IOStandard("LVCMOS33")),
+    ("user_led", 2, Pins("N13"),  IOStandard("LVCMOS33")),
+    ("user_led", 3, Pins("N14"),  IOStandard("LVCMOS33")),
+    ("user_led", 4, Pins("AA18"), IOStandard("LVCMOS33")),
+
+    # Leds on core module (under heatsink)
+    ("module_led", 0, Pins("P20"), IOStandard("LVCMOS33")),
+    ("module_led", 1, Pins("N15"), IOStandard("LVCMOS33")),
+
+    # Buttons
+    ("user_btn", 0, Pins("AB18"), IOStandard("LVCMOS33")),
+    ("user_btn", 1, Pins("Y18"),  IOStandard("LVCMOS33")),
+    ("user_btn", 2, Pins("Y19"),  IOStandard("LVCMOS33")),
+    ("user_btn", 3, Pins("U17"),  IOStandard("LVCMOS33")),
+    ("user_btn", 4, Pins("U18"),  IOStandard("LVCMOS33")),
+
+    # Serial J4
+    ("serial", 0,
+        Subsignal("tx", Pins("V18")),
+        Subsignal("rx", Pins("V19")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # I2C / AT24C64
+    ("i2c", 0,
+        Subsignal("scl", Pins("E21")),
+        Subsignal("sda", Pins("D21")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # SDCard J5
+    ("spisdcard", 0,
+        Subsignal("clk",  Pins("B20")),
+        Subsignal("cs_n", Pins("A21")),
+        Subsignal("mosi", Pins("E17"), Misc("PULLUP")),
+        Subsignal("miso", Pins("A20"), Misc("PULLUP")),
+        Misc("SLEW=FAST"),
+        IOStandard("LVCMOS33")
+    ),
+    ("sdcard", 0,
+        Subsignal("clk",  Pins("B20")),
+        Subsignal("cmd",  Pins("E17"), Misc("PULLUP True")),
+        Subsignal("data", Pins("A20 B21 F16 A21"), Misc("PULLUP True")),
+        Misc("SLEW=FAST"),
+        IOStandard("LVCMOS33")
+    ),
+
+    # SPIFlash
+    ("flash_cs_n", 0, Pins("T19"), IOStandard("LVCMOS33")),
+    ("flash", 0,
+        Subsignal("mosi", Pins("P22")),
+        Subsignal("miso", Pins("R22")),
+        Subsignal("wp",   Pins("P21")),
+        Subsignal("hold", Pins("R21")),
+        IOStandard("LVCMOS33"),
+    ),
+
+    # DDR3 SDRAM MT41K256M16
+    ("ddram", 0,
+        Subsignal("a", Pins(
+            "AA4 AB2 AA5 AB5 AB1 U3 W1 T1",
+            "V2  U2  Y1  W2  Y2  U1 W5"),
+            IOStandard("SSTL135")),
+        Subsignal("ba",    Pins("AA3 Y3 Y4"), IOStandard("SSTL135")),
+        Subsignal("ras_n", Pins("V4"), IOStandard("SSTL135")),
+        Subsignal("cas_n", Pins("W4"), IOStandard("SSTL135")),
+        Subsignal("we_n",  Pins("AA1"), IOStandard("SSTL135")),
+        Subsignal("cs_n",  Pins("AB3"), IOStandard("SSTL135")),
+        Subsignal("dm",    Pins("D2 G2 M2 M5"),IOStandard("SSTL135")),
+        Subsignal("dq",    Pins(
+            "C2 G1 A1 F3 B2 F1 B1 E2",
+            "H3 G3 H2 H5 J1 J5 K1 H4",
+            "L4 M3 L3 J6 K3 K6 J4 L5",
+            "P1 N4 R1 N2 M6 N5 P6 P2"),
+            IOStandard("SSTL135"),
+            Misc("IN_TERM=UNTUNED_SPLIT_40")),
+        Subsignal("dqs_n", Pins("D1 J2 L1 P4"),
+            IOStandard("DIFF_SSTL135"),
+            Misc("IN_TERM=UNTUNED_SPLIT_40")),
+        Subsignal("dqs_p", Pins("E1 K2 M1 P5"),
+            IOStandard("DIFF_SSTL135"),
+            Misc("IN_TERM=UNTUNED_SPLIT_40")),
+        Subsignal("clk_p", Pins("R3"), IOStandard("DIFF_SSTL135")),
+        Subsignal("clk_n", Pins("R2"), IOStandard("DIFF_SSTL135")),
+        Subsignal("cke",   Pins("T5"), IOStandard("SSTL135")),
+        Subsignal("odt",   Pins("U5"), IOStandard("SSTL135")),
+        Subsignal("reset_n", Pins("W6"), IOStandard("SSTL135")),
+        Misc("SLEW=FAST")
+    ),
+
+    # PCIe
+    ("pcie_x1", 0,
+        Subsignal("rst_n", Pins("A13"), IOStandard("LVCMOS33")),
+        Subsignal("clk_p", Pins("F6")),
+        Subsignal("clk_n", Pins("E6")),
+        Subsignal("rx_p",  Pins("D11")),
+        Subsignal("rx_n",  Pins("C11")),
+        Subsignal("tx_p",  Pins("D5")),
+        Subsignal("tx_n",  Pins("C5")),
+    ),
+    ("pcie_x2", 0,
+        Subsignal("rst_n", Pins("A13"), IOStandard("LVCMOS33")),
+        Subsignal("clk_p", Pins("F6")),
+        Subsignal("clk_n", Pins("E6")),
+        Subsignal("rx_p",  Pins("D11 B8")),
+        Subsignal("rx_n",  Pins("C11 A8")),
+        Subsignal("tx_p",  Pins("D5 B4")),
+        Subsignal("tx_n",  Pins("C5 A4"))
+    ),
+
+    # SFP-1 J12
+    ("sfp", 0,
+        Subsignal("txp", Pins("B6")),
+        Subsignal("txn", Pins("A6")),
+        Subsignal("rxp", Pins("B10")),
+        Subsignal("rxn", Pins("A10")),
+    ),
+    ("sfp_tx_disable", 0, Pins("A14"),  IOStandard("LVCMOS33")),
+
+    # SFP-2 J11
+    ("sfp", 1,
+        Subsignal("txp", Pins("D7")),
+        Subsignal("txn", Pins("C7")),
+        Subsignal("rxp", Pins("D9")),
+        Subsignal("rxn", Pins("C9")),
+    ),
+    ("sfp_tx_disable", 1, Pins("A15"),  IOStandard("LVCMOS33")),
+
+    # RGMII Ethernet (RTL8211F) on core module
+    ("eth_clocks", 0,
+        Subsignal("tx", Pins("N17")),
+        Subsignal("rx", Pins("U20")),
+        IOStandard("LVCMOS33")
+    ),
+    ("eth", 0,
+        Subsignal("rst_n",   Pins("P17")), # marked “reserved” in the manual but used in the sample project (?)
+        Subsignal("mdio",    Pins("T20")),
+        Subsignal("mdc",     Pins("AA19")),
+        Subsignal("rx_ctl",  Pins("AB20")),
+        Subsignal("rx_data", Pins("AA20 AB21 AA21 AB22")),
+        Subsignal("tx_ctl",  Pins("Y21")),
+        Subsignal("tx_data", Pins("V22 W22 W21 Y22")),
+        IOStandard("LVCMOS33")
+    ),
+    # RGMII Ethernet (RTL8211F) on board
+    ("eth_clocks", 1,
+        Subsignal("tx", Pins("M15")),
+        Subsignal("rx", Pins("J19")),
+        IOStandard("LVCMOS33")
+    ),
+    ("eth", 1,
+        Subsignal("rst_n",   Pins("L13")),
+        Subsignal("mdio",    Pins("J17")),
+        Subsignal("mdc",     Pins("N17")),
+        Subsignal("rx_ctl",  Pins("H19")),
+        Subsignal("rx_data", Pins("J14 H14 J20 J21")),
+        Subsignal("tx_ctl",  Pins("M16")),
+        Subsignal("tx_data", Pins("K13 K14 L14 L15")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # HDMI out 0
+    ("hdmi_out", 0,
+        Subsignal("clk_p",   Pins("B17"), IOStandard("TMDS_33")),
+        Subsignal("clk_n",   Pins("B18"), IOStandard("TMDS_33")),
+        Subsignal("data0_p", Pins("B15"), IOStandard("TMDS_33")),
+        Subsignal("data0_n", Pins("B16"), IOStandard("TMDS_33")),
+        Subsignal("data1_p", Pins("D14"), IOStandard("TMDS_33")),
+        Subsignal("data1_n", Pins("D15"), IOStandard("TMDS_33")),
+        Subsignal("data2_p", Pins("D17"), IOStandard("TMDS_33")),
+        Subsignal("data2_n", Pins("C17"), IOStandard("TMDS_33")),
+        Subsignal("scl",     Pins("A18"), IOStandard("LVCMOS33")),
+        Subsignal("sda",     Pins("A19"), IOStandard("LVCMOS33")),
+        Subsignal("hdp",     Pins("D20"), IOStandard("LVCMOS33")),
+        Subsignal("cec",     Pins("F19"), IOStandard("LVCMOS33")),
+        # HDMI1_OUT_EN C20
+    ),
+
+    ("hdmi_out", 1,
+        Subsignal("clk_p",   Pins("E19"), IOStandard("TMDS_33")),
+        Subsignal("clk_n",   Pins("D19"), IOStandard("TMDS_33")),
+        Subsignal("data0_p", Pins("F13"), IOStandard("TMDS_33")),
+        Subsignal("data0_n", Pins("F14"), IOStandard("TMDS_33")),
+        Subsignal("data1_p", Pins("E13"), IOStandard("TMDS_33")),
+        Subsignal("data1_n", Pins("E14"), IOStandard("TMDS_33")),
+        Subsignal("data2_p", Pins("C18"), IOStandard("TMDS_33")),
+        Subsignal("data2_n", Pins("C19"), IOStandard("TMDS_33")),
+        Subsignal("scl",     Pins("C13"), IOStandard("LVCMOS33")),
+        Subsignal("sda",     Pins("B13"), IOStandard("LVCMOS33")),
+        Subsignal("hdp",     Pins("C14"), IOStandard("LVCMOS33")),
+        Subsignal("cec",     Pins("C22"), IOStandard("LVCMOS33")),
+        # HDMI1_OUT_EN C15
+    ),
+]
+
+_connectors = [
+    ("JM1", {
+#         1: VDD_5V,   2: VDD_3V3,
+#         3: GND,      4: GND,
+          5: "G17",    6: "J15",
+          7: "G18",    8: "H15",
+          9: "G15",   10: "K18",
+         11: "G16",   12: "K19",
+         13: "H17",   14: "H20",
+         15: "H18",   16: "G20",
+         17: "J22",   18: "M21",
+         19: "H22",   20: "L21",
+         21: "H13",   22: "L19",
+         23: "G13",   24: "L20",
+         25: "K21",   26: "N22",
+         27: "K22",   28: "M22",
+         29: "L16",   30: "N20",
+         31: "K16",   32: "M20",
+#        33: GND,     34: GND,
+#        35: GND,     36: GND,
+         37: "M18",   38: "N18",
+         39: "L18",   40: "N19",
+    }),
+    ("JM2", {
+#         1: VDD_5V,   2: VDD_3V3,
+#         3: GND,      4: GND,
+          5: "Y16",    6: "T14",
+          7: "AA16",   8: "T15",
+          9: "W15",   10: "U15",
+         11: "W16",   12: "V15",
+         13: "AB16",  14: "V13",
+         15: "AB17",  16: "V14",
+         17: "W14",   18: "W11",
+         19: "Y14",   20: "W12",
+         21: "AA15",  22: "Y13",
+         23: "AB15",  24: "AA14",
+         25: "AA13",  26: "AA10",
+         27: "AB13",  28: "AA11",
+         29: "AB11",  30: "Y11",
+         31: "AB12",  32: "Y12",
+#        33: GND,     34: GND,
+#        35: GND,     36: GND,
+         37: "AA9",   38: "V10",
+         39: "AB10",  40: "W10",
+    })
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(Xilinx7SeriesPlatform):
+    default_clk_name   = "clk200"
+    default_clk_period = 1e9/200e6
+    kgates             = None
+
+    def __init__(self, kgates=75, toolchain="vivado"):
+        assert(kgates in [35, 75, 100, 200], "kgates can only be 35, 75, 100 or 200, representing a XC7A35T, XC7A75T, XC7TA100T, XC7A200T")
+        self.kgates = kgates
+        device = "xc7a200tfbg484-2" if kgates == 200 else f"xc7a{kgates}tfgg484-2"
+        io = _io
+        connectors = _connectors
+
+        Xilinx7SeriesPlatform.__init__(self, device, io, connectors, toolchain=toolchain)
+
+        self.add_platform_command("set_property INTERNAL_VREF 0.750 [get_iobanks 34]")
+        self.add_platform_command("set_property INTERNAL_VREF 0.750 [get_iobanks 35]")
+
+        self.toolchain.bitstream_commands = [
+            "set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]",
+            "set_property BITSTREAM.CONFIG.CONFIGRATE 16 [current_design]",
+            "set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]",
+            "set_property CFGBVS VCCO [current_design]",
+            "set_property CONFIG_VOLTAGE 3.3 [current_design]",
+        ]
+
+    def create_programmer(self):
+        part = "xc7a200tfbg484" if self.kgates == 200 else f"xc7a{self.kgates}tfgg484"
+        return OpenFPGALoader(cable="ft232", fpga_part=part)
+
+    def do_finalize(self, fragment):
+        Xilinx7SeriesPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk200",           loose=True), 1e9/200e6)
+        self.add_period_constraint(self.lookup_request("clk125",           loose=True), 1e9/125e6)
+        self.add_period_constraint(self.lookup_request("eth_clocks:rx", 0, loose=True), 1e9/125e6)
+        self.add_period_constraint(self.lookup_request("eth_clocks:tx", 0, loose=True), 1e9/125e6)
+        self.add_period_constraint(self.lookup_request("eth_clocks:rx", 1, loose=True), 1e9/125e6)
+        self.add_period_constraint(self.lookup_request("eth_clocks:tx", 1, loose=True), 1e9/125e6)

--- a/litex_boards/targets/puzhi_pz_a7xxt_kfb.py
+++ b/litex_boards/targets/puzhi_pz_a7xxt_kfb.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Denis Bodor <lefinnois@lefinnois.net>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# PZ-A775T-KFB : https://www.puzhi.com/en/detail/442.html
+# Also available with XC7A35T, XC7A75T, XC7A100T, or XC7A200T core module, the PCIe card is always the same.
+
+from migen import *
+from litex.gen import *
+
+from litex_boards.platforms import puzhi_pz_a7xxt_kfb
+
+from litex.soc.cores.clock import *
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.video import VideoS7HDMIPHY
+from litex.soc.cores.led import LedChaser
+
+from litedram.modules import MT41K256M16
+from litedram.phy import s7ddrphy
+
+from liteeth.phy.a7_gtp import QPLLSettings, QPLL
+from liteeth.phy.s7rgmii import LiteEthPHYRGMII
+
+from litepcie.phy.s7pciephy import S7PCIEPHY
+from litepcie.software import generate_litepcie_software
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq, toolchain="vivado"):
+        self.rst          = Signal()
+        self.cd_sys       = ClockDomain()
+        self.cd_sys4x     = ClockDomain()
+        self.cd_sys4x_dqs = ClockDomain()
+        self.cd_idelay    = ClockDomain()
+        self.cd_hdmi      = ClockDomain()
+        self.cd_hdmi5x    = ClockDomain()
+
+        # Clk/Rst
+        clk200 = platform.request("clk200")
+        rst    = ~platform.request("cpu_reset")
+
+        # PLL
+        if toolchain == "vivado":
+            self.pll = pll = S7MMCM(speedgrade=-2)
+        else:
+            self.pll = pll = S7PLL(speedgrade=-2)
+        self.comb += pll.reset.eq(rst | self.rst)
+        pll.register_clkin(clk200,           200e6)
+        pll.create_clkout(self.cd_sys,       sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x,     4*sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x_dqs, 4*sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_idelay,    200e6)
+        pll.create_clkout(self.cd_hdmi,      40e6)
+        pll.create_clkout(self.cd_hdmi5x,    5*40e6)
+        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst
+
+        self.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, toolchain="vivado", kgates=75, sys_clk_freq=100e6,
+        with_led_chaser        = True,
+        with_pcie              = False,
+        pcie_lanes             = 2,
+        with_i2c               = False,
+        with_ethernet          = False,
+        with_etherbone         = False,
+        eth_phy                = 0,
+        eth_ip                 = "192.168.1.50",
+        remote_ip              = None,
+        eth_dynamic_ip         = False,
+        with_hdmi              = False,
+        hdmi_port              = 0,
+        with_video_terminal    = False,
+        with_video_framebuffer = False,
+        with_video_colorbars   = False,
+        **kwargs):
+        platform = puzhi_pz_a7xxt_kfb.Platform(kgates=kgates, toolchain=toolchain)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.crg = _CRG(platform, sys_clk_freq, toolchain)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Puzhi PZ-A7{kgates}T-KFB", **kwargs)
+
+        # PCIe -------------------------------------------------------------------------------------  targets/ocp_tap_timecard
+        if with_pcie:
+            if pcie_lanes == 2:
+                self.pcie_phy = S7PCIEPHY(platform, platform.request("pcie_x2"),
+                    data_width = 64,
+                    bar0_size  = 0x20000)
+                platform.toolchain.pre_placement_commands.append("reset_property LOC [get_cells -hierarchical -filter {{NAME=~*gtp_channel.gtpe2_channel_i}}]")
+                platform.toolchain.pre_placement_commands.append("set_property LOC GTPE2_CHANNEL_X0Y5 [get_cells -hierarchical -filter {{NAME=~pcie_s7/*pipe_lane[0].gt_wrapper_i/gtp_channel.gtpe2_channel_i}}]")
+                platform.toolchain.pre_placement_commands.append("set_property LOC GTPE2_CHANNEL_X0Y6 [get_cells -hierarchical -filter {{NAME=~pcie_s7/*pipe_lane[1].gt_wrapper_i/gtp_channel.gtpe2_channel_i}}]")
+            else:
+                self.pcie_phy = S7PCIEPHY(platform, platform.request("pcie_x1"),
+                    data_width = 64,
+                    bar0_size  = 0x20000)
+                platform.toolchain.pre_placement_commands.append("reset_property LOC [get_cells -hierarchical -filter {{NAME=~*gtp_channel.gtpe2_channel_i}}]")
+                platform.toolchain.pre_placement_commands.append("set_property LOC GTPE2_CHANNEL_X0Y5 [get_cells -hierarchical -filter {{NAME=~*gtp_channel.gtpe2_channel_i}}]")
+
+            self.add_pcie(phy=self.pcie_phy, ndmas=1)
+
+            # ICAP (For FPGA reload over PCIe).
+            from litex.soc.cores.icap import ICAP
+            self.icap = ICAP()
+            self.icap.add_reload()
+            self.icap.add_timing_constraints(platform, sys_clk_freq, self.crg.cd_sys.clk)
+
+            # Flash (For SPIFlash update over PCIe).
+            from litex.soc.cores.gpio import GPIOOut
+            from litex.soc.cores.spi_flash import S7SPIFlash
+            self.flash_cs_n = GPIOOut(platform.request("flash_cs_n"))
+            self.flash      = S7SPIFlash(platform.request("flash"), sys_clk_freq, 25e6)
+
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.ddrphy = s7ddrphy.A7DDRPHY(
+                platform.request("ddram"),
+                memtype        = "DDR3",
+                nphases        = 4,
+                sys_clk_freq   = sys_clk_freq)
+            self.add_sdram("sdram",
+                phy           = self.ddrphy,
+                module        = MT41K256M16(sys_clk_freq, "1:4"),
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+
+        # I2C / AT24C64 ----------------------------------------------------------------------------
+        if with_i2c:
+            from litex.soc.cores.bitbang import I2CMaster
+            self.i2c = I2CMaster(platform.request("i2c"))
+            self.add_csr("i2c")
+
+        # Ethernet / Etherbone ---------------------------------------------------------------------
+        if with_ethernet or with_etherbone:
+            self.ethphy = LiteEthPHYRGMII(
+                clock_pads = self.platform.request("eth_clocks", eth_phy),
+                pads       = self.platform.request("eth", eth_phy),
+                tx_delay   = 1.417e-9,
+                rx_delay   = 1.417e-9,
+            )
+            if with_etherbone:
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip, with_ethmac=with_ethernet)
+            elif with_ethernet:
+                self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip, local_ip=eth_ip, remote_ip=remote_ip)
+
+        # HDMI -------------------------------------------------------------------------------------
+        if with_hdmi and (with_video_colorbars or with_video_framebuffer or with_video_terminal):
+            self.videophy = VideoS7HDMIPHY(platform.request("hdmi_out", hdmi_port), clock_domain="hdmi")
+            if with_video_colorbars:
+                self.add_video_colorbars(phy=self.videophy, timings="640x480@60Hz", clock_domain="hdmi")
+            if with_video_terminal:
+                self.add_video_terminal(phy=self.videophy, timings="640x480@60Hz", clock_domain="hdmi")
+            if with_video_framebuffer:
+                self.add_video_framebuffer(phy=self.videophy, timings="640x480@60Hz", clock_domain="hdmi")
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=puzhi_pz_a7xxt_kfb.Platform, description="LiteX SoC on Puzhi PZ-A7xxT-KFB")
+    parser.add_target_argument("--kgates",          default=75,   type=int,    help="Number of kgates. Allowed values: 35, 75, 100, 200, representing XC7A35T, XC7A75T, XC7A100T and XC7A200T")
+    parser.add_target_argument("--flash",           action="store_true",       help="Flash bitstream.")
+    parser.add_target_argument("--sys-clk-freq",    default=100e6, type=float, help="System clock frequency.")
+    parser.add_target_argument("--with-pcie",       action="store_true",       help="Enable PCIe support.")
+    parser.add_target_argument("--pcie-lanes",      default=2, type=int,       help="Number of PCIe lanes (1 or 2).")
+    parser.add_target_argument("--driver",          action="store_true",       help="Generate PCIe driver.")
+    sdopts = parser.target_group.add_mutually_exclusive_group()
+    sdopts.add_argument("--with-spi-sdcard",        action="store_true",       help="Enable SPI-mode SDCard support.")
+    sdopts.add_argument("--with-sdcard",            action="store_true",       help="Enable SDCard support.")
+    parser.add_target_argument("--with-i2c",        action="store_true",       help="Enable I2C support.")
+    parser.add_target_argument("--with-ethernet",   action="store_true",       help="Enable Ethernet support.")
+    parser.add_target_argument("--with-etherbone",  action="store_true",       help="Enable Etherbone support.")
+    parser.add_target_argument("--eth-phy",         default=0, type=int,       help="Ethernet PHY (0 or 1).")
+    parser.add_target_argument("--eth-ip",          default="192.168.1.50",    help="Ethernet/Etherbone IP address.")
+    parser.add_target_argument("--remote-ip",       default="192.168.1.100",   help="Remote IP address of TFTP server.")
+    parser.add_target_argument("--eth-dynamic-ip",  action="store_true",       help="Enable dynamic Ethernet IP addresses setting.")
+    parser.add_argument("--with-hdmi",              action="store_true",       help="Enable HDMI")
+    parser.add_target_argument("--hdmi-port",       default=0, type=int,       help="Ethernet PHY (0 or 1).")
+    viopts = parser.target_group.add_mutually_exclusive_group()
+    viopts.add_argument("--with-video-terminal",    action="store_true",       help="Enable Video Terminal (HDMI).")
+    viopts.add_argument("--with-video-framebuffer", action="store_true",       help="Enable Video Framebuffer (HDMI).")
+    viopts.add_argument("--with-video-colorbars",   action="store_true",       help="Enable Video Colorbars (HDMI).")
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        toolchain              = args.toolchain,
+        kgates                 = args.kgates,
+        sys_clk_freq           = args.sys_clk_freq,
+        with_pcie              = args.with_pcie,
+        pcie_lanes             = args.pcie_lanes,
+        with_i2c               = args.with_i2c,
+        with_ethernet          = args.with_ethernet,
+        with_etherbone         = args.with_etherbone,
+        eth_ip                 = args.eth_ip,
+        remote_ip              = args.remote_ip,
+        eth_dynamic_ip         = args.eth_dynamic_ip,
+        eth_phy                = args.eth_phy,
+        with_hdmi              = args.with_hdmi,
+        hdmi_port              = args.hdmi_port,
+        with_video_terminal    = args.with_video_terminal,
+        with_video_framebuffer = args.with_video_framebuffer,
+        with_video_colorbars   = args.with_video_colorbars,
+        **parser.soc_argdict
+    )
+
+    if args.with_spi_sdcard:
+        soc.add_spi_sdcard()
+    if args.with_sdcard:
+        soc.add_sdcard()
+
+    builder  = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+    if args.driver:
+        generate_litepcie_software(soc, os.path.join(builder.output_dir, "driver"))
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram", ext=".bit"))
+
+    if args.flash:
+        prog = soc.platform.create_programmer()
+        prog.flash(address=0, data_file=builder.get_bitstream_filename(mode="flash", ext=".bit"), unprotect_flash=True)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi,

Here is the support for the PCIe card [PZ-A775T-KFB](https://www.puzhi.com/en/detail/442.html) from Puzhi Electronic Technology.

What has been tested and works:
  * the A775T version of the board (there are also A735T, A7100T, and A7200T versions. The board is the same, only the core module changes),
  * DDR3 memory,
  * onboard serial interface,
  * LedChaser,
  * the two Ethernet interfaces,
  * both HDMI connectors in output mode,
  * SD card (SPI and SD-mode),
  * each of the I/O pins on both 40-pin connectors,
  * i2c interface (with AT24C64 onboard)
  * PCIe interface.

What has not been tested:
  * SFP sockets.

```
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2025 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Oct  4 2025 17:18:41
 BIOS CRC passed (87681f19)

 LiteX git sha1: 863a2b14f

--=============== SoC ==================--
CPU:            VexRiscv @ 100MHz
BUS:            wishbone 32-bit @ 4GiB
CSR:            32-bit data big ordering
ROM:            128.0KiB
SRAM:           8.0KiB
L2:             8.0KiB
SDRAM:          1.0GiB 32-bit @ 800MT/s (CL-7 CWL-5)
MAIN-RAM:       1.0GiB

--========== Initialization ============--
Ethernet init...
Local IP: 192.168.0.4

Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Read leveling:
  m0, b00: |00000000000000000000000000000000| delays: -
  m0, b01: |00000000000000000000000000000000| delays: -
  m0, b02: |11111111111100000000000000000000| delays: 05+-05
  m0, b03: |00000000000000011111111111111000| delays: 21+-06
  m0, b04: |00000000000000000000000000000000| delays: -
  m0, b05: |00000000000000000000000000000000| delays: -
  m0, b06: |00000000000000000000000000000000| delays: -
  m0, b07: |00000000000000000000000000000000| delays: -
  best: m0, b03 delays: 21+-06
  m1, b00: |00000000000000000000000000000000| delays: -
  m1, b01: |00000000000000000000000000000000| delays: -
  m1, b02: |11111111111100000000000000000000| delays: 05+-05
  m1, b03: |00000000000000111111111111110000| delays: 21+-06
  m1, b04: |00000000000000000000000000000000| delays: -
  m1, b05: |00000000000000000000000000000000| delays: -
  m1, b06: |00000000000000000000000000000000| delays: -
  m1, b07: |00000000000000000000000000000000| delays: -
  best: m1, b03 delays: 21+-06
  m2, b00: |00000000000000000000000000000000| delays: -
  m2, b01: |00000000000000000000000000000000| delays: -
  m2, b02: |11111111111111000000000000000000| delays: 06+-06
  m2, b03: |00000000000000001111111111111100| delays: 22+-06
  m2, b04: |00000000000000000000000000000000| delays: -
  m2, b05: |00000000000000000000000000000000| delays: -
  m2, b06: |00000000000000000000000000000000| delays: -
  m2, b07: |00000000000000000000000000000000| delays: -
  best: m2, b03 delays: 22+-06
  m3, b00: |00000000000000000000000000000000| delays: -
  m3, b01: |00000000000000000000000000000000| delays: -
  m3, b02: |11111111111111000000000000000000| delays: 06+-06
  m3, b03: |00000000000000001111111111111110| delays: 23+-06
  m3, b04: |00000000000000000000000000000000| delays: -
  m3, b05: |00000000000000000000000000000000| delays: -
  m3, b06: |00000000000000000000000000000000| delays: -
  m3, b07: |00000000000000000000000000000000| delays: -
  best: m3, b03 delays: 23+-06
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB     
   Read: 0x40000000-0x40200000 2.0MiB     
Memtest OK
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 57.9MiB/s
   Read speed: 62.3MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
Timeout
Booting from network...
Local IP: 192.168.0.4
Remote IP: 192.168.0.55
Booting from boot.json...
Copying hello.bin to 0x40000000... (7120 bytes)
Executing booted program at 0x40000000

--============= Liftoff! ===============--

Blinky blink blink...

malloc buffer (heap)       @ 0x40021D08
zeroed static buffer (bss) @ 0x40001BF4
initialized buffer (stack) @ 0x7FFFFEE0

All buffers RW ok

Press a key to reboot...
```

I hope I didn't go overboard with the options, but I wanted it to be complete ;)
