### PR TITLE
targets/mnt_rkx7: Fix framebuffer memory mapping

### DIFF
--- a/litex_boards/targets/mnt_rkx7.py
+++ b/litex_boards/targets/mnt_rkx7.py
@@ -74,8 +74,7 @@ class _CRG(LiteXModule):
 
 class BaseSoC(SoCCore):
     mem_map = {**SoCCore.mem_map, **{
-        # FIXME: ends up as 0x7f000000 in linux
-        "video_framebuffer": 0x3f000000,
+        "video_framebuffer": 0x7f000000,
         "usb_ohci"         : 0xc0000000,
     }}
 


### PR DESCRIPTION
The `mnt_rkx7` target declared the framebuffer at `0x3f000000`, which is the
LiteDRAM-local offset rather than an address in the CPU-visible main RAM region
at `0x40000000..0x80000000`. The common framebuffer integration now validates
explicit regions, so the target correctly fails elaboration because that address
is outside main RAM.

Use the corresponding CPU-visible address, `0x7f000000`, directly. This is the
address software already observed, as noted by the previous target comment, so
the framebuffer location remains unchanged while its region can be validated
and reserved correctly.

This fixes the failure in the [current master CI run](https://github.com/litex-hub/litex-boards/actions/runs/29941007612).

Validated with:

```
python3 -m litex_boards.targets.mnt_rkx7 \
    --cpu-type=vexriscv \
    --cpu-variant=minimal \
    --uart-name=stub \
    --build \
    --no-compile
pytest -q test/test_board_guardrails.py test/test_parser_alignment.py test/test_parser_style.py
```
