### PR TITLE
terasic_de10nano: Add Cyclone V HPS (cyclonev_hps) CPU support

### DIFF
--- a/litex_boards/targets/terasic_de10nano.py
+++ b/litex_boards/targets/terasic_de10nano.py
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 # Cyclone V HPS (MiSTer) use:
-# ./terasic_de10nano.py --cpu-type=cyclonev_hps --build [--with-mister-sdram]
+# ./terasic_de10nano.py --cpu-type=cyclonev_hps --build [--with-mister-sdram] [--with-f2h-sdram]
 # Copy the bitstream to the MiSTer and load it:
 #  scp build/terasic_de10nano/gateware/terasic_de10nano.rbf root@<mister-ip>:/media/fat/litex.rbf
 #  ssh root@<mister-ip> "echo load_core /media/fat/litex.rbf > /dev/MiSTer_cmd"
@@ -76,6 +76,7 @@ class BaseSoC(SoCCore):
         with_mister_sdram          = True,
         with_mister_video_terminal = False,
         with_h2f_bridge            = False,
+        with_f2h_sdram             = False,
         sdram_rate                 = "1:1",
         **kwargs):
         platform = terasic_de10nano.Platform()
@@ -104,6 +105,19 @@ class BaseSoC(SoCCore):
             # H2F Bridge (LiteX bus/Fabric SDRAM visible to the ARM at 0xc000_0000).
             if with_h2f_bridge or with_mister_sdram:
                 self.bus.add_master(name="h2f", master=self.cpu.add_axi_h2f_master())
+            # F2SDRAM Port 1 (64-bit): first 256MB of HPS DDR3 visible on the LiteX bus at
+            # 0xd000_0000 (non-coherent with the ARM caches; useful for Fabric DMAs and as a
+            # F2SDRAM smoke test from the ARM through the H2F bridge).
+            if with_f2h_sdram:
+                from litex.soc.interconnect.avalon import Wishbone2AvalonMM
+                f2h_sdram_region = SoCRegion(origin=0xd000_0000, size=256 * MEGABYTE)
+                self.f2h_sdram = Wishbone2AvalonMM(
+                    data_width           = 64,
+                    avalon_address_width = 29,
+                    avalon_base_address  = f2h_sdram_region.origin >> 3,
+                )
+                self.comb += self.f2h_sdram.w2a_avl.connect(self.cpu.add_fpga2sdram_port(n=1))
+                self.bus.add_slave(name="f2h_sdram", slave=self.f2h_sdram.w2a_wb, region=f2h_sdram_region)
 
         # SDR SDRAM --------------------------------------------------------------------------------
         if with_mister_sdram and not self.integrated_main_ram_size:
@@ -135,6 +149,7 @@ def main():
     parser.add_target_argument("--with-mister-sdram",          action="store_true",      help="Enable SDRAM with MiSTer expansion board.")
     parser.add_target_argument("--with-mister-video-terminal", action="store_true",      help="Enable Video Terminal with Mister expansion board.")
     parser.add_target_argument("--with-h2f-bridge",            action="store_true",      help="Enable H2F bridge (with cyclonev_hps CPU).")
+    parser.add_target_argument("--with-f2h-sdram",             action="store_true",      help="Enable F2SDRAM port (with cyclonev_hps CPU).")
     parser.add_target_argument("--sdram-rate",                 default="1:1",            help="SDRAM Rate (1:1 Full Rate or 1:2 Half Rate).")
     args = parser.parse_args()
 
@@ -143,6 +158,7 @@ def main():
         with_mister_sdram          = args.with_mister_sdram,
         with_mister_video_terminal = args.with_mister_video_terminal,
         with_h2f_bridge            = args.with_h2f_bridge,
+        with_f2h_sdram             = args.with_f2h_sdram,
         sdram_rate                 = args.sdram_rate,
         **parser.soc_argdict
     )

--- a/litex_boards/targets/terasic_de10nano.py
+++ b/litex_boards/targets/terasic_de10nano.py
@@ -4,6 +4,7 @@
 # This file is part of LiteX-Boards.
 #
 # Copyright (c) 2020 Paul Sajna <sajattack@gmail.com>
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
@@ -16,6 +17,7 @@ from litex_boards.platforms import terasic_de10nano
 
 from litex.soc.cores.clock import CycloneVPLL
 from litex.soc.integration.soc import *
+from litex.soc.integration.soc import SoCRegion
 from litex.soc.integration.builder import *
 from litex.soc.cores.video import VideoVGAPHY
 from litex.soc.cores.led import LedChaser
@@ -65,6 +67,7 @@ class BaseSoC(SoCCore):
         with_led_chaser            = True,
         with_mister_sdram          = True,
         with_mister_video_terminal = False,
+        with_h2f_bridge            = False,
         sdram_rate                 = "1:1",
         **kwargs):
         platform = terasic_de10nano.Platform()
@@ -73,7 +76,26 @@ class BaseSoC(SoCCore):
         self.crg = _CRG(platform, sys_clk_freq, with_sdram=with_mister_sdram, sdram_rate=sdram_rate)
 
         # SoCCore ----------------------------------------------------------------------------------
+        if kwargs.get("cpu_type", None) == "cyclonev_hps":
+            kwargs["with_uart"]            = False # Console is on HPS UART0 (Linux on MiSTer).
+            kwargs["integrated_sram_size"] = 0     # SRAM region is in HPS DDR3 (Linker-only).
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on DE10-Nano", **kwargs)
+
+        # Cyclone V HPS Integration ----------------------------------------------------------------
+        if kwargs.get("cpu_type", None) == "cyclonev_hps":
+            # HPS DDR3 Regions (Linker-only, enable BIOS compilation as on Zynq targets).
+            self.bus.add_region("sram", SoCRegion(
+                origin = self.cpu.mem_map["sram"],
+                size   = 15 * MEGABYTE,
+            ))
+            self.bus.add_region("rom", SoCRegion(
+                origin = self.cpu.mem_map["rom"],
+                size   = 8 * MEGABYTE,
+                linker = True,
+            ))
+            # H2F Bridge (LiteX bus/Fabric SDRAM visible to the ARM at 0xc000_0000).
+            if with_h2f_bridge or with_mister_sdram:
+                self.bus.add_master(name="h2f", master=self.cpu.add_axi_h2f_master())
 
         # SDR SDRAM --------------------------------------------------------------------------------
         if with_mister_sdram and not self.integrated_main_ram_size:
@@ -104,6 +126,7 @@ def main():
     parser.add_target_argument("--sys-clk-freq",               default=50e6, type=float, help="System clock frequency.")
     parser.add_target_argument("--with-mister-sdram",          action="store_true",      help="Enable SDRAM with MiSTer expansion board.")
     parser.add_target_argument("--with-mister-video-terminal", action="store_true",      help="Enable Video Terminal with Mister expansion board.")
+    parser.add_target_argument("--with-h2f-bridge",            action="store_true",      help="Enable H2F bridge (with cyclonev_hps CPU).")
     parser.add_target_argument("--sdram-rate",                 default="1:1",            help="SDRAM Rate (1:1 Full Rate or 1:2 Half Rate).")
     args = parser.parse_args()
 
@@ -111,6 +134,7 @@ def main():
         sys_clk_freq               = args.sys_clk_freq,
         with_mister_sdram          = args.with_mister_sdram,
         with_mister_video_terminal = args.with_mister_video_terminal,
+        with_h2f_bridge            = args.with_h2f_bridge,
         sdram_rate                 = args.sdram_rate,
         **parser.soc_argdict
     )

--- a/litex_boards/targets/terasic_de10nano.py
+++ b/litex_boards/targets/terasic_de10nano.py
@@ -7,6 +7,14 @@
 # Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+# Cyclone V HPS (MiSTer) use:
+# ./terasic_de10nano.py --cpu-type=cyclonev_hps --build [--with-mister-sdram]
+# Copy the bitstream to the MiSTer and load it:
+#  scp build/terasic_de10nano/gateware/terasic_de10nano.rbf root@<mister-ip>:/media/fat/litex.rbf
+#  ssh root@<mister-ip> "echo load_core /media/fat/litex.rbf > /dev/MiSTer_cmd"
+# LiteX CSRs are then accessible from the HPS at 0xff20_0000 (addresses in csr.csv), ex:
+#  devmem <ctrl_scratch_addr> -> 0x12345678.
+
 from migen import *
 
 from litex.gen import *


### PR DESCRIPTION
Companion PR to enjoy-digital/litex#2496 (Intel Cyclone V HPS hardcore CPU support).

Allow building the DE10-Nano/MiSTer SoC with `--cpu-type=cyclonev_hps`:
- The HPS becomes the SoC's CPU through the H2F LW bridge (CSRs at `0xff20_0000`).
- LiteX UART disabled (console is on HPS UART0, running Linux on MiSTer).
- sram/rom regions mapped to HPS DDR3 (Linker-only, enables BIOS compilation as on Zynq targets).
- The MiSTer SDRAM (when enabled) is made visible to the ARM at `0xc000_0000` through the H2F bridge (also exposed via `--with-h2f-bridge`).
- `--with-f2h-sdram`: first 256MB of HPS DDR3 exposed on the LiteX bus at `0xd000_0000` through F2SDRAM Port 1 (64-bit Avalon-MM) and the new `Wishbone2AvalonMM` bridge — useful for Fabric DMAs and as a F2SDRAM smoke test from the ARM (reading `0xd000_0000` from the HPS returns the DDR3 content at `0x0000_0000`).
- MiSTer build/load/test instructions documented at the top of the target.

The softcore path is unchanged.

**Tested:** full Quartus 23.1 builds (with and without `--with-f2h-sdram`): 0 errors, `.rbf` produced, HPS bridge/F2SDRAM atoms placed/routed; BIOS compiled with `arm-none-eabi-gcc`. Hardware bring-up on a MiSTer is the next step:
```
./terasic_de10nano.py --cpu-type=cyclonev_hps --with-mister-sdram --with-f2h-sdram --build
scp build/terasic_de10nano/gateware/terasic_de10nano.rbf root@<mister-ip>:/media/fat/litex.rbf
ssh root@<mister-ip> "echo load_core /media/fat/litex.rbf > /dev/MiSTer_cmd"
ssh root@<mister-ip> "devmem 0xff200004" # ctrl_scratch -> 0x12345678
ssh root@<mister-ip> "devmem 0xd0000000" # HPS DDR3 @ 0x0 through F2SDRAM
```
