### PR TITLE
targets/efinix: clean up defaults and board integrations

### DIFF
--- a/litex_boards/platforms/adiuvo_forgix.py
+++ b/litex_boards/platforms/adiuvo_forgix.py
@@ -90,4 +90,6 @@ class Platform(EfinixPlatform):
 
     def do_finalize(self, fragment):
         EfinixPlatform.do_finalize(self, fragment)
-        self.add_period_constraint(self.lookup_request("clk32", loose=True), 1e9/32e6)
+        self.add_period_constraint(
+            self.lookup_request(self.default_clk_name, loose=True),
+            self.default_clk_period)

--- a/litex_boards/platforms/efinix_t120_f576_dev_kit.py
+++ b/litex_boards/platforms/efinix_t120_f576_dev_kit.py
@@ -170,6 +170,15 @@ def usb_pmod_io(pmod):
         ),
     ]
 
+def i2c_pmod_io(pmod):
+    return [
+        ("i2c", 0,
+            Subsignal("sda", Pins(f"{pmod}:0")),
+            Subsignal("scl", Pins(f"{pmod}:1")),
+            IOStandard("3.3_V_LVTTL_/_LVCMOS"),
+        ),
+    ]
+
 # Platform -----------------------------------------------------------------------------------------
 
 class Platform(EfinixPlatform):
@@ -185,4 +194,6 @@ class Platform(EfinixPlatform):
 
     def do_finalize(self, fragment):
         EfinixPlatform.do_finalize(self, fragment)
-        self.add_period_constraint(self.lookup_request("clk40", loose=True), 1e9/40e6)
+        self.add_period_constraint(
+            self.lookup_request(self.default_clk_name, loose=True),
+            self.default_clk_period)

--- a/litex_boards/platforms/efinix_t20_f256_dev_kit.py
+++ b/litex_boards/platforms/efinix_t20_f256_dev_kit.py
@@ -124,4 +124,6 @@ class Platform(EfinixPlatform):
 
     def do_finalize(self, fragment):
         EfinixPlatform.do_finalize(self, fragment)
-        self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)
+        self.add_period_constraint(
+            self.lookup_request(self.default_clk_name, loose=True),
+            self.default_clk_period)

--- a/litex_boards/platforms/efinix_t20_mipi_dev_kit.py
+++ b/litex_boards/platforms/efinix_t20_mipi_dev_kit.py
@@ -108,4 +108,6 @@ class Platform(EfinixPlatform):
 
     def do_finalize(self, fragment):
         EfinixPlatform.do_finalize(self, fragment)
-        self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)
+        self.add_period_constraint(
+            self.lookup_request(self.default_clk_name, loose=True),
+            self.default_clk_period)

--- a/litex_boards/platforms/efinix_t8_f81_dev_kit.py
+++ b/litex_boards/platforms/efinix_t8_f81_dev_kit.py
@@ -50,8 +50,8 @@ _connectors = [
 # Platform -----------------------------------------------------------------------------------------
 
 class Platform(EfinixPlatform):
-    default_clk_name = "clk33"
-    default_clk_freq = 33.333e6
+    default_clk_name   = "clk33"
+    default_clk_freq   = 33.333e6
     default_clk_period = 1e9/33.333e6
 
     def __init__(self, toolchain="efinity"):
@@ -62,4 +62,6 @@ class Platform(EfinixPlatform):
 
     def do_finalize(self, fragment):
         EfinixPlatform.do_finalize(self, fragment)
-        self.add_period_constraint(self.lookup_request("clk33", loose=True), 1e9/33.333e6)
+        self.add_period_constraint(
+            self.lookup_request(self.default_clk_name, loose=True),
+            self.default_clk_period)

--- a/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/platforms/efinix_ti375_c529_dev_kit.py
@@ -312,4 +312,6 @@ class Platform(EfinixPlatform):
 
     def do_finalize(self, fragment):
         EfinixPlatform.do_finalize(self, fragment)
-        self.add_period_constraint(self.lookup_request("clk100", loose=True), 1e9/100e6)
+        self.add_period_constraint(
+            self.lookup_request(self.default_clk_name, loose=True),
+            self.default_clk_period)

--- a/litex_boards/platforms/efinix_ti60_f225_dev_kit.py
+++ b/litex_boards/platforms/efinix_ti60_f225_dev_kit.py
@@ -194,4 +194,6 @@ class Platform(EfinixPlatform):
 
     def do_finalize(self, fragment):
         EfinixPlatform.do_finalize(self, fragment)
-        self.add_period_constraint(self.lookup_request("clk25", loose=True), 1e9/25e6)
+        self.add_period_constraint(
+            self.lookup_request(self.default_clk_name, loose=True),
+            self.default_clk_period)

--- a/litex_boards/platforms/efinix_tz170_j484_dev_kit.py
+++ b/litex_boards/platforms/efinix_tz170_j484_dev_kit.py
@@ -206,6 +206,20 @@ _connectors = [
     ),
 ]
 
+# DDR Configuration --------------------------------------------------------------------------------
+
+ddr_config = {
+    "memory_type"     : "LPDDR4",
+    "memory_density"  : "8G",
+    "clkin_sel"       : "CLKIN 2",
+    "location"        : "DDR_0",
+    "dq_width"        : 32,
+    "physical_rank"   : 1,
+    "data_width"      : 512,
+    "address_width"   : 33,
+    "id_width"        : 8,
+}
+
 # Platform -----------------------------------------------------------------------------------------
 
 class Platform(EfinixPlatform):
@@ -215,6 +229,8 @@ class Platform(EfinixPlatform):
 
     def __init__(self, toolchain="efinity"):
         EfinixPlatform.__init__(self, "Tz170J484I3", _io, _connectors, iobank_info=_bank_info, toolchain=toolchain, spi_width="4")
+        self.ddr_config = ddr_config
+        self.ddr_size   = 0x4000_0000 # 1GB.
 
     def create_programmer(self):
         return EfinixProgrammer(family=self.family)

--- a/litex_boards/platforms/efinix_tz170_j484_dev_kit.py
+++ b/litex_boards/platforms/efinix_tz170_j484_dev_kit.py
@@ -237,4 +237,6 @@ class Platform(EfinixPlatform):
 
     def do_finalize(self, fragment):
         EfinixPlatform.do_finalize(self, fragment)
-        self.add_period_constraint(self.lookup_request(self.default_clk_name, loose=True), self.default_clk_period)
+        self.add_period_constraint(
+            self.lookup_request(self.default_clk_name, loose=True),
+            self.default_clk_period)

--- a/litex_boards/platforms/efinix_xyloni_dev_kit.py
+++ b/litex_boards/platforms/efinix_xyloni_dev_kit.py
@@ -70,8 +70,8 @@ _connectors = [
 # Platform -----------------------------------------------------------------------------------------
 
 class Platform(EfinixPlatform):
-    default_clk_name = "clk33"
-    default_clk_freq = 33.333e6
+    default_clk_name   = "clk33"
+    default_clk_freq   = 33.333e6
     default_clk_period = 1e9/33.333e6
 
     def __init__(self, toolchain="efinity"):
@@ -82,4 +82,6 @@ class Platform(EfinixPlatform):
 
     def do_finalize(self, fragment):
         EfinixPlatform.do_finalize(self, fragment)
-        self.add_period_constraint(self.lookup_request("clk33", loose=True), 1e9/33.333e6)
+        self.add_period_constraint(
+            self.lookup_request(self.default_clk_name, loose=True),
+            self.default_clk_period)

--- a/litex_boards/platforms/jungle_electronics_fireant.py
+++ b/litex_boards/platforms/jungle_electronics_fireant.py
@@ -60,4 +60,6 @@ class Platform(EfinixPlatform):
 
     def do_finalize(self, fragment):
         EfinixPlatform.do_finalize(self, fragment)
-        self.add_period_constraint(self.lookup_request("clk33", loose=True), 1e9/33.33e6)
+        self.add_period_constraint(
+            self.lookup_request(self.default_clk_name, loose=True),
+            self.default_clk_period)

--- a/litex_boards/targets/efinix_t120_f576_dev_kit.py
+++ b/litex_boards/targets/efinix_t120_f576_dev_kit.py
@@ -7,14 +7,14 @@
 # Copyright (c) 2021 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
-import time
-
 from migen import *
 
 from litex.gen import *
 from litex.gen.genlib.misc import WaitTimer
 
 from litex_boards.platforms import efinix_t120_f576_dev_kit
+
+from litex.build.generic_platform import Pins, Subsignal, IOStandard
 
 from litex.soc.cores.clock import *
 from litex.soc.integration.soc import *
@@ -40,13 +40,13 @@ class _CRG(LiteXModule):
 
         self.comb += self.cd_rst.clk.eq(clk40)
 
-         # A pulse is necessary to do a reset.
+        # A pulse is necessary to do a reset.
         self.rst_pulse = Signal()
         self.reset_timer = reset_timer = ClockDomainsRenamer("rst")(WaitTimer(25e-6*platform.default_clk_freq))
         self.comb += self.rst_pulse.eq(self.rst ^ reset_timer.done)
         self.comb += reset_timer.wait.eq(self.rst)
 
-        # PLL
+        # PLL.
         self.pll = pll = TRIONPLL(platform)
         self.comb += pll.reset.eq(~rst_n | self.rst_pulse)
         pll.register_clkin(clk40, platform.default_clk_freq)
@@ -65,13 +65,14 @@ class BaseSoC(SoCCore):
         remote_ip       = None,
         eth_dynamic_ip  = False,
         with_led_chaser = True,
+        with_i2c        = False,
         **kwargs):
         platform = efinix_t120_f576_dev_kit.Platform()
 
-        # USBUART PMOD as Serial--------------------------------------------------------------------
+        # USB-UART PMOD as Serial ------------------------------------------------------------------
         platform.add_extension(efinix_t120_f576_dev_kit.usb_pmod_io("pmod_e"))
         if kwargs.get("uart_name", "serial") == "serial":
-            if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "usb_uart"
+            kwargs["uart_name"] = "usb_uart"
 
         # CRG --------------------------------------------------------------------------------------
         self.crg = _CRG(platform, sys_clk_freq)
@@ -91,15 +92,11 @@ class BaseSoC(SoCCore):
                 pads         = platform.request_all("user_led"),
                 sys_clk_freq = sys_clk_freq)
 
-        # Tristate Test ----------------------------------------------------------------------------
-        from litex.build.generic_platform import Subsignal, Pins, IOStandard
-        from litex.soc.cores.bitbang import I2CMaster
-        platform.add_extension([("i2c", 0,
-            Subsignal("sda",   Pins("T12")),
-            Subsignal("scl",   Pins("V11")),
-            IOStandard("3.3_V_LVTTL_/_LVCMOS"),
-        )])
-        self.i2c = I2CMaster(pads=platform.request("i2c"))
+        # I2C ---------------------------------------------------------------------------------------
+        if with_i2c:
+            from litex.soc.cores.bitbang import I2CMaster
+            platform.add_extension(efinix_t120_f576_dev_kit.i2c_pmod_io("pmod_a"))
+            self.i2c = I2CMaster(pads=platform.request("i2c"))
 
         # Ethernet / Etherbone ---------------------------------------------------------------------
         if with_ethernet or with_etherbone:
@@ -111,7 +108,6 @@ class BaseSoC(SoCCore):
                 msg += "- rx_ctl: a wire must be soldered between R120 and R174\n"
                 msg += "- tx_ctl: a wire must be soldered between ETH1_TXEN (Pad 30) and R173\n"
                 print(msg)
-                time.sleep(2)
                 self.ethphy = LiteEthPHYRGMII(
                     platform           = platform,
                     clock_pads         = platform.request("eth_clocks", eth_phy),
@@ -119,7 +115,6 @@ class BaseSoC(SoCCore):
                     with_hw_init_reset = False)
             # Use Ethernet RMII PMOD.
             else:
-                from litex.build.generic_platform import Pins, Subsignal, IOStandard
                 def eth_lan8720_rmii_pmod_io(pmod):
                     # Lan8020 RMII PHY "PMOD": To be used as a PMOD, MDIO should be disconnected and TX1 connected to PMOD8 IO.
                     return [
@@ -392,6 +387,7 @@ def main():
     parser.add_target_argument("--flash",          action="store_true",      help="Flash bitstream.")
     parser.add_target_argument("--sys-clk-freq",   default=75e6, type=float, help="System clock frequency.")
     parser.add_target_argument("--with-spi-flash", action="store_true",      help="Enable memory-mapped SPI flash.")
+    parser.add_target_argument("--with-i2c",       action="store_true",      help="Enable I2C on PMOD A.")
     ethopts = parser.target_group.add_mutually_exclusive_group()
     ethopts.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support.")
     ethopts.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support.")
@@ -399,12 +395,13 @@ def main():
     parser.add_target_argument("--eth-dynamic-ip", action="store_true",     help="Enable dynamic Ethernet IP assignment.")
     parser.add_target_argument("--remote-ip",      default="192.168.1.100", help="Remote IP address of TFTP server.")
     parser.add_target_argument("--eth-rgmii-phy",  action="store_true",     help="Uses onboard RGMII Phy instead of RMII PMOD.")
-    parser.add_target_argument("--eth-phy",        default=0, type=int,     help="Ethernet PHY: 0 (default) or 1. (Only available with --eth-rgmii-phy")
+    parser.add_target_argument("--eth-phy",        default=0, type=int, choices=[0, 1], help="Ethernet PHY (only available with --eth-rgmii-phy).")
     args = parser.parse_args()
 
     soc = BaseSoC(
         sys_clk_freq   = args.sys_clk_freq,
         with_spi_flash = args.with_spi_flash,
+        with_i2c       = args.with_i2c,
         with_ethernet  = args.with_ethernet,
         with_etherbone = args.with_etherbone,
         eth_ip         = args.eth_ip,

--- a/litex_boards/targets/efinix_t20_f256_dev_kit.py
+++ b/litex_boards/targets/efinix_t20_f256_dev_kit.py
@@ -60,7 +60,7 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=100e6, with_spi_flash=False, with_led_chaser=True, **kwargs):
+    def __init__(self, sys_clk_freq=45e6, with_spi_flash=False, with_led_chaser=True, **kwargs):
         platform = efinix_t20_f256_dev_kit.Platform()
 
         # CRG --------------------------------------------------------------------------------------
@@ -70,7 +70,7 @@ class BaseSoC(SoCCore):
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Efinix Trion T20 BGA256 Dev Kit", **kwargs)
 
         # SDR SDRAM --------------------------------------------------------------------------------
-        if not self.integrated_main_ram_size and sys_clk_freq <= 50e6 :
+        if not self.integrated_main_ram_size and sys_clk_freq <= 50e6:
             self.specials += ClkOutput(ClockSignal("sys_ps"), platform.request("sdram_clock"))
 
             self.sdrphy = GENSDRPHY(platform.request("sdram"), sys_clk_freq)
@@ -106,7 +106,7 @@ def main():
     soc = BaseSoC(
         sys_clk_freq   = args.sys_clk_freq,
         with_spi_flash = args.with_spi_flash,
-         **parser.soc_argdict)
+        **parser.soc_argdict)
     builder = Builder(soc, **parser.builder_argdict)
     if args.build:
         builder.build(**parser.toolchain_argdict)
@@ -117,7 +117,7 @@ def main():
 
     if args.flash:
         from litex.build.openfpgaloader import OpenFPGALoader
-        prog = OpenFPGALoader("trion_t120_bga576")
+        prog = OpenFPGALoader("trion_t20_bga256")
         prog.flash(0, builder.get_bitstream_filename(mode="flash", ext=".hex")) # FIXME
 
 if __name__ == "__main__":

--- a/litex_boards/targets/efinix_t20_mipi_dev_kit.py
+++ b/litex_boards/targets/efinix_t20_mipi_dev_kit.py
@@ -35,13 +35,13 @@ class _CRG(LiteXModule):
 
         self.comb += self.cd_rst.clk.eq(clk50)
 
-         # A pulse is necessary to do a reset.
+        # A pulse is necessary to do a reset.
         self.rst_pulse = Signal()
         self.reset_timer = reset_timer = ClockDomainsRenamer("rst")(WaitTimer(25e-6*platform.default_clk_freq))
         self.comb += self.rst_pulse.eq(self.rst ^ reset_timer.done)
         self.comb += reset_timer.wait.eq(self.rst)
 
-        # PLL
+        # PLL.
         self.pll = pll = TRIONPLL(platform)
         self.comb += pll.reset.eq(~rst_n | self.rst_pulse)
         pll.register_clkin(clk50, platform.default_clk_freq)
@@ -81,10 +81,10 @@ def main():
     parser.add_target_argument("--with-spi-flash", action="store_true",       help="Enable memory-mapped SPI flash.")
     args = parser.parse_args()
 
-    soc     = BaseSoC(
+    soc = BaseSoC(
         sys_clk_freq   = args.sys_clk_freq,
         with_spi_flash = args.with_spi_flash,
-         **parser.soc_argdict)
+        **parser.soc_argdict)
     builder = Builder(soc, **parser.builder_argdict)
     if args.build:
         builder.build(**parser.toolchain_argdict)
@@ -95,7 +95,7 @@ def main():
 
     if args.flash:
         from litex.build.openfpgaloader import OpenFPGALoader
-        prog = OpenFPGALoader("trion_t120_bga576")
+        prog = OpenFPGALoader("trion_t20_bga256")
         prog.flash(0, builder.get_bitstream_filename(mode="flash", ext=".hex")) # FIXME
 
 if __name__ == "__main__":

--- a/litex_boards/targets/efinix_t8_f81_dev_kit.py
+++ b/litex_boards/targets/efinix_t8_f81_dev_kit.py
@@ -61,6 +61,9 @@ class BaseSoC(SoCCore):
         # SoCCore ----------------------------------------------------------------------------------
         # Disable Integrated ROM.
         kwargs["integrated_rom_size"]  = 0
+        # Use Crossover UART by default.
+        if kwargs.get("uart_name", "serial") == "serial":
+            kwargs["uart_name"] = "crossover"
         # Set CPU variant / reset address
         if kwargs.get("cpu_type", "vexriscv") == "vexriscv":
             kwargs["cpu_variant"] = "minimal"

--- a/litex_boards/targets/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/targets/efinix_ti375_c529_dev_kit.py
@@ -88,21 +88,21 @@ class BaseSoC(SoCCore):
     }}
 
     def __init__(self,
-            sys_clk_freq   = 100e6,
-            cpu_clk_freq   = 100e6,
-            with_spi_flash = False,
+            sys_clk_freq     = 100e6,
+            cpu_clk_freq     = 100e6,
+            with_spi_flash   = False,
             spi_flash_number = 0,
-            spi_flash_rate = "1:1",
-            with_ethernet  = False,
-            with_etherbone = False,
-            with_ptp       = False,
-            eth_phy        = "rgmii",
-            eth_ip         = "192.168.1.50",
-            remote_ip      = None,
-            eth_dynamic_ip = False,
-            ptp_p2p        = False,
-            ptp_debug      = False,
-            with_ohci      = False,
+            spi_flash_rate   = "1:2",
+            with_ethernet    = False,
+            with_etherbone   = False,
+            with_ptp         = False,
+            eth_phy          = "rgmii",
+            eth_ip           = "192.168.1.50",
+            remote_ip        = None,
+            eth_dynamic_ip   = False,
+            ptp_p2p          = False,
+            ptp_debug        = False,
+            with_ohci        = False,
             **kwargs):
         platform = efinix_ti375_c529_dev_kit.Platform()
 
@@ -403,7 +403,7 @@ class BaseSoC(SoCCore):
             # (integer) of the reference clock. If all your system clocks do not fall within
             # this range, you should dedicate one unused clock for CLKOUT0.
             pll3.create_clkout(None, 125e6, with_reset=True)
-            pll3.create_clkout(self.cd_eth_rx, 125e6,phase =270)
+            pll3.create_clkout(self.cd_eth_rx, 125e6, phase=270)
 
             platform.add_false_path_constraints(self.crg.cd_sys.clk, self.cd_eth.clk)
 
@@ -456,7 +456,7 @@ def main():
     parser = LiteXArgumentParser(platform=efinix_ti375_c529_dev_kit.Platform, description="LiteX SoC on Efinix Ti375 C529 Dev Kit.")
     parser.add_target_argument("--flash",            action="store_true",                             help="Flash bitstream.")
     parser.add_target_argument("--sys-clk-freq",     default=100e6, type=float,                       help="System clock frequency.")
-    parser.add_target_argument("--cpu-clk-freq",     default=100e6, type=float,                       help="System clock frequency.")
+    parser.add_target_argument("--cpu-clk-freq",     default=100e6, type=float,                       help="CPU clock frequency.")
     parser.add_target_argument("--with-spi-flash",   action="store_true",                             help="Enable SPI Flash.")
     parser.add_target_argument("--spi-flash-number", default=0, type=int, choices=[0, 1],             help="SPI Flash number.")
     parser.add_target_argument("--spi-flash-rate",   default="1:2", type=str, choices=["1:1", "1:2"], help="SPI Flash rate.")

--- a/litex_boards/targets/efinix_tz170_j484_dev_kit.py
+++ b/litex_boards/targets/efinix_tz170_j484_dev_kit.py
@@ -74,7 +74,14 @@ class _CRG_DDR(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, sys_clk_freq=100e6, cpu_clk_freq=175e6, with_spi_flash=False, spi_flash_number=0, spi_flash_rate="1:1", with_led_chaser=True, **kwargs):
+    def __init__(self,
+        sys_clk_freq     = 100e6,
+        cpu_clk_freq     = 175e6,
+        with_spi_flash   = False,
+        spi_flash_number = 0,
+        spi_flash_rate   = "1:2",
+        with_led_chaser  = False,
+        **kwargs):
         platform = efinix_tz170_j484_dev_kit.Platform()
 
         # CRG --------------------------------------------------------------------------------------
@@ -138,8 +145,14 @@ def main():
     parser.add_target_argument("--with-led-chaser",  action="store_true",                             help="Enable LED Chaser.")
     args = parser.parse_args()
 
-    soc = BaseSoC(args.sys_clk_freq, args.cpu_clk_freq, args.with_spi_flash,
-                  args.spi_flash_number, args.spi_flash_rate, args.with_led_chaser, **parser.soc_argdict)
+    soc = BaseSoC(
+        sys_clk_freq     = args.sys_clk_freq,
+        cpu_clk_freq     = args.cpu_clk_freq,
+        with_spi_flash   = args.with_spi_flash,
+        spi_flash_number = args.spi_flash_number,
+        spi_flash_rate   = args.spi_flash_rate,
+        with_led_chaser  = args.with_led_chaser,
+        **parser.soc_argdict)
 
     if args.with_spi_sdcard:
         soc.add_spi_sdcard()

--- a/litex_boards/targets/efinix_tz170_j484_dev_kit.py
+++ b/litex_boards/targets/efinix_tz170_j484_dev_kit.py
@@ -10,17 +10,13 @@ from migen import *
 
 from litex.gen import *
 
-from litex.build.generic_platform import Subsignal, Pins
-
 from litex_boards.platforms import efinix_tz170_j484_dev_kit
 
 from litex.soc.integration.soc import *
-from litex.soc.integration.soc import SoCRegion
 from litex.soc.integration.builder import *
 
-from litex.soc.interconnect import axi
-
 from litex.soc.cores.clock.efinix import *
+from litex.soc.cores.ram.efinix_ddr import EfinixDDR, add_efinix_ddr
 
 # CRG ----------------------------------------------------------------------------------------------
 
@@ -75,149 +71,6 @@ class _CRG_DDR(LiteXModule):
         pll.create_clkout(None,         600e6, nclkout=4, margin=1e-02) # LPDDR4 ctrl
 
 
-class EfinixLPDDR4(LiteXModule):
-    def __init__(self, soc, axi_clk, own_crg=True):
-        platform = soc.platform
-        data_width = 512
-
-        # DRAM Blocks.
-        # ------------------
-        from litex.build.efinix import InterfaceWriterBlock
-
-        self.bus = axi_bus = axi.AXIInterface(data_width=data_width, address_width=33, id_width=8)
-
-        if own_crg:
-            self.ddr_crg = _CRG_DDR(platform)
-
-        class EfinixDRAMBlock(InterfaceWriterBlock):
-            @staticmethod
-            def generate():
-                name          = "ddr_inst1"
-                ddr_def       = "DDR_0"
-                clkin_sel     = "CLKIN 2"
-                data_width    = "32"
-                physical_rank = "1"
-                mem_type      = "LPDDR4"
-                mem_density   = "8G"
-
-                cmd = []
-                cmd.append('design.create_block("{}", "DDR")'.format(name))
-                cmd.append('design.set_property("{}", "MEMORY_TYPE",    "{}", "DDR")'.format(name, mem_type))
-                cmd.append('design.set_property("{}", "DQ_WIDTH",       "{}", "DDR")'.format(name, data_width))
-                cmd.append('design.set_property("{}", "MEMORY_DENSITY", "{}", "DDR")'.format(name, mem_density))
-                cmd.append('design.set_property("{}", "PHYSICAL_RANK",  "{}", "DDR")'.format(name, physical_rank))
-                cmd.append('design.set_property("{}", "CLKIN_SEL",      "{}", "DDR")'.format(name, clkin_sel))
-
-                cmd.append('design.set_property("{}","TARGET0_EN",      "1", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","TARGET1_EN",      "0", "DDR")'.format(name))
-
-                cmd.append('design.set_property("{}","AXI0_ARADDR_BUS","ddr0_araddr", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARAPCMD_PIN","ddr0_arapcmd", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARBURST_BUS","ddr0_arburst", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARID_BUS","ddr0_arid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARLEN_BUS","ddr0_arlen", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARLOCK_PIN","ddr0_arlock", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARQOS_PIN","ddr0_arqos", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARREADY_PIN","ddr0_arready", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARSIZE_BUS","ddr0_arsize", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARSTN_PIN","ddr0_resetn", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_ARVALID_PIN","ddr0_arvalid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWADDR_BUS","ddr0_awaddr", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWALLSTRB_PIN","ddr0_awallstrb", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWAPCMD_PIN","ddr0_awapcmd", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWBURST_BUS","ddr0_awburst", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWCACHE_BUS","ddr0_awcache", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWCOBUF_PIN","ddr0_awcobuf", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWID_BUS","ddr0_awid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWLEN_BUS","ddr0_awlen", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWLOCK_PIN","ddr0_awlock", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWQOS_PIN","ddr0_awqos", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWREADY_PIN","ddr0_awready", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWSIZE_BUS","ddr0_awsize", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_AWVALID_PIN","ddr0_awvalid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_BID_BUS","ddr0_bid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_BREADY_PIN","ddr0_bready", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_BRESP_BUS","ddr0_bresp", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_BVALID_PIN","ddr0_bvalid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_CLK_INPUT_PIN","{}", "DDR")'.format(name, axi_clk))
-                cmd.append('design.set_property("{}","AXI0_CLK_INVERT_EN","0", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_DATA_WIDTH","512", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_RDATA_BUS","ddr0_rdata", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_RID_BUS","ddr0_rid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_RLAST_PIN","ddr0_rlast", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_RREADY_PIN","ddr0_rready", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_RRESP_BUS","ddr0_rresp", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_RVALID_PIN","ddr0_rvalid", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_WDATA_BUS","ddr0_wdata", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_WLAST_PIN","ddr0_wlast", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_WREADY_PIN","ddr0_wready", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_WSTRB_BUS","ddr0_wstrb", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","AXI0_WVALID_PIN","ddr0_wvalid", "DDR")'.format(name))
-
-                cmd.append('design.set_property("{}","CFG_DONE_PIN",   "cfg_done", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CFG_RESET_PIN",  "cfg_reset", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CFG_SEL_PIN",    "cfg_sel", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CFG_START_PIN",  "cfg_start", "DDR")'.format(name))
-
-                cmd.append('design.set_property("{}","CTRL_BUSY_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_CKE_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_CLK_INVERT_EN","0", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_CLK_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_CMD_Q_ALMOST_FULL_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_DP_IDLE_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_INT_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_MEM_RST_VALID_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_PORT_BUSY_PIN","", "DDR")'.format(name))
-                cmd.append('design.set_property("{}","CTRL_REFRESH_PIN","", "DDR")'.format(name))
-
-                cmd.append('design.assign_resource("{}", "{}","DDR")\n'.format(name, ddr_def))
-
-                return '\n'.join(cmd) + '\n'
-
-        platform.toolchain.ifacewriter.blocks.append(EfinixDRAMBlock())
-
-        # DRAM AXI-Ports.
-        # --------------
-        axi_io = platform.add_iface_ios(axi_bus.get_ios("ddr0"))
-        self.comb += axi_bus.connect_to_pads(axi_io, mode="master")
-
-        ios = [(f"ddr0", 0,
-            Subsignal("arapcmd",   Pins(1)),
-            Subsignal("awallstrb", Pins(1)),
-            Subsignal("awapcmd",   Pins(1)),
-            Subsignal("awcobuf",    Pins(1)),
-            Subsignal("resetn",     Pins(1)),
-        )]
-
-        io   = platform.add_iface_ios(ios)
-        self.comb += [
-            io.arapcmd.eq(0),
-            io.awallstrb.eq(getattr(soc.cpu, "mBus_awallStrb", 0)),
-            io.awapcmd.eq(0),
-            io.awcobuf.eq(0),
-            io.resetn.eq(~ResetSignal()),
-        ]
-
-        cfgs = [(f"cfg", 0,
-            Subsignal("start",  Pins(1)),
-            Subsignal("reset",  Pins(1)),
-            Subsignal("sel",    Pins(1)),
-            Subsignal("done",   Pins(1)),
-        )]
-
-        cfg = platform.add_iface_ios(cfgs)
-        self.cfg_state = Signal(1, reset=0)
-        self.cfg_count = Signal(8, reset=0)
-
-        self.comb += [
-            cfg.sel.eq(0),
-            cfg.reset.eq(self.cfg_state == 0),
-            cfg.start.eq(self.cfg_state != 0),
-        ]
-
-        self.sync += self.cfg_count.eq(self.cfg_count + (self.cfg_count != 0xFF))
-        self.sync += self.cfg_state.eq(self.cfg_state | (self.cfg_count == 0xFF))
-
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
@@ -234,31 +87,17 @@ class BaseSoC(SoCCore):
 
         # LPDDR4 SDRAM -----------------------------------------------------------------------------
         if not self.integrated_main_ram_size:
-            if hasattr(self.cpu, "add_memory_buses") and hasattr(self.cpu, "cpu_clk"):
-                axi_clk = self.crg.cd_cpu.clk.name_override
-            else:
-                axi_clk = self.crg.cd_sys.clk.name_override
-
-            self.ddr = EfinixLPDDR4(self, axi_clk)
-            axi_bus = self.ddr.bus
-
-            soc_region = SoCRegion(
-                origin = self.mem_map.get("main_ram", None),
-                size   = 0x4000_0000, # 1GB.
-                mode   ="rwx",
+            self.ddr_crg = _CRG_DDR(platform)
+            clock_domain = "cpu" if (
+                hasattr(self.cpu, "add_memory_buses") and
+                hasattr(self.cpu, "cpu_clk")
+            ) else "sys"
+            self.ddr = EfinixDDR(
+                platform     = platform,
+                clock_domain = clock_domain,
+                **platform.ddr_config,
             )
-            # Use DRAM's target0 port as Main Ram.
-            if hasattr(self.cpu, "add_memory_buses"):
-                self.cpu.add_memory_buses(address_width = 32, data_width = axi_bus.data_width)
-
-                assert len(self.cpu.memory_buses) == 1
-                mbus = self.cpu.memory_buses[0]
-                self.comb +=mbus.connect(axi_bus)
-                self.bus.add_region("main_ram", soc_region)
-            else:
-                axi_lite_bus = axi.AXILiteInterface(data_width=axi_bus.data_width, address_width=axi_bus.address_width)
-                self.submodules += axi.AXILite2AXI(axi_lite_bus, axi_bus)
-                self.bus.add_slave("main_ram", axi_lite_bus, soc_region)
+            add_efinix_ddr(self, self.ddr, size=platform.ddr_size)
 
         # SPI Flash --------------------------------------------------------------------------------
         if with_spi_flash:

--- a/litex_boards/targets/efinix_xyloni_dev_kit.py
+++ b/litex_boards/targets/efinix_xyloni_dev_kit.py
@@ -94,9 +94,10 @@ def main():
     parser.add_target_argument("--bios-flash-offset", default="0x40000",            help="BIOS offset in SPI Flash.")
 
     args = parser.parse_args()
+    bios_flash_offset = int(args.bios_flash_offset, 0)
 
     soc = BaseSoC(
-        bios_flash_offset = int(args.bios_flash_offset, 0),
+        bios_flash_offset = bios_flash_offset,
         sys_clk_freq      = args.sys_clk_freq,
         **parser.soc_argdict)
     builder = Builder(soc, **parser.builder_argdict)
@@ -110,7 +111,7 @@ def main():
     if args.flash:
         prog = soc.platform.create_programmer()
         prog.flash(0, builder.get_bitstream_filename(mode="flash", ext=".hex")) # FIXME
-        prog.flash(args.bios_flash_offset, builder.get_bios_filename())
+        prog.flash(bios_flash_offset, builder.get_bios_filename())
 
 if __name__ == "__main__":
     main()

--- a/litex_boards/targets/jungle_electronics_fireant.py
+++ b/litex_boards/targets/jungle_electronics_fireant.py
@@ -64,7 +64,7 @@ serial = [
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, bios_flash_offset, sys_clk_freq=33.333e6, with_led_chaser=True, **kwargs):
+    def __init__(self, bios_flash_offset, sys_clk_freq=33.33e6, with_led_chaser=True, **kwargs):
         platform = jungle_electronics_fireant.Platform()
         platform.add_extension(serial)
 
@@ -82,7 +82,7 @@ class BaseSoC(SoCCore):
         # SPI Flash --------------------------------------------------------------------------------
         from litespi.modules import W25Q80BV
         from litespi.opcodes import SpiNorFlashOpCodes as Codes
-        # Board is using W25Q80DV, which is replacemenet for W25Q80BV
+        # Board is using W25Q80DV, which is a replacement for W25Q80BV.
         self.add_spi_flash(name="spiflash", mode="1x", module=W25Q80BV(Codes.READ_1_1_1), with_master=False)
 
         # Add ROM linker region --------------------------------------------------------------------
@@ -105,12 +105,13 @@ def main():
     from litex.build.parser import LiteXArgumentParser
     parser = LiteXArgumentParser(platform=jungle_electronics_fireant.Platform, description="LiteX SoC on Jungle Electronics FireAnt.")
     parser.add_target_argument("--flash",             action="store_true",          help="Flash bitstream.")
-    parser.add_target_argument("--sys-clk-freq",      default=33.333e6, type=float, help="System clock frequency.")
+    parser.add_target_argument("--sys-clk-freq",      default=33.33e6, type=float,  help="System clock frequency.")
     parser.add_target_argument("--bios-flash-offset", default="0x40000",            help="BIOS offset in SPI Flash.")
     args = parser.parse_args()
+    bios_flash_offset = int(args.bios_flash_offset, 0)
 
     soc = BaseSoC(
-        bios_flash_offset = int(args.bios_flash_offset, 0),
+        bios_flash_offset = bios_flash_offset,
         sys_clk_freq      = args.sys_clk_freq,
         **parser.soc_argdict)
     builder = Builder(soc, **parser.builder_argdict)
@@ -124,7 +125,7 @@ def main():
     if args.flash:
         prog = soc.platform.create_programmer()
         prog.flash(0, builder.get_bitstream_filename(mode="flash", ext=".hex")) # FIXME
-        prog.flash(args.bios_flash_offset, builder.get_bios_filename())
+        prog.flash(bios_flash_offset, builder.get_bios_filename())
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- align Efinix target API defaults with their command-line configurations
- use matching T20 OpenFPGALoader profiles and integer BIOS flash offsets
- make T120 PMOD I2C support explicit and remove its build delay
- make the T8 target usable with its default UART selection
- derive platform timing constraints from default clock metadata
- bring the already-reviewed TZ170 common DDR integration from the stacked branch onto master

## Validation

- `pytest -q test/test_targets.py::TestTargets::test_efinity_targets`
  - 1 passed, 10 subtests passed
- focused T120 build with `--with-i2c --no-compile-gateware --no-compile-software`
- Python compile and `git diff --check`
