### PR TITLE
targets/sipeed: Align GW5 DDR system clocks

### DIFF
--- a/litex_boards/targets/sipeed_tang_console.py
+++ b/litex_boards/targets/sipeed_tang_console.py
@@ -73,7 +73,11 @@ class _CRG(LiteXModule):
             self.pll = pll = GW5APLL(devicename=platform.devicename, device=platform.device)
             self.comb += pll.reset.eq(~por_done | rst)
             pll.register_clkin(clk50, 50e6)
-            pll.create_clkout(self.cd_sys, sys_clk_freq, with_reset=not with_ddr3)
+            if with_ddr3:
+                # Keep sys/sys2x phase-aligned across the PHY stop/reset sequence.
+                pll.create_clkout(self.cd_sys2x_i, 2*sys_clk_freq)
+            else:
+                pll.create_clkout(self.cd_sys, sys_clk_freq)
 
             # SDRAM clock
             if with_sdram:
@@ -88,12 +92,18 @@ class _CRG(LiteXModule):
 
         # DDR3 clock
         if with_ddr3:
-            pll.create_clkout(self.cd_sys2x_i, 2*sys_clk_freq)
             self.specials += [
                 Instance("DHCE",
                     i_CLKIN  = self.cd_sys2x_i.clk,
                     i_CEN    = self.stop,
                     o_CLKOUT = self.cd_sys2x.clk
+                ),
+                Instance("CLKDIV",
+                    p_DIV_MODE = "2",
+                    i_CALIB    = 0,
+                    i_HCLKIN   = self.cd_sys2x.clk,
+                    i_RESETN   = ~self.reset,
+                    o_CLKOUT   = self.cd_sys.clk
                 ),
                 AsyncResetSynchronizer(self.cd_sys, ~pll.locked | self.reset),
             ]

--- a/litex_boards/targets/sipeed_tang_mega_138k.py
+++ b/litex_boards/targets/sipeed_tang_mega_138k.py
@@ -81,7 +81,11 @@ class _CRG(LiteXModule):
         self.pll = pll = GW5APLL(devicename=platform.devicename, device=platform.device)
         self.comb += pll.reset.eq(~por_done | self.rst)
         pll.register_clkin(clk50, 50e6)
-        pll.create_clkout(self.cd_sys, sys_clk_freq, with_reset=not with_ddr3)
+        if with_ddr3:
+            # Keep sys/sys2x phase-aligned across the PHY stop/reset sequence.
+            pll.create_clkout(self.cd_sys2x_i, 2*sys_clk_freq)
+        else:
+            pll.create_clkout(self.cd_sys, sys_clk_freq)
         if cpu_clk_freq:
             pll.create_clkout(self.cd_cpu, cpu_clk_freq, with_reset=False)
         platform.toolchain.additional_cst_commands.append("INS_LOC \"PLL\" PLL_R[0]") # Magic incantation for Gowin-AE350 CPU :)
@@ -99,12 +103,18 @@ class _CRG(LiteXModule):
 
         # DDR3 clock
         if with_ddr3:
-            pll.create_clkout(self.cd_sys2x_i, 2*sys_clk_freq)
             self.specials += [
                 Instance("DHCE",
                     i_CLKIN  = self.cd_sys2x_i.clk,
                     i_CEN    = self.stop,
                     o_CLKOUT = self.cd_sys2x.clk
+                ),
+                Instance("CLKDIV",
+                    p_DIV_MODE = "2",
+                    i_CALIB    = 0,
+                    i_HCLKIN   = self.cd_sys2x.clk,
+                    i_RESETN   = ~self.reset,
+                    o_CLKOUT   = self.cd_sys.clk
                 ),
                 AsyncResetSynchronizer(self.cd_sys, ~pll.locked | self.reset),
             ]

--- a/litex_boards/targets/sipeed_tang_mega_138k_pro.py
+++ b/litex_boards/targets/sipeed_tang_mega_138k_pro.py
@@ -76,7 +76,11 @@ class _CRG(LiteXModule):
         self.pll = pll = GW5APLL(devicename=platform.devicename, device=platform.device)
         self.comb += pll.reset.eq(~por_done | rst)
         pll.register_clkin(clk50, 50e6)
-        pll.create_clkout(self.cd_sys, sys_clk_freq, with_reset=not with_ddr3)
+        if with_ddr3:
+            # Keep sys/sys2x phase-aligned across the PHY stop/reset sequence.
+            pll.create_clkout(self.cd_sys2x_i, 2*sys_clk_freq)
+        else:
+            pll.create_clkout(self.cd_sys, sys_clk_freq)
         if cpu_clk_freq:
             pll.create_clkout(self.cd_cpu, cpu_clk_freq, with_reset=False)
         platform.toolchain.additional_cst_commands.append("INS_LOC \"PLL\" PLL_R[0]") # Magic incantation for Gowin-AE350 CPU :)
@@ -94,12 +98,18 @@ class _CRG(LiteXModule):
 
         # DDR3 clock
         if with_ddr3:
-            pll.create_clkout(self.cd_sys2x_i, 2*sys_clk_freq)
             self.specials += [
                 Instance("DHCE",
                     i_CLKIN  = self.cd_sys2x_i.clk,
                     i_CEN    = self.stop,
                     o_CLKOUT = self.cd_sys2x.clk
+                ),
+                Instance("CLKDIV",
+                    p_DIV_MODE = "2",
+                    i_CALIB    = 0,
+                    i_HCLKIN   = self.cd_sys2x.clk,
+                    i_RESETN   = ~self.reset,
+                    o_CLKOUT   = self.cd_sys.clk
                 ),
                 AsyncResetSynchronizer(self.cd_sys, ~pll.locked | self.reset),
             ]


### PR DESCRIPTION
## Summary

- generate a single 2x PLL clock for GW5 DDR3 configurations
- gate that clock with `DHCE` and derive `sys` through a resettable divide-by-two `CLKDIV`
- apply the topology to Tang Console, Tang Mega 138K and Tang Mega 138K Pro
- leave non-DDR clock generation unchanged

## Rationale

`GW5DDRPHY` uses `sys` as the DDR primitive PCLK and `sys2x` as FCLK. The initialization sequence stops and restarts `sys2x`; generating `sys` from a separate PLL output does not preserve their phase relationship across that sequence.

The working GW2 targets derive `sys` from the gated 2x clock, and Gowin's GW5 DDR reference design likewise derives the primitive PCLK from the memory clock with `CLKDIV`. This change applies the same relationship to the GW5 targets.

Related to #549. This is a draft until DDR initialization and read leveling are confirmed on hardware.

## Verification

- all three changed targets generate with and without `--with-ddr3`
- Tang Mega 138K Pro completes Gowin synthesis, place-and-route, timing analysis and bitstream generation
- focused repository tests: `24 passed`
- full target matrix: `30 passed`, `628 subtests passed`; 85 unrelated target generations fail in the current local environment