### PR TITLE
test: cover framebuffer memory backends

### DIFF
--- a/test/test_targets.py
+++ b/test/test_targets.py
@@ -252,6 +252,30 @@ class TestTargets(unittest.TestCase):
                 if result.returncode != 0:
                     self.fail(result.stdout)
 
+    # Build a framebuffer target with native SDRAM and integrated main RAM.
+    def test_video_framebuffer_memory_backends(self):
+        configurations = {
+            "litedram"       : [],
+            "integrated_ram" : ["--integrated-main-ram-size=0x400000"],
+        }
+        for name, args in configurations.items():
+            with self.subTest(configuration=name):
+                output_dir = os.path.join("build", "test_video_framebuffer_memory_backends", name)
+                shutil.rmtree(output_dir, ignore_errors=True)
+                cmd = [
+                    sys.executable,
+                    "-m", "litex_boards.targets.digilent_nexys_video",
+                    "--cpu-type=vexriscv",
+                    "--cpu-variant=minimal",
+                    "--uart-name=stub",
+                    "--with-video-framebuffer",
+                    "--build",
+                    "--no-compile",
+                    "--output-dir", output_dir,
+                    *args,
+                ]
+                subprocess.check_call(cmd)
+
     # Build simple design for all platforms.
     def test_platforms(self):
         # Collect platforms.


### PR DESCRIPTION
## Summary

Add focused no-compile target coverage for the two framebuffer memory paths exercised by [LiteX #2531](https://github.com/enjoy-digital/litex/pull/2531):

- the existing Nexys Video configuration with its native LiteDRAM framebuffer port;
- the same target with integrated `main_ram`, which routes framebuffer reads through a registered system-bus master.

This only adds regression coverage and does not change the target's options or hardware behavior.

## Validation

- `pytest -q test/test_targets.py::TestTargets::test_video_framebuffer_memory_backends` (`1 passed`, `2 subtests passed`)
- both configurations generated their no-compile Verilog outputs with the LiteX #2531 branch
