### PR TITLE
Fix platform colorlight_i9+ (spi_flash data width, sdram clock phase,…

### DIFF
--- a/litex_boards/platforms/colorlight_i9plus.py
+++ b/litex_boards/platforms/colorlight_i9plus.py
@@ -3,6 +3,10 @@
 #
 # Copyright (c) 2023 Charles-Henri Mousset <ch.mousset@gmail.com>
 # SPDX-License-Identifier: BSD-2-Clause
+#
+# ColorLight i9+ Module and Ext-Board with onboard CH347 jtag usb-c interface are available on AliExpress
+# see https://github.com/wuxx/Colorlight-FPGA-Projects/blob/master/colorlight_i9plus_v6.1.md
+#     https://www.aliexpress.com/item/1005007847728268.html
 
 from litex.build.generic_platform import *
 from litex.build.xilinx import Xilinx7SeriesPlatform
@@ -16,6 +20,8 @@ _io = [
 
     # Leds.
     ("user_led", 0, Pins("A18"), IOStandard("LVCMOS33")),
+    # (Ext-Board, socket P2, pin 26: WS2812 DOUT)
+    ("serial_rgb_led_dout", 0, Pins("T3"), IOStandard("LVCMOS33")),
 
     # RGMII Ethernet (B50612D) PHY 0.
     ("eth_clocks", 0, # U5 is SDIO phy #0
@@ -33,6 +39,7 @@ _io = [
         Subsignal("tx_data", Pins("B2 B1 C2 D2")),
         IOStandard("LVCMOS33")
     ),
+
     # RGMII Ethernet (B50612D) PHY 1.
     ("eth_clocks", 1, # U9 is SDIO phy #1
         Subsignal("tx", Pins("M6")),
@@ -49,6 +56,7 @@ _io = [
         Subsignal("tx_data", Pins("M5 M2 N4 P4")),
         IOStandard("LVCMOS33")
     ),
+
     # SDRRAM (M12L64322A).
     ("sdram_clock", 0, Pins("E14"), IOStandard("LVCMOS33")),
     ("sdram", 0,
@@ -69,7 +77,23 @@ _io = [
         Subsignal("ba",    Pins("D19 B13")),
         #Subsignal("dm",   Pins("")), # GND
         IOStandard("LVCMOS33"),
-        Misc("SLEWRATE=FAST")
+        Misc("SLEW=FAST")
+    ),
+
+    # Serial
+    # (Ext-Board, P2 conn., pin 23,25 : RX,TX)
+    ("serial", 0,
+        Subsignal("tx", Pins("R2")),
+        Subsignal("rx", Pins("T4")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # SPIFlash (1 bit SPI, clk is provided by USRMCLK like ColorLight-i5)
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("T19")),
+        Subsignal("mosi", Pins("P22")),
+        Subsignal("miso", Pins("R22")),
+        IOStandard("LVCMOS33"),
     ),
 ]
 
@@ -120,12 +144,8 @@ class Platform(Xilinx7SeriesPlatform):
 
     def __init__(self, toolchain="vivado"):
         Xilinx7SeriesPlatform.__init__(self, "xc7a50tfgg484-1", _io, _connectors, toolchain=toolchain)
-        self.toolchain.bitstream_commands = \
-            ["set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]"]
-        self.toolchain.additional_commands = \
-            ["write_cfgmem -force -format bin -interface spix4 -size 16 "
-             "-loadbit \"up 0x0 {build_name}.bit\" -file {build_name}.bin"]
-
+        self.toolchain.bitstream_commands = ["set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 1 [current_design]"]
+        #self.toolchain.additional_commands = ["write_cfgmem -force -format bin -interface spix1 -size 16 " "-loadbit \"up 0x0 {build_name}.bit\" -file {build_name}.bin"]
 
     def create_programmer(self):
         return OpenFPGALoader(cable="ch347_jtag")

--- a/litex_boards/targets/colorlight_i9plus.py
+++ b/litex_boards/targets/colorlight_i9plus.py
@@ -14,11 +14,12 @@
 # J3: TDI
 # J4: TMS
 # J5: TCK
+#
+# ColorLight i9+ Module and Ext-Board with onboard CH347 jtag usb-c interface are available on AliExpress
+# see https://github.com/wuxx/Colorlight-FPGA-Projects/blob/master/colorlight_i9plus_v6.1.md
+#     https://www.aliexpress.com/item/1005007847728268.html
+# use openFPGALoader -c ch347_jtag file.bit (-f)
 
-# wuxx's extension board's JTAG isn't compatible with the i9+ headers.
-# The extension board's pogopins must be isolated to avoid shorts.
-# However, is provides PMOD-compatible headers and the ethernet IOs are compatible.
-# See https://github.com/wuxx/Colorlight-FPGA-Projects#ext-board for more infos.
 
 from migen import *
 
@@ -29,9 +30,12 @@ from litex.build.io import DDROutput
 from litex_boards.platforms import colorlight_i9plus
 
 from litex.soc.cores.clock import *
+from litex.soc.integration.soc import SoCRegion
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
-from litex.soc.cores.led import LedChaser
+from litex.soc.cores.led import LedChaser, WS2812
+from litex.soc.cores.gpio import GPIOIn, GPIOTristate
+from litex.soc.cores.xadc import XADC
 from litex.soc.cores.dna  import DNA
 
 from litedram.modules import M12L64322A
@@ -62,26 +66,29 @@ class _CRG(LiteXModule):
         pll.create_clkout(self.cd_idelay,    200e6)
         platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
         if with_dram:
-            pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=90) # untested
+            pll.create_clkout(self.cd_sys_ps, sys_clk_freq, phase=27) #some errors with 90, fine with 45
             # SDRAM clock
             sdram_clk = ClockSignal("sys_ps")
             self.specials += DDROutput(1, 0, platform.request("sdram_clock"), sdram_clk)
 
         self.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
 
+
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
     def __init__(self, toolchain="vivado", sys_clk_freq=100e6,
         with_dna        = False,
+        with_xadc       = False,
         with_pmod_uart  = False,
         with_ethernet   = False,
         with_etherbone  = False,
         eth_port        = 0,
         eth_ip          = "192.168.1.50",
-        remote_ip       = None,
+        remote_ip       = "192.168.1.100",
         eth_dynamic_ip  = False,
         with_led_chaser = True,
+        with_rgb_led    = False,
         with_spi_flash  = False,
         **kwargs):
         platform = colorlight_i9plus.Platform(toolchain=toolchain)
@@ -95,7 +102,11 @@ class BaseSoC(SoCCore):
         self.crg  = _CRG(platform, sys_clk_freq, with_dram)
 
         # SoCCore ----------------------------------------------------------------------------------
-        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Arty A7", **kwargs)
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on ColorLight-i9+", **kwargs)
+
+        # XADC -------------------------------------------------------------------------------------
+        if with_xadc:
+            self.xadc = XADC()
 
         # DNA --------------------------------------------------------------------------------------
         if with_dna:
@@ -112,22 +123,23 @@ class BaseSoC(SoCCore):
                 l2_cache_size = kwargs.get("l2_size", 8192)
             )
 
+
         # Ethernet / Etherbone ---------------------------------------------------------------------
         if with_ethernet or with_etherbone:
             self.ethphy = LiteEthPHYRGMII(
                 clock_pads = self.platform.request("eth_clocks", eth_port),
                 pads       = self.platform.request("eth", eth_port),
                 tx_delay = 0)
-            if with_etherbone:
-                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip, with_ethmac=with_ethernet)
             if with_ethernet:
-                self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip, local_ip=eth_ip, remote_ip=remote_ip)
+                self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip)
+            if with_etherbone:
+                self.add_etherbone(phy=self.ethphy, ip_address=eth_ip)
 
         # SPI Flash --------------------------------------------------------------------------------
         if with_spi_flash:
             from litespi.modules import MX25L12833F
             from litespi.opcodes import SpiNorFlashOpCodes as Codes
-            self.add_spi_flash(mode="4x", module=MX25L12833F(Codes.READ_1_1_4), rate="1:2", with_master=True)
+            self.add_spi_flash(mode="1x", module=MX25L12833F(Codes.READ_1_1_1))
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:
@@ -136,23 +148,35 @@ class BaseSoC(SoCCore):
                 sys_clk_freq = sys_clk_freq,
             )
 
+        # RGB Led ----------------------------------------------------------------------------------
+        if with_rgb_led:
+            self.rgb_led = WS2812(
+                    pad = platform.request("serial_rgb_led_dout"),
+                    nleds = 8,
+                    sys_clk_freq = sys_clk_freq
+            )
+            self.bus.add_slave(name="rgb_led", slave=self.rgb_led.bus, region=SoCRegion(origin = 0x2000_0000, size=4*8))
+
+
 # Build --------------------------------------------------------------------------------------------
 
 def main():
     from litex.build.parser import LiteXArgumentParser
-    parser = LiteXArgumentParser(platform=colorlight_i9plus.Platform, description="LiteX SoC on Colorlight i9+.")
+    parser = LiteXArgumentParser(platform=colorlight_i9plus.Platform, description="LiteX SoC on Arty A7.")
     parser.add_target_argument("--flash",          action="store_true",       help="Flash bitstream.")
     parser.add_target_argument("--sys-clk-freq",   default=100e6, type=float, help="System clock frequency.")
     parser.add_target_argument("--with-dna",       action="store_true",       help="Enable 7-Series DNA.")
-    parser.add_target_argument("--with-pmod-uart", action="store_true",       help="Enable uart on P2 (top) PMOD")
+    parser.add_target_argument("--with-xadc",      action="store_true",       help="Enable 7-Series XADC.")
+    parser.add_target_argument("--with-rgb-led",   action="store_true",       help="Enable WS2812 RGB Led on Ext-Board conn. P2, pin 15")
+    parser.add_target_argument("--with-pmod-uart", action="store_true",       help="Enable uart on ExtBoard conn. P2, pins 23=Rx,25=Tx")
     ethopts = parser.target_group.add_mutually_exclusive_group()
-    ethopts.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support.")
-    ethopts.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support.")
-    parser.add_target_argument("--eth-port",       default=0, type=int,     help="Ethernet port to use (0/1)")
-    parser.add_target_argument("--eth-ip",         default="192.168.1.50",  help="Ethernet/Etherbone IP address.")
-    parser.add_target_argument("--remote-ip",      default="192.168.1.100", help="Remote IP address of TFTP server.")
-    parser.add_target_argument("--eth-dynamic-ip", action="store_true",     help="Enable dynamic Ethernet IP assignment.")
-    parser.add_target_argument("--with-spi-flash", action="store_true",     help="Enable memory-mapped SPI flash.")
+    ethopts.add_argument("--with-ethernet",        action="store_true",       help="Enable Ethernet support.")
+    ethopts.add_argument("--with-etherbone",       action="store_true",       help="Enable Etherbone support.")
+    parser.add_target_argument("--eth-port",       default=0, type=int,       help="Ethernet port to use (0/1)")
+    parser.add_target_argument("--eth-ip",         default="192.168.1.50",    help="Ethernet/Etherbone IP address.")
+    parser.add_target_argument("--remote-ip",      default="192.168.1.100",   help="Remote IP address of TFTP server.")
+    parser.add_target_argument("--eth-dynamic-ip", action="store_true",       help="Enable dynamic Ethernet IP addresses setting.")
+    parser.add_target_argument("--with-spi-flash", action="store_true",       help="Enable SPI Flash (MMAPed).")
     args = parser.parse_args()
 
     assert not (args.with_etherbone and args.eth_dynamic_ip)
@@ -161,6 +185,8 @@ def main():
         toolchain      = args.toolchain,
         sys_clk_freq   = args.sys_clk_freq,
         with_dna       = args.with_dna,
+        with_xadc      = args.with_xadc,
+        with_rgb_led   = args.with_rgb_led,
         with_pmod_uart = args.with_pmod_uart,
         with_ethernet  = args.with_ethernet,
         with_etherbone = args.with_etherbone,


### PR DESCRIPTION
… Vivado params), add spi_flash, PMOD UART and WS2812 led bar on Ext-Board

I bought a Colorlight i9+ Module (Artix7 with SDRAM form factor) and his Ext-Board on AliExpress.
Tried Litex with Vivado 2025.2.1 without success.
Target and Platform files has to be modified to work:

 -The onboard bitstream flash is 1 bit width (1x, not 4x), and clk is provided by USRMCLK (like on ColorLight i5)
 -SDRAM phase was 90 degree and was not reliable (bus errors). 27 degree seems optimal, VexRiscV softcore works now up to 120MHz !
 -Added UART on ExtBoard P2 connector
 -Added WS2812 data port on ExtBoard P2 connector
 -Ethernet and Etherbone tested on RJ45 plugs connected to ExtBoard P1 connector.
 -Added DNA and XADC target parameters
 -Updated some comments in code
