### PR TITLE
litex_boards/targets/sipeed_tang_nano_9k.py: set Ibex platform regfile option to fpga

### DIFF
--- a/litex_boards/targets/sipeed_tang_nano_9k.py
+++ b/litex_boards/targets/sipeed_tang_nano_9k.py
@@ -65,6 +65,11 @@ class BaseSoC(SoCCore):
         **kwargs):
         platform = sipeed_tang_nano_9k.Platform(toolchain=toolchain)
 
+        # This GW1NR-9 is tight on LUTs, so build Ibex (when selected) with its
+        # distributed-RAM register file instead of the default flip-flop one,
+        # which overflows the part. Ignored by every other CPU.
+        platform.ibex_regfile = "fpga"
+
         # CRG --------------------------------------------------------------------------------------
         self.crg = _CRG(platform, sys_clk_freq, with_video_pll=with_video_terminal)
 


### PR DESCRIPTION
This change pairs with the recent upstream change in LiteX itself: https://github.com/enjoy-digital/litex/pull/2510

It selects Ibex's FPGA (distributed-RAM) register file on the resource-constrained GW1NR-9 so the CPU fits. Only applies specifically to the Ibex CPU on the Sipeed Tang Nano 9K (GW1NR-9), no other chip and/or board.