### PR TITLE
targets/efinix_ti60: use common HyperRAM integration

### DIFF
--- a/litex_boards/targets/efinix_ti60_f225_dev_kit.py
+++ b/litex_boards/targets/efinix_ti60_f225_dev_kit.py
@@ -16,10 +16,6 @@ from litex_boards.platforms import efinix_ti60_f225_dev_kit
 from litex.soc.cores.clock import *
 from litex.soc.integration.soc import *
 from litex.soc.integration.builder import *
-from litex.soc.integration.soc import SoCRegion
-from litex.soc.interconnect import wishbone
-
-from litex.soc.cores.hyperbus import HyperRAM
 
 from liteeth.phy.titaniumrgmii import LiteEthPHYRGMII
 
@@ -87,35 +83,16 @@ class BaseSoC(SoCCore):
 
         # HyperRAM ---------------------------------------------------------------------------------
         if with_hyperram:
-            # HyperRAM Parameters.
-            hyperram_device     = "W958D6NW"
-            hyperram_size       = 32 * MEGABYTE
-            hyperram_cache_size = 16 * KILOBYTE
-
-            # HyperRAM Bus/Slave Interface.
-            hyperram_bus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
-            self.bus.add_slave(name="main_ram", slave=hyperram_bus, region=SoCRegion(origin=0x40000000, size=hyperram_size, mode="rwx"))
-
-            # HyperRAM L2 Cache.
-            hyperram_cache = wishbone.Cache(
-                cachesize = hyperram_cache_size//4,
-                master    = hyperram_bus,
-                slave     = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+            self.add_hyperram(
+                region_name   = "main_ram",
+                origin        = self.mem_map["main_ram"],
+                size          = 32*MEGABYTE,
+                l2_cache_size = 16*KILOBYTE,
+                latency       = 7,
+                latency_mode  = "variable",
+                clk_ratio     = "2:1",
+                dq_i_cd       = "sys2x_ps",
             )
-            hyperram_cache = FullMemoryWE()(hyperram_cache)
-            self.hyperram_cache = hyperram_cache
-            self.add_config("L2_SIZE", hyperram_cache_size)
-
-            # HyperRAM Core.
-            self.hyperram = HyperRAM(
-                pads         = platform.request("hyperram"),
-                latency      = 7,
-                latency_mode = "variable",
-                sys_clk_freq = sys_clk_freq,
-                clk_ratio    = "2:1",
-                dq_i_cd      = "sys2x_ps",
-            )
-            self.comb += self.hyperram_cache.slave.connect(self.hyperram.bus)
 
         # Ethernet / Etherbone ---------------------------------------------------------------------
         if with_ethernet or with_etherbone:


### PR DESCRIPTION
## Summary

- replace the TI60 target-local Wishbone, cache, and HyperRAM plumbing with `SoC.add_hyperram()`
- preserve the 32 MB main RAM region and 16 KB L2 cache
- preserve variable latency, the 2:1 clock ratio, and `sys2x_ps` input sampling

This removes 32 lines of target-specific integration code.

## Dependency

- enjoy-digital/litex#2547

## Validation

- generated the TI60 Efinity project with `--with-hyperram --build --no-compile`
- compared the previous and new implementations
  - CSR map and `CONFIG_L2_SIZE` are unchanged
  - Efinity peripheral XML is unchanged
  - SoC hierarchy, memory map, cache size, and HyperRAM parameters are unchanged

Efinity 2025.1 reports the existing `sys2x_ps_pll0_clk:PHASE_SHIFT` design-check diagnostic for the 315-degree sampling clock in both the previous and new implementations. This migration does not change that clocking configuration.
