### PR TITLE
targets/efinix_tz170: use common hard DDR integration

### DIFF
--- a/litex_boards/platforms/efinix_tz170_j484_dev_kit.py
+++ b/litex_boards/platforms/efinix_tz170_j484_dev_kit.py
@@ -206,6 +206,20 @@ _connectors = [
     ),
 ]
 
+# DDR Configuration --------------------------------------------------------------------------------
+
+ddr_config = {
+    "memory_type"     : "LPDDR4",
+    "memory_density"  : "8G",
+    "clkin_sel"       : "CLKIN 2",
+    "location"        : "DDR_0",
+    "dq_width"        : 32,
+    "physical_rank"   : 1,
+    "data_width"      : 512,
+    "address_width"   : 33,
+    "id_width"        : 8,
+}
+
 # Platform -----------------------------------------------------------------------------------------
 
 class Platform(EfinixPlatform):
@@ -215,6 +229,8 @@ class Platform(EfinixPlatform):
 
     def __init__(self, toolchain="efinity"):
         EfinixPlatform.__init__(self, "Tz170J484I3", _io, _connectors, iobank_info=_bank_info, toolchain=toolchain, spi_width="4")
+        self.ddr_config = ddr_config
+        self.ddr_size   = 0x4000_0000 # 1GB.
 
     def create_programmer(self):
         return EfinixProgrammer(family=self.family)

--- a/litex_boards/targets/efinix_tz170_j484_dev_kit.py
+++ b/litex_boards/targets/efinix_tz170_j484_dev_kit.py
@@ -10,17 +10,13 @@ from migen import *
 
 from litex.gen import *
 
-from litex.build.generic_platform import Subsignal, Pins
-
 from litex_boards.platforms import efinix_tz170_j484_dev_kit
 
 from litex.soc.integration.soc import *
-from litex.soc.integration.soc import SoCRegion
 from litex.soc.integration.builder import *
 
-from litex.soc.interconnect import axi
-
 from litex.soc.cores.clock.efinix import *
+from litex.soc.cores.ram.efinix_ddr import EfinixDDR, add_efinix_ddr
 
 # CRG ----------------------------------------------------------------------------------------------
 
@@ -75,149 +71,6 @@ class _CRG_DDR(LiteXModule):
         pll.create_clkout(None,         600e6, nclkout=4, margin=1e-02) # LPDDR4 ctrl
 
 
-class EfinixLPDDR4(LiteXModule):
-    def __init__(self, soc, axi_clk, own_crg=True):
-        platform = soc.platform
-        data_width = 512
-
-        # DRAM Blocks.
-        # ------------------
-        from litex.build.efinix import InterfaceWriterBlock
-
-        self.bus = axi_bus = axi.AXIInterface(data_width=data_width, address_width=33, id_width=8)
-
-        if own_crg:
-            self.ddr_crg = _CRG_DDR(platform)
-
-        class EfinixDRAMBlock(InterfaceWriterBlock):
-            @staticmethod
-            def generate():
-                name          = "ddr_inst1"
-                ddr_def       = "DDR_0"
-                clkin_sel     = "CLKIN 2"
-                data_width    = "32"
-                physical_rank = "1"
-                mem_type      = "LPDDR4"
-                mem_density   = "8G"
-
-                cmd = []
-                cmd.append('design.create_block("{}", "DDR")'.format(name))
-                cmd.append('design.set_property("{}", "MEMORY_TYPE",    "{}", "DDR")'.format(name, mem_type))
-                cmd.append('design.set_property("{}", "DQ_WIDTH",       "{}", "DDR")'.format(name, data_width))
-                cmd.append('design.set_property("{}", "MEMORY_DENSITY", "{}", "DDR")'.format(name, mem_density))
-                cmd.append('design.set_property("{}", "PHYSICAL_RANK",  "{}", "DDR")'.format(name, physical_rank))
-                cmd.append('design.set_property("{}", "CLKIN_SEL",      "{}", "DDR")'.format(name, clkin_sel))
-
-                cmd.append('design.set_property("{}","TARGET0_EN",      "1", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","TARGET1_EN",      "0", "DDR")'.format(name))
-
-                cmd.append('design.set_property("{}","AXI0_ARADDR_BUS","ddr0_araddr", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARAPCMD_PIN","ddr0_arapcmd", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARBURST_BUS","ddr0_arburst", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARID_BUS","ddr0_arid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARLEN_BUS","ddr0_arlen", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARLOCK_PIN","ddr0_arlock", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARQOS_PIN","ddr0_arqos", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARREADY_PIN","ddr0_arready", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARSIZE_BUS","ddr0_arsize", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARSTN_PIN","ddr0_resetn", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARVALID_PIN","ddr0_arvalid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWADDR_BUS","ddr0_awaddr", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWALLSTRB_PIN","ddr0_awallstrb", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWAPCMD_PIN","ddr0_awapcmd", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWBURST_BUS","ddr0_awburst", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWCACHE_BUS","ddr0_awcache", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWCOBUF_PIN","ddr0_awcobuf", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWID_BUS","ddr0_awid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWLEN_BUS","ddr0_awlen", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWLOCK_PIN","ddr0_awlock", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWQOS_PIN","ddr0_awqos", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWREADY_PIN","ddr0_awready", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWSIZE_BUS","ddr0_awsize", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWVALID_PIN","ddr0_awvalid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_BID_BUS","ddr0_bid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_BREADY_PIN","ddr0_bready", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_BRESP_BUS","ddr0_bresp", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_BVALID_PIN","ddr0_bvalid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_CLK_INPUT_PIN","{}", "DDR")'.format(name, axi_clk))
-                cmd.append('design.set_property("{}","AXI0_CLK_INVERT_EN","0", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_DATA_WIDTH","512", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_RDATA_BUS","ddr0_rdata", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_RID_BUS","ddr0_rid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_RLAST_PIN","ddr0_rlast", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_RREADY_PIN","ddr0_rready", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_RRESP_BUS","ddr0_rresp", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_RVALID_PIN","ddr0_rvalid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_WDATA_BUS","ddr0_wdata", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_WLAST_PIN","ddr0_wlast", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_WREADY_PIN","ddr0_wready", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_WSTRB_BUS","ddr0_wstrb", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_WVALID_PIN","ddr0_wvalid", "DDR")'.format(name))
-
-                cmd.append('design.set_property("{}","CFG_DONE_PIN",   "cfg_done", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CFG_RESET_PIN",  "cfg_reset", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CFG_SEL_PIN",    "cfg_sel", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CFG_START_PIN",  "cfg_start", "DDR")'.format(name))
-
-                cmd.append('design.set_property("{}","CTRL_BUSY_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_CKE_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_CLK_INVERT_EN","0", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_CLK_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_CMD_Q_ALMOST_FULL_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_DP_IDLE_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_INT_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_MEM_RST_VALID_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_PORT_BUSY_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_REFRESH_PIN","", "DDR")'.format(name))
-
-                cmd.append('design.assign_resource("{}", "{}","DDR")\n'.format(name, ddr_def))
-
-                return '\n'.join(cmd) + '\n'
-
-        platform.toolchain.ifacewriter.blocks.append(EfinixDRAMBlock())
-
-        # DRAM AXI-Ports.
-        # --------------
-        axi_io = platform.add_iface_ios(axi_bus.get_ios("ddr0"))
-        self.comb += axi_bus.connect_to_pads(axi_io, mode="master")
-
-        ios = [(f"ddr0", 0,
-            Subsignal("arapcmd",   Pins(1)),
-            Subsignal("awallstrb", Pins(1)),
-            Subsignal("awapcmd",   Pins(1)),
-            Subsignal("awcobuf",    Pins(1)),
-            Subsignal("resetn",     Pins(1)),
-        )]
-
-        io   = platform.add_iface_ios(ios)
-        self.comb += [
-            io.arapcmd.eq(0),
-            io.awallstrb.eq(getattr(soc.cpu, "mBus_awallStrb", 0)),
-            io.awapcmd.eq(0),
-            io.awcobuf.eq(0),
-            io.resetn.eq(~ResetSignal()),
-        ]
-
-        cfgs = [(f"cfg", 0,
-            Subsignal("start",  Pins(1)),
-            Subsignal("reset",  Pins(1)),
-            Subsignal("sel",    Pins(1)),
-            Subsignal("done",   Pins(1)),
-        )]
-
-        cfg = platform.add_iface_ios(cfgs)
-        self.cfg_state = Signal(1, reset=0)
-        self.cfg_count = Signal(8, reset=0)
-
-        self.comb += [
-            cfg.sel.eq(0),
-            cfg.reset.eq(self.cfg_state == 0),
-            cfg.start.eq(self.cfg_state != 0),
-        ]
-
-        self.sync += self.cfg_count.eq(self.cfg_count + (self.cfg_count != 0xFF))
-        self.sync += self.cfg_state.eq(self.cfg_state | (self.cfg_count == 0xFF))
-
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
@@ -234,31 +87,17 @@ class BaseSoC(SoCCore):
 
         # LPDDR4 SDRAM -----------------------------------------------------------------------------
         if not self.integrated_main_ram_size:
-            if hasattr(self.cpu, "add_memory_buses") and hasattr(self.cpu, "cpu_clk"):
-                axi_clk = self.crg.cd_cpu.clk.name_override
-            else:
-                axi_clk = self.crg.cd_sys.clk.name_override
-
-            self.ddr = EfinixLPDDR4(self, axi_clk)
-            axi_bus = self.ddr.bus
-
-            soc_region = SoCRegion(
-                origin = self.mem_map.get("main_ram", None),
-                size   = 0x4000_0000, # 1GB.
-                mode   ="rwx",
+            self.ddr_crg = _CRG_DDR(platform)
+            clock_domain = "cpu" if (
+                hasattr(self.cpu, "add_memory_buses") and
+                hasattr(self.cpu, "cpu_clk")
+            ) else "sys"
+            self.ddr = EfinixDDR(
+                platform     = platform,
+                clock_domain = clock_domain,
+                **platform.ddr_config,
             )
-            # Use DRAM's target0 port as Main Ram.
-            if hasattr(self.cpu, "add_memory_buses"):
-                self.cpu.add_memory_buses(address_width = 32, data_width = axi_bus.data_width)
-
-                assert len(self.cpu.memory_buses) == 1
-                mbus = self.cpu.memory_buses[0]
-                self.comb +=mbus.connect(axi_bus)
-                self.bus.add_region("main_ram", soc_region)
-            else:
-                axi_lite_bus = axi.AXILiteInterface(data_width=axi_bus.data_width, address_width=axi_bus.address_width)
-                self.submodules += axi.AXILite2AXI(axi_lite_bus, axi_bus)
-                self.bus.add_slave("main_ram", axi_lite_bus, soc_region)
+            add_efinix_ddr(self, self.ddr, size=platform.ddr_size)
 
         # SPI Flash --------------------------------------------------------------------------------
         if with_spi_flash:


### PR DESCRIPTION
## Summary

- move the board-specific LPDDR4 geometry into the platform
- replace the target-local Efinity DDR generator and bus adapters with the common LiteX integration
- preserve the dedicated 33.33 MHz to 600 MHz DDR controller PLL
- support both native VexiiRiscv AXI and default bus-adapted CPU configurations

This is a follow-up to [litex-hub/litex-boards#765](https://github.com/litex-hub/litex-boards/pull/765)
and depends on [enjoy-digital/litex#2544](https://github.com/enjoy-digital/litex/pull/2544).

## Validation

- default VexRiscv/Wishbone generation and Efinity Interface Designer checks pass
- VexiiRiscv native-AXI generation and Efinity Interface Designer checks pass
- the old/new Efinity peripheral databases match except for their generation timestamps
- full default VexRiscv Efinity 2025.1 synthesis, place-and-route, timing analysis,
  programming-file generation, and bitstream generation pass
  - 100 MHz system setup slack: `+1.827 ns`
  - estimated maximum system frequency: `122.354 MHz`
- a full four-core VexiiRiscv flow also produces a bitstream, but the existing 175 MHz
  CPU configuration does not meet timing (`-0.901 ns`, estimated maximum `151.172 MHz`)
