### PR TITLE
targets/decklink_mini_4k: Generate exact video clocks

### DIFF
--- a/litex_boards/targets/decklink_mini_4k.py
+++ b/litex_boards/targets/decklink_mini_4k.py
@@ -32,41 +32,52 @@ from litepcie.software import generate_litepcie_software
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(LiteXModule):
-    def __init__(self, platform, sys_clk_freq):
+    def __init__(self, platform, sys_clk_freq, with_video=False):
         self.rst          = Signal()
         self.cd_sys       = ClockDomain()
         self.cd_sys4x     = ClockDomain()
         self.cd_sys4x_dqs = ClockDomain()
         self.cd_idelay    = ClockDomain()
-        self.cd_hdmi      = ClockDomain()
 
         # # #
 
-        # Clk.
+        # Clks.
+        clk24  = platform.request("clk24")
         clk100 = platform.request("clk100")
-        platform.add_platform_command("set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets clk100_IBUF]")
-        platform.add_platform_command("set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets s7pll0_clkin]")
 
-        # Main PLL.
-        self.pll = pll = S7PLL(speedgrade=-1)
-        self.comb += pll.reset.eq(self.rst)
-        pll.register_clkin(clk100, 100e6)
-        pll.create_clkout(self.cd_sys, sys_clk_freq)
-        pll.create_clkout(self.cd_sys4x,     4*sys_clk_freq)
-        pll.create_clkout(self.cd_sys4x_dqs, 4*sys_clk_freq, phase=90)
-        pll.create_clkout(self.cd_idelay,    200e6, margin=1e-1)   # FIXME: Re-arrange clocking.
-        pll.create_clkout(self.cd_hdmi,      148.5e6, margin=2e-2) # FIXME: Use a second PLL or move to clkout0 that has fractional support.
-        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
+        # Main MMCM.
+        # The 24MHz input allows exact 148.5/594MHz video and DDR3 clocks.
+        self.mmcm = mmcm = S7MMCM(speedgrade=-1)
+        self.comb += mmcm.reset.eq(self.rst)
+        mmcm.register_clkin(clk24, 24e6)
+        mmcm.create_clkout(self.cd_sys, sys_clk_freq)
+        mmcm.create_clkout(self.cd_sys4x,     4*sys_clk_freq)
+        mmcm.create_clkout(self.cd_sys4x_dqs, 4*sys_clk_freq, phase=90)
+        if with_video:
+            self.cd_hdmi = ClockDomain()
+            mmcm.create_clkout(self.cd_hdmi, 148.5e6, margin=0)
+        # Ignore sys_clk to mmcm.clkin path created by SoC's reset.
+        platform.add_false_path_constraints(self.cd_sys.clk, mmcm.clkin)
+
+        # Auxiliary PLL.
+        # Generate exact IDELAY and SATA reference clocks from the 100MHz input.
+        self.aux_pll = aux_pll = S7PLL(speedgrade=-1)
+        self.comb += aux_pll.reset.eq(self.rst)
+        aux_pll.register_clkin(clk100, 100e6)
+        aux_pll.create_clkout(self.cd_idelay,       200e6, margin=0)
+        self.cd_sata_refclk = ClockDomain()
+        aux_pll.create_clkout(self.cd_sata_refclk, 150e6, margin=0)
+        platform.add_false_path_constraints(self.cd_sys.clk, aux_pll.clkin)
+        platform.add_platform_command(
+            "set aux_pll_clkin [get_nets -quiet {{{clkin}}}]\n"
+            "if {{[llength $aux_pll_clkin]}} {{\n"
+            "    set_property CLOCK_DEDICATED_ROUTE FALSE $aux_pll_clkin\n"
+            "}}",
+            clkin=aux_pll.clkin
+        )
 
         # IDELAY Ctrl.
         self.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
-
-        # SATA PLL.
-        self.cd_sata_refclk = ClockDomain()
-        self.sata_pll = sata_pll = S7PLL(speedgrade=-1)
-        self.comb += sata_pll.reset.eq(self.rst)
-        sata_pll.register_clkin(clk100, 100e6)
-        sata_pll.create_clkout(self.cd_sata_refclk, 150e6)
 
 # BaseSoC ------------------------------------------------------------------------------------------
 
@@ -82,7 +93,8 @@ class BaseSoC(SoCMini):
         platform = decklink_mini_4k.Platform()
 
         # CRG --------------------------------------------------------------------------------------
-        self.crg = _CRG(platform, sys_clk_freq)
+        self.crg = _CRG(platform, sys_clk_freq,
+            with_video = with_video_terminal or with_video_framebuffer)
 
         # SoCCore ----------------------------------------------------------------------------------
         if kwargs.get("uart_name", "serial") == "serial":


### PR DESCRIPTION
## Summary

- Generate the 148.5MHz system/video and 594MHz DDR3 clocks from the board's 24MHz clock-capable input with an S7 MMCM.
- Generate exact 200MHz IDELAY and 150MHz SATA reference clocks from the 100MHz input with one auxiliary PLL.
- Replace stale hard-coded clock-net constraints with a constraint resolved from the generated PLL input signal.
- Declare the independent 24MHz and 100MHz clock trees asynchronous.

## Problem

The previous CRG requested 148.5MHz, 594MHz and 200MHz outputs from one integer S7 PLL driven at 100MHz. That combination cannot produce the required clocks exactly, so Vivado selected:

| Clock | Previous | New |
| --- | ---: | ---: |
| System / HDMI | 147.5MHz | 148.5MHz |
| DDR3 x4 | 590MHz | 594MHz |
| IDELAY reference | 196.667MHz | 200MHz |
| SATA reference | 150MHz | 150MHz |

Besides moving the HDMI timing away from the requested 1080p60 mode, the 196.667MHz IDELAY clock did not match the `IDELAYE2` 200MHz reference-frequency setting.

The 24MHz input permits an exact MMCM configuration with a 49.5 multiplier and output dividers of 8 and 2. The 100MHz input permits exact 200MHz and 150MHz auxiliary PLL outputs.

## Validation

- Default target generation with `--build --no-compile`.
- Framebuffer target generation with `--with-video-framebuffer --build --no-compile`.
- Vivado 2025.2 synthesis, placement and routing without bitstream generation.
- Final setup WNS: +0.170ns.
- Final hold WHS: +0.065ns.
- No unrouted nets, implementation errors, critical warnings, or IDELAY reference-frequency mismatch.

Hardware validation of the HDMI output is still requested in #763.

Related to #763.
