### PR TITLE
targets/terasic_atum_a3_nano.py: added with_phy_reset = False in LiteEthAgilexPHYRGMII constructor call

### DIFF
--- a/litex_boards/targets/terasic_atum_a3_nano.py
+++ b/litex_boards/targets/terasic_atum_a3_nano.py
@@ -16,7 +16,7 @@ from litex.build.io import DDROutput
 from litex_boards.platforms import terasic_atum_a3_nano
 
 from litex.soc.integration.soc      import *
-from litex.soc.integration.soc import *
+from litex.soc.integration.soc      import *
 from litex.soc.integration.builder  import *
 
 from litex.soc.cores.bitbang import I2CMaster
@@ -147,10 +147,11 @@ class BaseSoC(SoCCore):
         # Ethernet / Etherbone ---------------------------------------------------------------------
         if with_eth:
             self.ethphy = LiteEthAgilexPHYRGMII(
-                platform   = platform,
-                clock_pads = platform.request("eth_clocks"),
-                pads       = platform.request("eth"),
-                ref_tx_clk = ClockSignal("eth"),
+                platform       = platform,
+                clock_pads     = platform.request("eth_clocks"),
+                pads           = platform.request("eth"),
+                ref_tx_clk     = ClockSignal("eth"),
+                with_phy_reset = False,
             )
 
             if with_etherbone:


### PR DESCRIPTION
When netboot is automatically executed at boot time first TX ARP sequence is never received by host computer/tftp server.
The RGMII phy seems requiring long delay after reset to be ready/stable.
This commit adds `with_phy_reset = False` to avoid reseting the PHY at boot time.

This PR requires https://github.com/enjoy-digital/liteeth/pull/203