### PR TITLE
targets: Update bitstream extension for Sipeed Tang Primer (TD 5.0)

### DIFF
--- a/litex_boards/targets/sipeed_tang_primer.py
+++ b/litex_boards/targets/sipeed_tang_primer.py
@@ -80,7 +80,7 @@ def main():
 
     if args.flash:
         prog = soc.platform.create_programmer()
-        prog.load_bitstream(builder.get_bitstream_filename(mode="flash", ext=".bin")) # FIXME
+        prog.load_bitstream(builder.get_bitstream_filename(mode="flash", ext=".bit")) # FIXME
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Hi,

When I tried to run the command:

```
python3 -m litex_boards.targets.sipeed_tang_primer --flash
```

It returned an error as the latest version of TD has changed the bitstream format from `bin` to `bit`:

```
openFPGALoader --board licheeTang --bitstream ./build/sipeed_tang_primer/gateware/sipeed_tang_primer.bin
Jtag frequency : requested 6000000Hz -> real 6000000Hz
Error: Failed to claim FPGA device: incompatible file format
```

By changing the file extension from `.bin` to `.bit` for the flash mode bitstream:

```
openFPGALoader --board licheeTang --bitstream ./build/sipeed_tang_primer/gateware/sipeed_tang_primer.bit
Jtag frequency : requested 6000000Hz -> real 6000000Hz
Parse file header end
DONE
```