### PR TITLE
Add support for microphase_a7_lite board

### DIFF
--- a/litex_boards/platforms/microphase_a7_lite.py
+++ b/litex_boards/platforms/microphase_a7_lite.py
@@ -1,0 +1,112 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Victor-zyy <gt7591665@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import XilinxPlatform, VivadoProgrammer
+from litex.build.openocd import OpenOCD
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("clk50",    0, Pins("J19"), IOStandard("LVCMOS33")), #50MHz
+    ("cpu_reset", 0, Pins("L18"), IOStandard("LVCMOS33")),
+
+
+    # Leds
+    ("user_led", 0, Pins("M18"),  IOStandard("LVCMOS33")), #green_led 1
+    ("user_led", 1, Pins("N18"),  IOStandard("LVCMOS33")), #green_led 2
+
+    # Switches
+
+    # Buttons
+    ("user_btn", 0, Pins("AA1"), IOStandard("LVCMOS33")), #KEY1
+    ("user_btn", 1, Pins("W1"), IOStandard("LVCMOS33")),  #KEY2
+
+    # Serial
+    ("serial", 0,
+        Subsignal("tx", Pins("V2")), # connect UART-RX
+        Subsignal("rx", Pins("U2")), # connect UART-TX
+        IOStandard("LVCMOS33")
+    ),
+
+    # SPIFlash
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("T19")),
+        Subsignal("clk",  Pins("L12")),
+        Subsignal("mosi", Pins("P22")),
+        Subsignal("miso", Pins("R22")),
+        Subsignal("wp",   Pins("P21")),
+        Subsignal("hold", Pins("R21")),
+        IOStandard("LVCMOS33"),
+    ),
+    ("spiflash4x", 0,   # dual mode 4 wire
+        Subsignal("cs_n", Pins("L19")),
+        Subsignal("clk",  Pins("L12")),
+        Subsignal("dq",   Pins("P22 R22 P21 R21")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # DDR3 SDRAM
+    ("ddram", 0,
+        Subsignal("a", Pins(
+            "P1 M6 K3 K4 M5 J6 N2 K6",
+            "P2 L1 M2 P6 L4 L5 N5"), #256Mbyte 4Gbits DDR3
+            IOStandard("SSTL15")),
+        Subsignal("ba",    Pins("J4 R1 M1"), IOStandard("SSTL15")),
+        Subsignal("ras_n", Pins("M3"), IOStandard("SSTL15")),
+        Subsignal("cas_n", Pins("N3"), IOStandard("SSTL15")),
+        Subsignal("we_n",  Pins("L6"), IOStandard("SSTL15")),
+        Subsignal("dm", Pins("E2 H3"), IOStandard("SSTL15")),
+        Subsignal("dq", Pins(
+            "B2 F1 B1 D2 C2 F3 A1 G1",
+            "J5 G2 K1 G3 H2 H5 J1 H4"),
+            IOStandard("SSTL15"),
+            Misc("IN_TERM=UNTUNED_SPLIT_40")),
+        Subsignal("dqs_p", Pins("E1 K2"),IOStandard("DIFF_SSTL15")),
+        Subsignal("dqs_n", Pins("D1 J2"),IOStandard("DIFF_SSTL15")),
+        Subsignal("clk_p", Pins("P5"), IOStandard("DIFF_SSTL15")),
+        Subsignal("clk_n", Pins("P4"), IOStandard("DIFF_SSTL15")),
+        Subsignal("cke",   Pins("N4"), IOStandard("SSTL15")),
+        Subsignal("odt",   Pins("L3"), IOStandard("SSTL15")),
+        Subsignal("reset_n", Pins("F4"), IOStandard("SSTL15")),
+        Misc("SLEW=FAST"),
+    ),
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = [
+    ("pmoda", "W21 W22 N17 P17 P19 R19 R18 T18 T21 U21 U22 V22 Y21 Y22 AA20 AA21 AB21 AB22 AA19 AB20 U20 V20 Y18"),
+    ("pmodb", "Y19 W19 W20 AA18 AB18 V18 V19 V17 W17 U17 U18 P14 R14 P16 R17 N13 N14 P15 R16 AB7 AB6"),
+    ("pmodc", "F13 F14 E13 E14 D14 D15 E16 D16 D17 C17 C13 B13 A13 A14 C14 C15 A15 A16 B15 B16 F16 E17 A18"),
+    ("pmodd", "A19 B17 B18 B20 A20 F19 F20 E19 D19 C18 C19 F18 E18 D20 C20 B21 A21 D21 G21 C22 B22"),
+]
+
+# PMODS --------------------------------------------------------------------------------------------
+
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(XilinxPlatform):
+    default_clk_name   = "clk50"
+    default_clk_period = 1e9/50e6
+
+    def __init__(self):
+        XilinxPlatform.__init__(self, "xc7a200t-fbg484-2", _io, _connectors, toolchain="vivado")
+        self.toolchain.bitstream_commands = \
+            ["set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]"]
+        self.toolchain.additional_commands = \
+            ["write_cfgmem -force -format bin -interface spix4 -size 16 "
+             "-loadbit \"up 0x0 {build_name}.bit\" -file {build_name}.bin"]
+        self.add_platform_command("set_property INTERNAL_VREF 0.750 [get_iobanks 35]")
+
+    def create_programmer(self):
+        return VivadoProgrammer(flash_part="is25lp128f-spi-x1_x2_x4");
+
+    def do_finalize(self, fragment):
+        XilinxPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)

--- a/litex_boards/targets/microphase_a7_lite.py
+++ b/litex_boards/targets/microphase_a7_lite.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Victor-zyy <gt7591665@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Note: For now, with --toolchain=yosys+nextpnr, DDR3 should be disabled and sys_clk_freq lowered, ex:
+# python3 -m litex_boards.targets.digilent_arty.py --sys-clk-freq=50e6 --integrated-main-ram-size=8192 --toolchain=yosys+nextpnr --build
+
+from migen import *
+
+from litex_boards.platforms import microphase_a7_lite
+from litex.build.xilinx.vivado import vivado_build_args, vivado_build_argdict
+
+from litex.soc.cores.clock import *
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+from litex.soc.cores.gpio import GPIOTristate
+
+from litedram.modules import MT41K256M16
+from litedram.phy import s7ddrphy
+
+from liteeth.phy.mii import LiteEthPHYMII
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst = Signal()
+        self.clock_domains.cd_sys       = ClockDomain()
+        self.clock_domains.cd_sys4x     = ClockDomain()
+        self.clock_domains.cd_sys4x_dqs = ClockDomain()
+        self.clock_domains.cd_idelay    = ClockDomain()
+
+
+        # # #
+        self.stop   = Signal();
+        self.reset  = Signal();
+        # Clk/Rst.
+        clk50  = platform.request("clk50")
+        rst_n  = platform.request("cpu_reset")
+
+        # PLL.
+        self.submodules.pll = pll = S7MMCM(speedgrade=-1) #for vivado speedgrade -2 -1 for test demo -2 is the real speed grade
+        self.comb += pll.reset.eq(~rst_n | self.rst)
+        pll.register_clkin(clk50, 50e6) # input 50MHz
+        pll.create_clkout(self.cd_sys, sys_clk_freq)
+        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
+        pll.create_clkout(self.cd_sys4x,     4*sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x_dqs, 4*sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_idelay,    200e6)
+
+        # IdelayCtrl.
+        self.submodules.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=int(100e6), 
+        with_led_chaser     = True,
+        with_spi_flash      = False,
+        **kwargs):
+        platform = microphase_a7_lite.Platform()
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Microphase_A7_Lite", **kwargs)
+
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.submodules.ddrphy = s7ddrphy.A7DDRPHY(platform.request("ddram"),
+                memtype        = "DDR3",
+                nphases        = 4,
+                sys_clk_freq   = sys_clk_freq)
+            self.add_sdram("sdram",
+                phy           = self.ddrphy,
+                module        = MT41K256M16(sys_clk_freq, "1:4"),
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+
+        if with_spi_flash:
+            from litespi.modules import IS25LP128
+            from litespi.opcodes import SpiNorFlashOpCodes as Codes
+            self.add_spi_flash(mode="4x", module=IS25LP128(Codes.READ_1_1_4), rate="1:2", with_master=True)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    from litex.soc.integration.soc import LiteXSoCArgumentParser
+    parser = LiteXSoCArgumentParser(description="LiteX SoC on microphase_a7_lite(200T)")
+    target_group = parser.add_argument_group(title="Target options")
+    parser.add_target_argument("--flash",              action="store_true",help="Flash bitstream.")
+    target_group.add_argument("--toolchain",           default="vivado",                 help="FPGA toolchain (vivado, symbiflow or yosys+nextpnr).")
+    target_group.add_argument("--build",               action="store_true",              help="Build design.")
+    target_group.add_argument("--load",                action="store_true",              help="Load bitstream.")
+    target_group.add_argument("--sys-clk-freq",        default=100e6,                    help="System clock frequency.")
+    builder_args(parser)
+    soc_core_args(parser)
+    vivado_build_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq   = int(float(args.sys_clk_freq)),
+        **soc_core_argdict(args)
+    )
+
+    builder = Builder(soc, **parser.builder_argdict)
+
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+    if args.flash:
+        prog = soc.platform.create_programmer()
+        prog.flash(0, builder.get_bitstream_filename(mode="flash"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi, I am victor-zyy. I just add two configurations for microphase_a7_lite board, it is a FPGA board company from china. And the FPGA is xc7a200Tfbg484-2. The VexRiscv was tested ok on that board with DDR memory and I also tested the CFU-PlayGround on that board.
<img width="779" height="527" alt="Microphase_a7_lite_board" src="https://github.com/user-attachments/assets/d212c40a-84a0-455a-b5e9-b57459745e02" />
