### PR TITLE
brisbaneSilicon BRS-100 GW1NR9

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Some of the supported boards, see yours? Give LiteX-Boards a try!
     ├── berkeleylab_marble
     ├── berkeleylab_obsidian
     ├── bochenjingxin_kintex7_basec
+    ├── brisbaneSilicon_brs_100_gw1nr9
     ├── camlink_4k
     ├── colognechip_gatemate_evb
     ├── colorlight_5a_75x

--- a/docs/boards_inventory.md
+++ b/docs/boards_inventory.md
@@ -37,6 +37,7 @@ python3 .github/scripts/generate_board_inventory.py --write
 | `berkeleylab_marble` | berkeleylab_marble | vivado | `125000000.0` | Ethernet, Etherbone | included |
 | `berkeleylab_obsidian` | berkeleylab_obsidian | vivado | `125000000.0` | Ethernet, Etherbone | included |
 | `bochenjingxin_kintex7_basec` | bochenjingxin_kintex7_basec | vivado | `125000000.0` | - | included |
+| `brisbaneSilicon_brs_100_gw1nr9` | brisbaneSilicon_brs_100_gw1nr9 | gowin | `27000000.0` | - | included |
 | `camlink_4k` | camlink_4k | trellis | `81000000.0` | - | included |
 | `colognechip_gatemate_evb` | colognechip_gatemate_evb | colognechip | `24000000.0` | SDCard, SPI SDCard, SPI Flash | included |
 | `colorlight_5a_75x` | colorlight_5a_75b, colorlight_5a_75e, colorlight_i5a_907 | trellis | `60000000.0` | Ethernet, Etherbone, SPI Flash | included |

--- a/litex_boards/platforms/brisbaneSilicon_brs_100_gw1nr9.py
+++ b/litex_boards/platforms/brisbaneSilicon_brs_100_gw1nr9.py
@@ -1,0 +1,80 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2026 Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+from litex.build.generic_platform import *
+from litex.build.gowin.platform import GowinPlatform
+from litex.build.openfpgaloader import OpenFPGALoader
+
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk / Rst
+    ("clk27", 0, Pins("52"), IOStandard("LVCMOS33"), Misc("PULL_MODE=UP")),
+
+    # Leds
+    ("user_led_n", 0, Pins("16"), Misc("PULL_MODE=UP DRIVE=8")),
+    ("user_led_n", 1, Pins("15"), Misc("PULL_MODE=UP DRIVE=8")),
+    ("user_led_n", 2, Pins("14"), Misc("PULL_MODE=UP DRIVE=8")),
+    ("user_led_n", 3, Pins("13"), Misc("PULL_MODE=UP DRIVE=8")),
+    ("user_led_n", 4, Pins("11"), Misc("PULL_MODE=UP DRIVE=8")),
+    ("user_led_n", 5, Pins("10"), Misc("PULL_MODE=UP DRIVE=8")),
+
+    # Buttons
+    ("user_btn_n", 0, Pins("3"), Misc("PULL_MODE=UP")),
+    ("user_btn_n", 1, Pins("4"), Misc("PULL_MODE=UP")),
+
+    # Serial
+    ("serial", 0,
+        Subsignal("rx", Pins("18"), Misc("PULL_MODE=UP")),
+        Subsignal("tx", Pins("17"), Misc("PULL_MODE=UP DRIVE=8")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # SPIFlash
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("60"), Misc("PULL_MODE=UP DRIVE=8")),
+        Subsignal("clk",  Pins("59"), Misc("PULL_MODE=UP DRIVE=8")),
+        Subsignal("miso", Pins("62"), Misc("PULL_MODE=UP")),
+        Subsignal("mosi", Pins("61"), Misc("PULL_MODE=UP DRIVE=8")),
+        IOStandard("LVCMOS33"),
+    ),
+
+    # PSRAM
+    ("O_psram_ck",      0, Pins(2)),
+    ("O_psram_ck_n",    0, Pins(2)),
+    ("O_psram_cs_n",    0, Pins(2)),
+    ("O_psram_reset_n", 0, Pins(2)),
+    ("IO_psram_dq",     0, Pins(16)),
+    ("IO_psram_rwds",   0, Pins(2)),
+]
+
+# Connectors ---------------------------------------------------------------------------------------
+
+_connectors = [
+    ["J5", "25 26 27 28 29 30 33 34 35 36 37 38 39 40 41 42"],
+    ["J6", "77 76 75 74 73 72 71 70 69 68 57 56 55 54 53 51"],
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(GowinPlatform):
+    default_clk_name   = "clk27"
+    default_clk_period = 1e9/27e6
+
+    def __init__(self, toolchain="gowin"):
+        GowinPlatform.__init__(self, "GW1NR-LV9QN88PC7/I6", _io, _connectors, toolchain=toolchain, devicename="GW1NR-9C")
+        self.toolchain.options["use_mspi_as_gpio"] = 1
+        self.toolchain.options["use_sspi_as_gpio"] = 1
+
+    def create_programmer(self):
+        return OpenFPGALoader("brs-100-gw1nr9")
+
+    def do_finalize(self, fragment):
+        GowinPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk27", loose=True), 1e9/27e6)

--- a/litex_boards/targets/brisbaneSilicon_brs_100_gw1nr9.py
+++ b/litex_boards/targets/brisbaneSilicon_brs_100_gw1nr9.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2026 Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+from migen import *
+
+from litex.gen import *
+
+from litex_boards.platforms import brisbaneSilicon_brs_100_gw1nr9
+
+from litex.soc.cores.clock.gowin_gw1n import GW1NPLL
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+
+from litex.soc.cores.hyperbus import HyperRAM
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst    = Signal()
+        self.cd_sys = ClockDomain()
+
+        # # #
+
+        # Clk / Rst
+        clk27 = platform.request("clk27")
+        rst_n = platform.request("user_btn_n", 0)
+
+        # PLL
+        self.pll = pll = GW1NPLL(devicename=platform.devicename, device=platform.device)
+        self.comb += pll.reset.eq(~rst_n)
+        pll.register_clkin(clk27, 27e6)
+        pll.create_clkout(self.cd_sys, sys_clk_freq)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, toolchain="gowin", sys_clk_freq=27e6, bios_flash_offset=0x0,
+        with_led_chaser = True,
+        **kwargs):
+        platform = brisbaneSilicon_brs_100_gw1nr9.Platform(toolchain=toolchain)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.crg = _CRG(platform, sys_clk_freq)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        # Disable Integrated ROM.
+        kwargs["integrated_rom_size"] = 0
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on BrisbaneSilicon BRS-100-GW1NR9", **kwargs)
+
+        # SPI Flash --------------------------------------------------------------------------------
+        from litespi.modules import P25Q32H
+        from litespi.opcodes import SpiNorFlashOpCodes as Codes
+        self.add_spi_flash(mode="1x", module=P25Q32H(Codes.READ_1_1_1), with_master=False)
+
+        # Add ROM linker region --------------------------------------------------------------------
+        self.bus.add_region("rom", SoCRegion(
+            origin = self.bus.regions["spiflash"].origin + bios_flash_offset,
+            size   = 64 * KILOBYTE,
+            linker = True)
+        )
+        self.cpu.set_reset_address(self.bus.regions["rom"].origin)
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.leds = LedChaser(
+                pads         = platform.request_all("user_led_n"),
+                sys_clk_freq = sys_clk_freq)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=brisbaneSilicon_brs_100_gw1nr9.Platform, description="LiteX SoC on BrisbaneSilicon BRS-100-GW1NR9.")
+    parser.add_target_argument("--flash",             action="store_true",      help="Flash bitstream and BIOS.")
+    parser.add_target_argument("--sys-clk-freq",      default=27e6, type=float, help="System clock frequency.")
+    parser.add_target_argument("--bios-flash-offset", default="0x0",            help="BIOS offset in SPI Flash.")
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        toolchain         = args.toolchain,
+        sys_clk_freq      = args.sys_clk_freq,
+        bios_flash_offset = int(args.bios_flash_offset, 0),
+        **parser.soc_argdict
+    )
+
+    builder = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+    if args.flash:
+        prog = soc.platform.create_programmer()
+        prog.flash(0, builder.get_bitstream_filename(mode="flash", ext=".fs"))
+        prog.flash(int(args.bios_flash_offset, 0), builder.get_bios_filename(), external=True)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The [brisbaneSilicon](https://brisbanesilicon.com.au) [BRS-100-GW1NR9](https://brisbanesilicon.com.au/brs-100-gw1nr9/) is a board based on Gowin GW1NR9 with a Feather form factor and
- 6 leds
- 2 buttons
- 1 FTDI used for both JTAG configuration and UART
- 2 x 16 IOs
- 4MB SPI Flash

Requires [litespi PR for SPI Flash support](https://github.com/litex-hub/litespi/pull/99)