### PR TITLE
Add multiple fix and improvement for alibaba vu13p board

### DIFF
--- a/litex_boards/platforms/alibaba_vu13p.py
+++ b/litex_boards/platforms/alibaba_vu13p.py
@@ -369,14 +369,14 @@ _io = [
             ),
             IOStandard("POD12_DCI")),
         Subsignal("dq", Pins(
-            "AY26 BB26 BA27 AY28 AW28 BB27 AY27 BA28",  # 0-7
+            "AY26 BB26 AY28 BA27 AW28 BB27 AY27 BA28",  # 0-7
             "AM16 AM19 AP19 AM20 AN16 AL20 AN19 AL19",  # 8-15
             "BE25 BE28 BF25 BF27 BC27 BD28 BC26 BE27",  # 16-23
             "AV18 AW18 AW19 AY18 AW20 BA18 AV19 AY20",  # 24-31
             "BC13 BF15 BD14 BE16 BC14 BD15 BE15 BD16",  # 32-39
             "AR28 AU27 AT27 AV27 AR27 AT28 AU26 AV28",  # 40-47
             "AR18 AT18 AU17 AR20 AP20 AU20 AP18 AT20",  # 48-55
-            "BB19 BE19 BC17 BF18 BB17 BD18 BC18 BF19",  # 56-63
+            "BB19 BE18 BC17 BF18 BB17 BD18 BC18 BF19",  # 56-63
             # ECC: "AL25 AP28 AN27 AM27 AM25 AL28 AN28 AL27", # 64-71
             ),
             IOStandard("POD12_DCI"),

--- a/litex_boards/platforms/alibaba_vu13p.py
+++ b/litex_boards/platforms/alibaba_vu13p.py
@@ -206,7 +206,8 @@ _io = [
         Subsignal("act_n", Pins("A22"), IOStandard("SSTL12_DCI")),
         Subsignal("dm", Pins(
             "P13 L13 N17 L17 G14 D13 H19 D19", # 0-7
-            "R21"), # 8
+            # ECC: "R21", # 8
+            ),
             IOStandard("POD12_DCI")),
         Subsignal("dq", Pins(
             "L14 P15 M14 P14 M16 R15 N16 N14",  # 0-7
@@ -217,19 +218,22 @@ _io = [
             "B16 A14 A17 C14 C16 B14 B17 A13",  # 40-47
             "E20 F17 G20 F19 F20 G19 E21 F18",  # 48-55
             "C21 A19 B21 A20 D21 B19 B20 D20",  # 56-63
-            "N22 P23 M22 P25 M24 R25 M25 N23"), # 64-71
+            # ECC: "N22 P23 M22 P25 M24 R25 M25 N23", # 64-71
+            ),
             IOStandard("POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_p", Pins(
             "R16 H17 P19 J21 G17 B15 E18 D18", # 0-7
-            "P24"), # 8
+            # ECC: "P24", # 8
+            ),
             IOStandard("DIFF_POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_n", Pins(
             "P16 H16 N19 H21 G16 A15 E17 C18", # 0-7
-            "N24"), # 8
+            # ECC: "N24", # 8
+            ),
             IOStandard("DIFF_POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
@@ -255,7 +259,8 @@ _io = [
         Subsignal("act_n", Pins("A28"), IOStandard("SSTL12_DCI")),
         Subsignal("dm", Pins(
             "E40 C36 M31 B34 H37 G30 U34 R30", # 0-7
-            "T28"), # 8
+            # ECC: "T28", # 8
+            ),
             IOStandard("POD12_DCI")),
         Subsignal("dq", Pins(
             "D39 C39 B40 A40 E38 D38 E39 C38",  # 0-7
@@ -266,19 +271,22 @@ _io = [
             "H32 E32 G31 F32 H31 E33 G32 F33",  # 40-47
             "V31 U32 U31 T32 T30 T33 U30 R33",  # 48-55
             "R32 N32 N31 N34 R31 P31 N33 P34",  # 56-63
-            "T27 R27 T26 R26 P28 N28 P26 N26"), # 64-71
+            # ECC: "T27 R27 T26 R26 P28 N28 P26 N26", # 64-71
+            ),
             IOStandard("POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_p", Pins(
             "B39 B36 K30 A32 H36 J33 V32 M34", # 0-7
-            "P29"), # 8
+            # ECC: "P29", # 8
+            ),
             IOStandard("DIFF_POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_n", Pins(
             "A39 B37 J30 A33 G36 H33 V33 L34", # 0-7
-            "N29"), # 8
+            # ECC: "N29", # 8
+            ),
             IOStandard("DIFF_POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
@@ -304,7 +312,8 @@ _io = [
         Subsignal("act_n", Pins("Y31"), IOStandard("SSTL12_DCI")),
         Subsignal("dm", Pins(
             "AJ27 AT33 AW29 AP31 BF39 BC34 BA34 BC31", # 0-7
-            "BF32"), # 8
+            # ECC: "BF32", # 8
+            ),
             IOStandard("POD12_DCI")),
         Subsignal("dq", Pins(
             "AK31 AG29 AJ30 AJ31 AJ29 AJ28 AK28 AG30",  # 0-7
@@ -315,19 +324,22 @@ _io = [
             "BE35 BB36 BE36 BA35 BD35 BB35 BD36 BC36",  # 40-47
             "AY35 AW34 AY36 AV34 AY33 AV33 BA33 AW33",  # 48-55
             "BB29 AY31 AY30 BB31 BA29 AY32 BA30 BB30",  # 56-63
-            "BE30 BE31 BF30 BE32 BD29 BD33 BC29 BE33"), # 64-71
+            # ECC: "BE30 BE31 BF30 BE32 BD29 BD33 BC29 BE33", # 64-71
+            ),
             IOStandard("POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_p", Pins(
             "AH28 AN32 AU29 AM29 BD40 BB37 AW35 BA32", # 0-7
-            "BD30"), # 8
+            # ECC: "BD30", # 8
+            ),
             IOStandard("DIFF_POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_n", Pins(
             "AH29 AN33 AV29 AM30 BE40 BC37 AW36 BB32", # 0-7
-            "BD31"), # 8
+            # ECC: "BD31", # 8
+            ),
             IOStandard("DIFF_POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
@@ -353,7 +365,8 @@ _io = [
         Subsignal("act_n", Pins("AR13"), IOStandard("SSTL12_DCI")),
         Subsignal("dm", Pins(
             "BA25 AN18 BF28 AY17 BF14 AV26 AT19 BE17", # 0-7
-            "AP25"), # 8
+            # ECC: "AP25", # 8
+            ),
             IOStandard("POD12_DCI")),
         Subsignal("dq", Pins(
             "AY26 BB26 BA27 AY28 AW28 BB27 AY27 BA28",  # 0-7
@@ -364,19 +377,22 @@ _io = [
             "AR28 AU27 AT27 AV27 AR27 AT28 AU26 AV28",  # 40-47
             "AR18 AT18 AU17 AR20 AP20 AU20 AP18 AT20",  # 48-55
             "BB19 BE19 BC17 BF18 BB17 BD18 BC18 BF19",  # 56-63
-            "AL25 AP28 AN27 AM27 AM25 AL28 AN28 AL27"), # 64-71
+            # ECC: "AL25 AP28 AN27 AM27 AM25 AL28 AN28 AL27", # 64-71
+            ),
             IOStandard("POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_p", Pins(
             "AW25 AL17 BD26 AV21 BD13 AR25 AR17 BC19", # 0-7
-            "AM26"), # 8
+            # ECC: "AM26", # 8
+            ),
             IOStandard("DIFF_POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),
         Subsignal("dqs_n", Pins(
             "AY25 AM17 BE26 AW21 BE13 AT25 AT17 BD19", # 0-7
-            "AN26"), # 8
+            # ECC: "AN26", # 8
+            ),
             IOStandard("DIFF_POD12_DCI"),
             Misc("PRE_EMPHASIS=RDRV_240"),
             Misc("EQUALIZATION=EQ_LEVEL2")),

--- a/litex_boards/targets/alibaba_vu13p.py
+++ b/litex_boards/targets/alibaba_vu13p.py
@@ -104,7 +104,6 @@ class BaseSoC(SoCCore):
 
         if kwargs.get("uart_name", "serial") == "serial":
             if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "crossover"
-        kwargs["with_jtagbone"] = True
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Alibaba VU13P", **kwargs)

--- a/litex_boards/targets/alibaba_vu13p.py
+++ b/litex_boards/targets/alibaba_vu13p.py
@@ -48,7 +48,7 @@ class _CRG(LiteXModule):
         self.cd_eth    = ClockDomain()
         self.cd_idelay = ClockDomain()
 
-        self.pll = pll = USMMCM(speedgrade=-2)
+        self.pll = pll = USPMMCM(speedgrade=-2)
         self.comb += pll.reset.eq(self.rst)
         pll.register_clkin(platform.request("clk400", 0), 400e6)
         pll.create_clkout(self.cd_pll4x, sys_clk_freq*4, buf=None, with_reset=False)

--- a/litex_boards/targets/alibaba_vu13p.py
+++ b/litex_boards/targets/alibaba_vu13p.py
@@ -129,6 +129,16 @@ class BaseSoC(SoCCore):
             self.pcie_phy = USPPCIEPHY(platform, platform.request(f"pcie_x{pcie_lanes}"),
                 data_width = {4: 128, 8: 256, 16: 512}[pcie_lanes],
                 bar0_size  = 0x20000)
+            self.pcie_phy.update_config({
+                "mode_selection"           : "Advanced",
+                "en_gt_selection"          : "true",
+                "select_quad"              : "GTY_Quad_227",
+                "pcie_blk_locn"            : "X0Y1",
+                "gen_x0y0"                 : "false",
+                "gen_x0y1"                 : "true",
+                "REF_CLK_FREQ"             : "100_MHz",
+                "PL_DISABLE_LANE_REVERSAL" : "TRUE",
+            })
             self.add_pcie(
                 phy              = self.pcie_phy,
                 ndmas            = pcie_ndmas,


### PR DESCRIPTION
This patch include some fix and improvement for running latest latex:
1. Comment all the DDR ECC pin as it is not supported and fix the wrong DDR pin of this board
2. Use USPMMCM as it is ultrascale plus.
3. Only add jtagbone when requested (it is not needed when using PCIe)
4. Add some necessary configuration for the PCIe PHY

Note: ~The timing of this board is still tight when enabling PCIe, I guess some improvement may be required~ With 150Mhz, I think the timing is acceptable.

Running Log:
```
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2026 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Jul 11 2026 16:57:11
 BIOS CRC passed (f5e8089e)

 LiteX git sha1: 274c1dff8

--================ SoC =================--
CPU:		VexiiRiscv (rv64i2p0_mafdch_zca_zihpm_zaamo_zalrsc_sstc_smaia_zcd_zicntr_zicsr_sscsrind_ssaia_zifencei_zicbom_smcsrind) @ 200MHz
BUS:		wishbone 32-bit data/32-bit addr
CSR:		32-bit data big ordering
ROM:		128.0KiB
SRAM:		8.0KiB
SDRAM:		4.0GiB 64-bit @ 1600MT/s (CL-11 CWL-9)
MAIN RAM:	1.0GiB

--=========== Initialization ===========--
Ethernet init...
Local IP: 192.168.1.50
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Write leveling:
  tCK equivalent taps: 368
  Cmd/Clk scan (0-184)
  |111  |111111111  |111111111  |111111111| best: 79
  Setting Cmd/Clk delay to 79 taps.
  Data scan:
  m0: |111111111100000000000011111| delay: 00
  m1: |011111111110000000000000111| delay: 06
  m2: |111111100000000000001111111| delay: 00
  m3: |111111100000000000001111111| delay: 00
  m4: |111100000000000001111111111| delay: 265
  m5: |111110000000000000111111111| delay: 287
  m6: |100000000000001111111111100| delay: 213
  m7: |100000000000001111111111100| delay: 218
Write latency calibration:
m0:6 m1:6 m2:6 m3:6 m4:0 m5:0 m6:0 m7:0 
Read leveling:
  m0, b04: |11000000000000000000000000000000| 
  m0, b05: |00000011111110000000000000000000| 
  m0, b06: |00000000000000000111111100000000| 
  m0, b07: |00000000000000000000000000000111| 
  best: m0, b05 delays: 137+-55
  m1, b04: |11110000000000000000000000000000| 
  m1, b05: |00000001111111100000000000000000| 
  m1, b06: |00000000000000000011111111000000| 
  m1, b07: |00000000000000000000000000000011| 
  best: m1, b05 delays: 165+-64
  m2, b04: |11111100000000000000000000000000| 
  m2, b05: |00000000001111111000000000000000| 
  m2, b06: |00000000000000000000011111111000| 
  best: m2, b06 delays: 394+-64
  m3, b04: |11111000000000000000000000000000| 
  m3, b05: |00000000001111111000000000000000| 
  m3, b06: |00000000000000000000011111110000| 
  best: m3, b05 delays: 203+-57
  m4, b04: |11111111000000000000000000000000| 
  m4, b05: |00000000000111111100000000000000| 
  m4, b06: |00000000000000000000001111111100| 
  best: m4, b05 delays: 225+-57
  m5, b04: |00111111100000000000000000000000| 
  m5, b05: |00000000000001111111100000000000| 
  m5, b06: |00000000000000000000000011111111| 
  best: m5, b05 delays: 259+-61
  m6, b04: |00111111110000000000000000000000| 
  m6, b05: |00000000000000111111100000000000| 
  m6, b06: |00000000000000000000000001111111| 
  best: m6, b04 delays: 91+-62
  m7, b04: |00011111111000000000000000000000| 
  m7, b05: |00000000000000011111110000000000| 
  m7, b06: |00000000000000000000000000011111| 
  best: m7, b04 delays: 106+-60
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB     
   Read: 0x40000000-0x40200000 2.0MiB     
Memtest OK
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 182.1MiB/s
   Read speed: 216.6MiB/s
--============== Console ===============--

litex> eth_mac_addr 10:e2:d5:00:00:00
MAC address: 10:e2:d5:00:00:00
Local IP: 192.168.1.50
litex> eth_remote_ip 192.168.1.151
Remote IP: 192.168.1.151
litex> eth_local_ip 192.168.1.50
Local IP: 192.168.1.50
Local IP: 192.168.1.50
litex> ping 192.168.1.1
32 bytes from 192.168.1.1: icmp_seq=1
litex> netboot
Booting from network...
Local IP: 192.168.1.50
Remote IP: 192.168.1.151
Booting from boot.json...
Copying Image to 0x40200000... ##########################(27565056 bytes)
Copying soc.dtb to 0x45800000... (5234 bytes)
Copying initramfs.cpio to 0x43000000... ##################################(36491776 bytes)
Copying fw_jump.bin to 0x40000000... (276744 bytes)
Executing booted program at 0x40000000

--============== Liftoff! ==============--

OpenSBI v1.8.1-38-g6d5b2b9b
   ____                    _____ ____ _____
  / __ \                  / ____|  _ \_   _|
 | |  | |_ __   ___ _ __ | (___ | |_) || |
 | |  | | '_ \ / _ \ '_ \ \___ \|  _ < | |
 | |__| | |_) |  __/ | | |____) | |_) || |_
  \____/| .__/ \___|_| |_|_____/|____/_____|
        | |
        |_|

Platform Name               : alibaba_vu13p
Platform Features           : medeleg
Platform HART Count         : 4
Platform HART Protection    : ---
Platform IPI Device         : aia-imsic
Platform Timer Device       : aclint-mtimer @ 100000000Hz
Platform Console Device     : litex_uart
Platform HSM Device         : ---
Platform PMU Device         : ---
Platform Reboot Device      : ---
Platform Shutdown Device    : ---
Platform Suspend Device     : ---
Platform CPPC Device        : ---
Firmware Base               : 0x40000000
Firmware Size               : 357 KB
Firmware RW Offset          : 0x40000
Firmware RW Size            : 101 KB
Firmware Heap Offset        : 0x4d000
Firmware Heap Size          : 49 KB (total), 0 KB (reserved), 13 KB (used), 34 KB (free)
Firmware Scratch Size       : 4096 B (total), 1528 B (used), 2568 B (free)
Runtime SBI Version         : 3.0
Standard SBI Extensions     : time,rfnc,ipi,base,hsm,pmu,dbcn,fwft,legacy,sse
Experimental SBI Extensions : none

Domain0 Name                : root
Domain0 Boot HART           : 0
Domain0 HARTs               : 0x0*,0x1*,0x2*,0x3*
Domain0 Region00            : 0x0000000040040000-0x000000004005ffff M: (F,R,W) S/U: ()
Domain0 Region01            : 0x0000000040000000-0x000000004003ffff M: (F,R,X) S/U: ()
Domain0 Region02            : 0x00000000f0010000-0x00000000f001ffff M: (I,R,W) S/U: ()
Domain0 Region03            : 0x00000000f0c00000-0x00000000f0dfffff M: (I,R,W) S/U: ()
Domain0 Region04            : 0x00000000f1000000-0x00000000f11fffff M: (I,R,W) S/U: ()
Domain0 Region05            : 0x0000000000000000-0xffffffffffffffff M: () S/U: (R,W,X)
Domain0 Next Address        : 0x0000000040200000
Domain0 Next Arg1           : 0x0000000042200000
Domain0 Next Mode           : S-mode
Domain0 SysReset            : yes
Domain0 SysSuspend          : yes

Boot HART ID                : 0
Boot HART Domain            : root
Boot HART Priv Version      : v1.12
Boot HART Base ISA          : rv64imafdch
Boot HART ISA Extensions    : smaia,sstc,zicntr,zihpm,zicbom,sdtrig,smcsrind,sscsrind
Boot HART PMP Count         : 0
Boot HART PMP Granularity   : 0 bits
Boot HART PMP Address Bits  : 0
Boot HART MHPM Info         : 0 (0x00000000)
Boot HART Debug Triggers    : 0 triggers
Boot HART MIDELEG           : 0x0000000000001666
Boot HART MEDELEG           : 0x0000000000f0b509
[    0.000000] Booting Linux on hartid 0
[    0.000000] Linux version 7.2.0-rc1-00015-gfed4b361a176 (inochi@inochi.infowork) (clang version 22.1.8, LLD 22.1.8) #2 SMP PREEMPT Sat Jul 11 13:19:06 CST 2026
[    0.000000] Machine model: alibaba_vu13p
[    0.000000] SBI specification v3.0 detected
[    0.000000] SBI implementation ID=0x1 Version=0x10008
[    0.000000] SBI TIME extension detected
[    0.000000] SBI IPI extension detected
[    0.000000] SBI RFENCE extension detected
[    0.000000] SBI DBCN extension detected
[    0.000000] SBI FWFT extension detected
[    0.000000] earlycon: liteuart0 at I/O port 0x0 (options '')
[    0.000000] Malformed early option 'console'
[    0.000000] printk: debug: ignoring loglevel setting.
[    0.000000] efi: UEFI not found.
[    0.000000] earlycon: liteuart0 at MMIO 0x00000000f0001000 (options '115200n8')
[    0.000000] printk: legacy bootconsole [liteuart0] enabled
[    0.000000] OF: reserved mem: 0x0000000040000000..0x000000004003ffff (256 KiB) nomap non-reusable mmode_resv1@40000000
[    0.000000] OF: reserved mem: 0x0000000040040000..0x000000004005ffff (128 KiB) nomap non-reusable mmode_resv0@40040000
[    0.000000] SBI HSM extension detected
[    0.000000] riscv: base ISA extensions acdfhim
[    0.000000] riscv: ELF capabilities acdfim
[    0.000000] Ticket spinlock: enabled
[    0.000000] Zone ranges:
[    0.000000]   DMA32    [mem 0x0000000040000000-0x000000007fffffff]
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x000000004005ffff]
[    0.000000]   node   0: [mem 0x0000000040060000-0x000000007fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000007fffffff]
[    0.000000] percpu: Embedded 31 pages/cpu s88152 r8192 d30632 u126976
[    0.000000] pcpu-alloc: s88152 r8192 d30632 u126976 alloc=31*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3 
[    0.000000] Kernel command line: console=liteuart,115200n8 earlycon ignore_loglevel
[    0.000000] printk: log buffer data + meta data: 131072 + 458752 = 589824 bytes
[    0.000000] Dentry cache hash table entries: 131072 (order: 8, 1048576 bytes, linear)
[    0.000000] Inode-cache hash table entries: 65536 (order: 7, 524288 bytes, linear)
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 1MB
[    0.000000] software IO TLB: area num 4.
[    0.000000] software IO TLB: mapped [mem 0x000000007dc80000-0x000000007dd80000] (1MB)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 262144
[    0.000000] mem auto-init: stack:all(zero), heap alloc:off, heap free:off
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	RCU event tracing is enabled.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=64 to nr_cpu_ids=4.
[    0.000000] 	Trampoline variant of Tasks RCU enabled.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=4
[    0.000000] RCU Tasks: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=4.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] riscv-intc: 64 local interrupts mapped using AIA
[    0.000000] riscv-imsic: interrupt-controller@f1200000: providing IPIs using interrupt 1
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.000000] clocksource: riscv_clocksource: mask: 0xffffffffffffffff max_cycles: 0x171024e7e0, max_idle_ns: 440795205315 ns
[    0.000009] sched_clock: 64 bits at 100MHz, resolution 10ns, wraps every 4398046511100ns
[    0.035759] riscv-timer: Timer interrupt in S-mode is available via sstc extension
[    0.067965] Console: colour dummy device 80x25
[    0.088964] Calibrating delay loop (skipped), value calculated using timer frequency.. 200.00 BogoMIPS (lpj=400000)
[    0.130469] pid_max: default: 32768 minimum: 301
[    0.152147] landlock: Up and running.
[    0.165729] Yama: becoming mindful.
[    0.182042] Mount-cache hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.212476] Mountpoint-cache hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.245262] VFS: Finished mounting rootfs on nullfs
[    0.295296] riscv: ELF compat mode unsupported
[    0.295504] ASID allocator using 8 bits (256 entries)
[    0.324738] rcu: Hierarchical SRCU implementation.
[    0.343369] rcu: 	Max phase no-delay instances is 1000.
[    0.369703] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.394071] EFI services will not be available.
[    0.417556] smp: Bringing up secondary CPUs ...
[    0.471151] smp: Brought up 1 node, 4 CPUs
[    0.486695] Memory: 943752K/1048576K available (12714K kernel code, 3936K rwdata, 6144K rodata, 2502K init, 463K bss, 100604K reserved, 0K cma-reserved)
[    0.547396] devtmpfs: initialized
[    0.587806] posixtimers hash table entries: 2048 (order: 3, 32768 bytes, linear)
[    0.617181] futex hash table entries: 1024 (65536 bytes on 1 NUMA nodes, total 64 KiB, linear).
[    0.663174] DMI: not present or invalid.
[    0.685418] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.711266] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.741111] audit: initializing netlink subsys (disabled)
[    0.766832] audit: type=2000 audit(0.252:1): state=initialized audit_enabled=0 res=1
[    0.772786] thermal_sys: Registered thermal governor 'step_wise'
[    0.794872] cpuidle: using governor menu
[    0.881346] HugeTLB: registered 2.00 MiB page size, pre-allocated 0 pages
[    0.902753] HugeTLB: 28 KiB vmemmap can be freed for a 2.00 MiB page
[    0.937780] ACPI: Interpreter disabled.
[    0.945058] iommu: Default domain type: Translated
[    0.965949] iommu: DMA domain TLB invalidation policy: strict mode
[    1.007038] SCSI subsystem initialized
[    1.025598] libata version 3.00 loaded.
[    1.037169] usbcore: registered new interface driver usbfs
[    1.057626] usbcore: registered new interface driver hub
[    1.080995] usbcore: registered new device driver usb
[    1.113857] Advanced Linux Sound Architecture Driver Initialized.
[    1.150366] vgaarb: loaded
[    1.158660] clocksource: Switched to clocksource riscv_clocksource
[    1.188030] pnp: PnP ACPI: disabled
[    1.360541] NET: Registered PF_INET protocol family
[    1.377694] IP idents hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    1.429494] tcp_listen_portaddr_hash hash table entries: 512 (order: 1, 8192 bytes, linear)
[    1.454423] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    1.481362] TCP established hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    1.515497] TCP bind hash table entries: 8192 (order: 6, 262144 bytes, linear)
[    1.545539] TCP: Hash tables configured (established 8192 bind 8192)
[    1.570386] UDP hash table entries: 512 (order: 3, 32768 bytes, linear)
[    1.598157] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    1.625733] RPC: Registered named UNIX socket transport module.
[    1.646301] RPC: Registered udp transport module.
[    1.662201] RPC: Registered tcp transport module.
[    1.683671] RPC: Registered tcp-with-tls transport module.
[    1.699283] RPC: Registered tcp NFSv4.1 backchannel transport module.
[    1.725979] PCI: CLS 0 bytes, default 64
[    1.748548] Unpacking initramfs...
[    1.759091] Initialise system trusted keyrings
[    1.780568] workingset: timestamp_bits=46 (anon: 41) max_order=18 bucket_order=0 (anon: 0)
[    1.817613] NFS: Registering the id_resolver key type
[    1.830499] Key type id_resolver registered
[    1.845976] Key type id_legacy registered
[    1.862422] nfs4filelayout_init: NFSv4 File Layout Driver Registering...
[    1.888389] nfs4flexfilelayout_init: NFSv4 Flexfile Layout Driver Registering...
[    1.918343] fuse: init (API version 7.45)
[    1.935612] 9p: Installing v9fs 9p2000 file system support
[    1.957572] Key type asymmetric registered
[    1.971606] Asymmetric key parser 'x509' registered
[    1.990002] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 244)
[    2.029131] io scheduler mq-deadline registered
[    2.044362] io scheduler kyber registered
[    2.063550] io scheduler bfq registered
[    2.082295] riscv-imsic: interrupt-controller@f1200000:  hart-index-bits: 2,  guest-index-bits: 2
[    2.117357] riscv-imsic: interrupt-controller@f1200000: group-index-bits: 0, group-index-shift: 24
[    2.154371] riscv-imsic: interrupt-controller@f1200000: per-CPU IDs 255 at base address 0x00000000f1200000
[    2.196848] riscv-imsic: interrupt-controller@f1200000: total 1016 interrupts available
[    2.288888] LiteX SoC Controller driver initialized
[    3.420521] Serial: 8250/16550 driver, 4 ports, IRQ sharing disabled
[    3.608754] loop: module loaded
[    3.625741] zram: Added device: zram0
[    3.679147] tun: Universal TUN/TAP device driver, 1.6
[    3.699867] e1000e: Intel(R) PRO/1000 Network Driver
[    3.714469] e1000e: Copyright(c) 1999 - 2015 Intel Corporation.
[    3.751860] usbcore: registered new interface driver uas
[    3.769012] usbcore: registered new interface driver usb-storage
[    3.794381] mousedev: PS/2 mouse device common for all mice
[    3.848375] usbcore: registered new interface driver usbhid
[    3.869046] usbhid: USB HID core driver
[    3.893139] riscv-pmu-sbi: SBI PMU extension is available
[    3.911220] riscv-pmu-sbi: 16 firmware and 2 hardware counters
[    3.934838] riscv-pmu-sbi: Perf sampling/filtering is not supported as sscof extension is not available
[    4.004417] NET: Registered PF_INET6 protocol family
[    4.041354] Segment Routing with IPv6
[    4.045736] In-situ OAM (IOAM) with IPv6
[    4.064797] NET: Registered PF_PACKET protocol family
[    4.087198] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
[    4.140308] 9pnet: Installing 9P2000 support
[    4.158258] Key type dns_resolver registered
[    4.243339] cpu0: scalar unaligned word access speed is 0.00x byte access speed (slow)
[    4.243443] cpu2: scalar unaligned word access speed is 0.00x byte access speed (slow)
[    4.243541] cpu3: scalar unaligned word access speed is 0.00x byte access speed (slow)
[    4.243865] cpu1: scalar unaligned word access speed is 0.00x byte access speed (slow)
[    4.605328] Loading compiled-in X.509 certificates
[    7.733310] Freeing initrd memory: 35636K
[    7.980894] Loaded X.509 cert 'Build time autogenerated kernel key: 0b310300a28356d717250a013bc612ed79f44cdc'
[    8.165393] riscv-aplic f0e00000.interrupt-controller: 31 interrupts forwarded to MSI base 0x00000000f1200000
[    8.204252] f0001000.serial: ttyLXU0 at MMIO 0x0 (irq = 11, base_baud = 0) is a liteuart
[    8.232716] printk: legacy console [liteuart0] enabled
[    8.232716] printk: legacy console [liteuart0] enabled
[    8.280573] printk: legacy bootconsole [liteuart0] disabled
[    8.280573] printk: legacy bootconsole [liteuart0] disabled
[    8.342398] liteeth f0002000.mac eth0: irq 12 slots: tx 2 rx 2 size 2048
[   22.633631] clk: Disabling unused clocks
[   22.638477] PM: genpd: Disabling unused power domains
[   22.661230] ALSA device list:
[   22.672755]   No soundcards found.
[   22.727300] Freeing unused kernel image (initmem) memory: 2500K
[   22.746038] Run /init as init process
[   22.761193]   with arguments:
[   22.772564]     /init
[   22.784509]   with environment:
[   22.796267]     HOME=/
[   22.808278]     TERM=linux
Starting syslogd: OK
Starting klogd: OK
Running sysctl: OK
Populating /dev using udev: [   24.099289] udevd[98]: starting version 3.2.14
[   24.323040] random: crng init done
[   24.470403] udevd[99]: starting eudev-3.2.14
done
Starting crond: OK

test login: root
[root@test /]# cat /proc/cpuinfo 
processor	: 0
hart		: 0
isa		: rv64imafdch_zicbom_zicntr_zicsr_zifencei_zihpm_zaamo_zalrsc_zca_zcd_smaia_ssaia_sstc
mmu		: sv39
mvendorid	: 0x0
marchid		: 0x2e
mimpid		: 0x0
hart isa	: rv64imafdch_zicbom_zicntr_zicsr_zifencei_zihpm_zaamo_zalrsc_zca_zcd_smaia_ssaia_sstc

processor	: 1
hart		: 1
isa		: rv64imafdch_zicbom_zicntr_zicsr_zifencei_zihpm_zaamo_zalrsc_zca_zcd_smaia_ssaia_sstc
mmu		: sv39
mvendorid	: 0x0
marchid		: 0x2e
mimpid		: 0x0
hart isa	: rv64imafdch_zicbom_zicntr_zicsr_zifencei_zihpm_zaamo_zalrsc_zca_zcd_smaia_ssaia_sstc

processor	: 2
hart		: 2
isa		: rv64imafdch_zicbom_zicntr_zicsr_zifencei_zihpm_zaamo_zalrsc_zca_zcd_smaia_ssaia_sstc
mmu		: sv39
mvendorid	: 0x0
marchid		: 0x2e
mimpid		: 0x0
hart isa	: rv64imafdch_zicbom_zicntr_zicsr_zifencei_zihpm_zaamo_zalrsc_zca_zcd_smaia_ssaia_sstc

processor	: 3
hart		: 3
isa		: rv64imafdch_zicbom_zicntr_zicsr_zifencei_zihpm_zaamo_zalrsc_zca_zcd_smaia_ssaia_sstc
mmu		: sv39
mvendorid	: 0x0
marchid		: 0x2e
mimpid		: 0x0
hart isa	: rv64imafdch_zicbom_zicntr_zicsr_zifencei_zihpm_zaamo_zalrsc_zca_zcd_smaia_ssaia_sstc

[root@test /]# cat /proc/interrupts 
            CPU0       CPU1       CPU2       CPU3       
  10:       5052       7932       3219       3980  RISC-V INTC                                5 Edge      riscv-timer
  11:        460          0          0          0  APLIC-MSI-f0e00000.interrupt-controller    1 Level   -fasteoi   liteuart
IPI0:        13         23         44         47  Rescheduling interrupts
IPI1:       869       1141       2181       1718  Function call interrupts
IPI2:         0          0          0          0  CPU stop interrupts
IPI3:         0          0          0          0  CPU stop (for crash dump) interrupts
IPI4:         2          2          2          1  IRQ work interrupts
IPI5:         0          0          0          0  Timer broadcast interrupts
IPI6:         0          0          0          0  CPU backtrace interrupts
IPI7:         0          0          0          0  KGDB roundup interrupts
[root@test /]# 
```