### PR TITLE
Tang nano 20k hdmi fix

### DIFF
--- a/litex_boards/targets/sipeed_tang_nano_20k.py
+++ b/litex_boards/targets/sipeed_tang_nano_20k.py
@@ -124,10 +124,9 @@ class BaseSoC(SoCCore):
         if with_hdmi:
             self.videophy = VideoGowinHDMIPHY(platform.request("hdmi"), clock_domain="hdmi", true_lvds=True)
             if with_video_terminal:
-                # self.add_video_terminal(phy=self.videophy, timings="800x600@60Hz", clock_domain="hdmi")
                 self.add_video_terminal(phy=self.videophy, timings="640x480@60Hz", clock_domain="hdmi")
             if with_video_colorbars:
-                self.add_video_colorbars(phy=self.videophy, timings="800x600@60Hz", clock_domain="hdmi")
+                self.add_video_colorbars(phy=self.videophy, timings="640x480@60Hz", clock_domain="hdmi")
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:

--- a/litex_boards/targets/sipeed_tang_nano_20k.py
+++ b/litex_boards/targets/sipeed_tang_nano_20k.py
@@ -122,7 +122,7 @@ class BaseSoC(SoCCore):
 
         # Video ------------------------------------------------------------------------------------
         if with_hdmi:
-            self.videophy = VideoGowinHDMIPHY(platform.request("hdmi"), clock_domain="hdmi")
+            self.videophy = VideoGowinHDMIPHY(platform.request("hdmi"), clock_domain="hdmi", true_lvds=True)
             if with_video_terminal:
                 # self.add_video_terminal(phy=self.videophy, timings="800x600@60Hz", clock_domain="hdmi")
                 self.add_video_terminal(phy=self.videophy, timings="640x480@60Hz", clock_domain="hdmi")


### PR DESCRIPTION
This PR fixes two issues with `sipeed_tang_nano_20.py` target related to HDMI:
- unlike some others *sipeed* boards, pairs used for HDMI are true differential. As mentioned in https://github.com/enjoy-digital/litex/pull/2341, a `TLVDS_OBUF` must be used otherwise *apicula* fails. the above mentioned PR has introduces the `true_lvds` CTOR's parameter for `VideoGowinHDMIPHY` to select between primitives. The first commit simply sets this parameter to `True` to uses the good primitive
- Second commit is related to `add_video_colorbars`: HDMI ClockDomain, at `CRG` level, is configured to have a pix_clk == 25MHz, but timings parameter is fixed to `800x600@60Hz` requiring a 40MHz. By switching `timings` to `640x480@60Hz` the colorbars mode is now working.