### PR TITLE
targets/lambdaconcept_ecpix5.py: added usb_acm support with explicit uart_pads

### DIFF
--- a/litex_boards/targets/lambdaconcept_ecpix5.py
+++ b/litex_boards/targets/lambdaconcept_ecpix5.py
@@ -91,7 +91,11 @@ class BaseSoC(SoCCore):
         self.crg = _CRG(platform, sys_clk_freq)
 
         # SoCCore ----------------------------------------------------------------------------------
-        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on ECPIX-5", **kwargs)
+        SoCCore.__init__(self, platform, sys_clk_freq,
+            uart_pads = {True: platform.request("ulpi"), False: None}[kwargs["uart_name"] == "usb_acm"],
+            ident     = "LiteX SoC on ECPIX-5",
+            **kwargs
+        )
 
         # DDR3 SDRAM -------------------------------------------------------------------------------
         if not self.integrated_main_ram_size:


### PR DESCRIPTION
Fix the recent `luna_cdc_acm` update it's possible to uses `d_p/d_n` pins for USB ACM but now ULPI PHY is supported.
The ECPIX5 board has an onboard USB3300 but resources is called `ulpi` instead of default `usb`.
This PR updates the target to fix `SocCore` `uart_pads` parameters with None when `uart_name != "usb_acm"` or pass pads explicitely