### PR TITLE
targets: uses self.cpu.set_libxil instead of explicit/dupplicated code for all boards based on zynq7000/zynmpMP

### DIFF
--- a/litex_boards/targets/alinx_axu2cga.py
+++ b/litex_boards/targets/alinx_axu2cga.py
@@ -16,16 +16,11 @@
 # Relies on https://github.com/lucaceresoli/zynqmp-pmufw-builder to create a generic PMU firmware;
 # first build will take a while because it includes a cross-toolchain.
 
-import os
-
 from migen import *
 
 from litex.gen import *
 
 from litex_boards.platforms import alinx_axu2cga
-
-from litex.build.tools import write_to_file
-
 
 from litex.soc.cores.clock import *
 from litex.soc.integration.soc import *
@@ -89,69 +84,21 @@ class BaseSoC(SoCCore):
                 linker = True)
             )
             self.constants["CONFIG_CLOCK_FREQUENCY"] = 1199880127
+            self.cpu.set_libxil({
+                "STDIN_BASEADDRESS"                         : "0xFF010000",
+                "STDOUT_BASEADDRESS"                        : "0xFF010000",
+                "XPAR_PSU_DDR_0_S_AXI_BASEADDR"             : "0x00000000",
+                "XPAR_PSU_DDR_0_S_AXI_HIGHADDR"             : "0x7FFFFFFF",
+                "XPAR_PSU_DDR_1_S_AXI_BASEADDR"             : "0x800000000",
+                "XPAR_PSU_DDR_1_S_AXI_HIGHADDR"             : "0x87FFFFFFF",
+                "XPAR_CPU_CORTEXA53_0_TIMESTAMP_CLK_FREQ"   : "99999005",
+            })
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:
             self.leds = LedChaser(
                 pads         = platform.request_all("user_led"),
                 sys_clk_freq = sys_clk_freq)
-
-    def finalize(self, *args, **kwargs):
-        super(BaseSoC, self).finalize(*args, **kwargs)
-        if self.cpu_type != "zynqmp":
-            return
-
-        libxil_path = os.path.join(self.builder.software_dir, 'libxil')
-        os.makedirs(os.path.realpath(libxil_path), exist_ok=True)
-        lib = os.path.join(libxil_path, 'embeddedsw')
-        if not os.path.exists(lib):
-            os.system("git clone --depth 1 https://github.com/Xilinx/embeddedsw {}".format(lib))
-
-        os.makedirs(os.path.realpath(self.builder.include_dir), exist_ok=True)
-
-        for header in [
-            'XilinxProcessorIPLib/drivers/uartps/src/xuartps_hw.h',
-            'lib/bsp/standalone/src/common/xil_types.h',
-            'lib/bsp/standalone/src/common/xil_assert.h',
-            'lib/bsp/standalone/src/common/xil_io.h',
-            'lib/bsp/standalone/src/common/xil_printf.h',
-            'lib/bsp/standalone/src/common/xstatus.h',
-            'lib/bsp/standalone/src/common/xdebug.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/xpseudo_asm.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/xreg_cortexa53.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/xil_cache.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/xil_errata.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/platform/ZynqMP/xparameters_ps.h',
-            'lib/bsp/standalone/src/arm/common/xil_exception.h',
-            'lib/bsp/standalone/src/arm/common/gcc/xpseudo_asm_gcc.h',
-        ]:
-            shutil.copy(os.path.join(lib, header), self.builder.include_dir)
-
-        write_to_file(os.path.join(self.builder.include_dir, 'bspconfig.h'), """
-#ifndef BSPCONFIG_H
-#define BSPCONFIG_H
-
-#define EL3 1
-#define EL1_NONSECURE 0
-
-#endif
-""")
-        write_to_file(os.path.join(self.builder.include_dir, 'xparameters.h'), '''
-#ifndef XPARAMETERS_H
-#define XPARAMETERS_H
-
-#include "xparameters_ps.h"
-
-#define STDIN_BASEADDRESS 0xFF010000
-#define STDOUT_BASEADDRESS 0xFF010000
-#define XPAR_PSU_DDR_0_S_AXI_BASEADDR 0x00000000
-#define XPAR_PSU_DDR_0_S_AXI_HIGHADDR 0x7FFFFFFF
-#define XPAR_PSU_DDR_1_S_AXI_BASEADDR 0x800000000
-#define XPAR_PSU_DDR_1_S_AXI_HIGHADDR 0x87FFFFFFF
-#define XPAR_CPU_CORTEXA53_0_TIMESTAMP_CLK_FREQ 99999005
-
-#endif
-''')
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -168,10 +115,6 @@ def main():
         **parser.soc_argdict
     )
     builder = Builder(soc, **parser.builder_argdict)
-    if args.cpu_type == "zynqmp":
-        soc.builder = builder
-        builder.add_software_package('libxil')
-        builder.add_software_library('libxil')
     if args.build:
         builder.build(**parser.toolchain_argdict)
 

--- a/litex_boards/targets/digilent_arty_z7.py
+++ b/litex_boards/targets/digilent_arty_z7.py
@@ -32,8 +32,6 @@ from migen import *
 from litex.gen import *
 
 from litex_boards.platforms import digilent_arty_z7
-from litex.build.tools import write_to_file
-
 
 from litex.soc.cores.clock import *
 from litex.soc.integration.soc import *
@@ -107,57 +105,17 @@ class BaseSoC(SoCCore):
             )
             self.constants["CONFIG_CLOCK_FREQUENCY"] = 666666687
             self.bus.add_region("flash",  SoCRegion(origin=0xFC00_0000, size=0x4_0000, mode="rwx"))
+            self.cpu.set_libxil({
+                "STDOUT_BASEADDRESS"            : "0xE0000000",
+                "XPAR_PS7_DDR_0_S_AXI_BASEADDR" : "0x00100000",
+                "XPAR_PS7_DDR_0_S_AXI_HIGHADDR" : "0x1FFFFFFF",
+            })
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:
             self.leds = LedChaser(
                 pads         = platform.request_all("user_led"),
                 sys_clk_freq = sys_clk_freq)
-
-    def finalize(self, *args, **kwargs):
-        super(BaseSoC, self).finalize(*args, **kwargs)
-        if self.cpu_type != "zynq7000":
-            return
-
-        libxil_path = os.path.join(self.builder.software_dir, 'libxil')
-        os.makedirs(os.path.realpath(libxil_path), exist_ok=True)
-        lib = os.path.join(libxil_path, 'embeddedsw')
-        if not os.path.exists(lib):
-            os.system("git clone --depth 1 https://github.com/Xilinx/embeddedsw {}".format(lib))
-
-        os.makedirs(os.path.realpath(self.builder.include_dir), exist_ok=True)
-        for header in [
-            'XilinxProcessorIPLib/drivers/uartps/src/xuartps_hw.h',
-            'lib/bsp/standalone/src/common/xil_types.h',
-            'lib/bsp/standalone/src/common/xil_assert.h',
-            'lib/bsp/standalone/src/common/xil_io.h',
-            'lib/bsp/standalone/src/common/xil_printf.h',
-            'lib/bsp/standalone/src/common/xstatus.h',
-            'lib/bsp/standalone/src/common/xdebug.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xpseudo_asm.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xreg_cortexa9.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xil_cache.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xparameters_ps.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xil_errata.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xtime_l.h',
-            'lib/bsp/standalone/src/arm/common/xil_exception.h',
-            'lib/bsp/standalone/src/arm/common/gcc/xpseudo_asm_gcc.h',
-        ]:
-            shutil.copy(os.path.join(lib, header), self.builder.include_dir)
-        write_to_file(os.path.join(self.builder.include_dir, 'bspconfig.h'),
-                      '#define FPU_HARD_FLOAT_ABI_ENABLED 1')
-        write_to_file(os.path.join(self.builder.include_dir, 'xparameters.h'), '''
-#ifndef __XPARAMETERS_H
-#define __XPARAMETERS_H
-
-#include "xparameters_ps.h"
-
-#define STDOUT_BASEADDRESS 0xE0000000
-#define XPAR_PS7_DDR_0_S_AXI_BASEADDR 0x00100000
-#define XPAR_PS7_DDR_0_S_AXI_HIGHADDR 0x1FFFFFFF
-
-#endif
-''')
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -177,10 +135,6 @@ def main():
         **parser.soc_argdict
     )
     builder = Builder(soc, **parser.builder_argdict)
-    if args.cpu_type == "zynq7000":
-        soc.builder = builder
-        builder.add_software_package('libxil')
-        builder.add_software_library('libxil')
     if args.build:
         builder.build(**parser.toolchain_argdict)
 

--- a/litex_boards/targets/digilent_zedboard.py
+++ b/litex_boards/targets/digilent_zedboard.py
@@ -11,8 +11,6 @@ from migen import *
 from litex.gen import *
 
 from litex_boards.platforms import digilent_zedboard
-from litex.build.tools import write_to_file
-
 
 from litex.soc.cores.clock import *
 from litex.soc.integration.soc import *
@@ -57,7 +55,7 @@ class BaseSoC(SoCCore):
             platform.add_extension(usb_pmod_io("pmodb"))
             if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "usb_uart"
         else:
-            kwargs["no_uart"] = True
+            kwargs["with_uart"] = False
 
         # CRG --------------------------------------------------------------------------------------
         use_ps7_clk = (kwargs.get("cpu_type", None) == "zynq7000")
@@ -84,57 +82,17 @@ class BaseSoC(SoCCore):
                 linker = True)
             )
             self.constants["CONFIG_CLOCK_FREQUENCY"] = 666666687
+            self.cpu.set_libxil({
+                "STDOUT_BASEADDRESS"            : "0xE0001000",
+                "XPAR_PS7_DDR_0_S_AXI_BASEADDR" : "0x00100000",
+                "XPAR_PS7_DDR_0_S_AXI_HIGHADDR" : "0x3FFFFFFF",
+            })
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:
             self.leds = LedChaser(
                 pads         = platform.request_all("user_led"),
                 sys_clk_freq = sys_clk_freq)
-
-    def finalize(self, *args, **kwargs):
-        super(BaseSoC, self).finalize(*args, **kwargs)
-        if self.cpu_type != "zynq7000":
-            return
-
-        libxil_path = os.path.join(self.builder.software_dir, 'libxil')
-        os.makedirs(os.path.realpath(libxil_path), exist_ok=True)
-        lib = os.path.join(libxil_path, 'embeddedsw')
-        if not os.path.exists(lib):
-            os.system("git clone --depth 1 https://github.com/Xilinx/embeddedsw {}".format(lib))
-
-        os.makedirs(os.path.realpath(self.builder.include_dir), exist_ok=True)
-        for header in [
-            'XilinxProcessorIPLib/drivers/uartps/src/xuartps_hw.h',
-            'lib/bsp/standalone/src/common/xil_types.h',
-            'lib/bsp/standalone/src/common/xil_assert.h',
-            'lib/bsp/standalone/src/common/xil_io.h',
-            'lib/bsp/standalone/src/common/xil_printf.h',
-            'lib/bsp/standalone/src/common/xstatus.h',
-            'lib/bsp/standalone/src/common/xdebug.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xpseudo_asm.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xreg_cortexa9.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xil_cache.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xparameters_ps.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xil_errata.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xtime_l.h',
-            'lib/bsp/standalone/src/arm/common/xil_exception.h',
-            'lib/bsp/standalone/src/arm/common/gcc/xpseudo_asm_gcc.h',
-        ]:
-            shutil.copy(os.path.join(lib, header), self.builder.include_dir)
-        write_to_file(os.path.join(self.builder.include_dir, 'bspconfig.h'),
-                      '#define FPU_HARD_FLOAT_ABI_ENABLED 1')
-        write_to_file(os.path.join(self.builder.include_dir, 'xparameters.h'), '''
-#ifndef __XPARAMETERS_H
-#define __XPARAMETERS_H
-
-#include "xparameters_ps.h"
-
-#define STDOUT_BASEADDRESS 0xE0001000
-#define XPAR_PS7_DDR_0_S_AXI_BASEADDR 0x00100000
-#define XPAR_PS7_DDR_0_S_AXI_HIGHADDR 0x3FFFFFFF
-
-#endif
-''')
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -151,10 +109,6 @@ def main():
         **parser.soc_argdict
     )
     builder = Builder(soc, **parser.builder_argdict)
-    if args.cpu_type == "zynq7000":
-        soc.builder = builder
-        builder.add_software_package('libxil')
-        builder.add_software_library('libxil')
     if args.build:
         builder.build(**parser.toolchain_argdict)
 

--- a/litex_boards/targets/puzhi_p7_starlite.py
+++ b/litex_boards/targets/puzhi_p7_starlite.py
@@ -12,8 +12,6 @@ from litex.gen import *
 
 from litex_boards.platforms import puzhi_p7_starlite
 
-from litex.build.tools import write_to_file
-
 from litex.soc.integration.soc import *
 from litex.soc.integration.soc import SoCRegion
 from litex.soc.integration.builder import *
@@ -119,6 +117,11 @@ class BaseSoC(SoCCore):
 
             # Enable SDIO.
             self.cpu.add_sdio(0, "MIO 40 .. 45", None, None, None)
+            self.cpu.set_libxil({
+                "STDOUT_BASEADDRESS"            : "0xE0000000",
+                "XPAR_PS7_DDR_0_S_AXI_BASEADDR" : "0x00100000",
+                "XPAR_PS7_DDR_0_S_AXI_HIGHADDR" : "0x1FFFFFFF",
+            })
 
         if not with_ps7 and (with_ethernet or with_etherbone):
             self.ethphy = LiteEthPHYRGMII(
@@ -134,51 +137,6 @@ class BaseSoC(SoCCore):
             self.leds = LedChaser(
                 pads         = platform.request_all("user_led"),
                 sys_clk_freq = sys_clk_freq)
-
-    def finalize(self, *args, **kwargs):
-        super(BaseSoC, self).finalize(*args, **kwargs)
-        if self.cpu_type != "zynq7000":
-            return
-
-        libxil_path = os.path.join(self.builder.software_dir, 'libxil')
-        os.makedirs(os.path.realpath(libxil_path), exist_ok=True)
-        lib = os.path.join(libxil_path, 'embeddedsw')
-        if not os.path.exists(lib):
-            os.system("git clone --depth 1 https://github.com/Xilinx/embeddedsw {}".format(lib))
-
-        os.makedirs(os.path.realpath(self.builder.include_dir), exist_ok=True)
-        for header in [
-            'XilinxProcessorIPLib/drivers/uartps/src/xuartps_hw.h',
-            'lib/bsp/standalone/src/common/xil_types.h',
-            'lib/bsp/standalone/src/common/xil_assert.h',
-            'lib/bsp/standalone/src/common/xil_io.h',
-            'lib/bsp/standalone/src/common/xil_printf.h',
-            'lib/bsp/standalone/src/common/xstatus.h',
-            'lib/bsp/standalone/src/common/xdebug.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xpseudo_asm.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xreg_cortexa9.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xil_cache.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xparameters_ps.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xil_errata.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xtime_l.h',
-            'lib/bsp/standalone/src/arm/common/xil_exception.h',
-            'lib/bsp/standalone/src/arm/common/gcc/xpseudo_asm_gcc.h',
-        ]:
-            shutil.copy(os.path.join(lib, header), self.builder.include_dir)
-        write_to_file(os.path.join(self.builder.include_dir, 'bspconfig.h'),
-                      '#define FPU_HARD_FLOAT_ABI_ENABLED 1')
-        write_to_file(os.path.join(self.builder.include_dir, 'xparameters.h'), '''
-#ifndef __XPARAMETERS_H
-#define __XPARAMETERS_H
-
-#include "xparameters_ps.h"
-
-#define STDOUT_BASEADDRESS 0xE0000000
-#define XPAR_PS7_DDR_0_S_AXI_BASEADDR 0x00100000
-#define XPAR_PS7_DDR_0_S_AXI_HIGHADDR 0x1FFFFFFF
-
-#endif
-''')
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -213,11 +171,6 @@ def main():
     )
 
     builder = Builder(soc, **parser.builder_argdict)
-    if args.cpu_type == "zynq7000":
-        soc.builder = builder
-        builder.add_software_package('libxil')
-        builder.add_software_library('libxil')
-
     if args.build:
         builder.build(**parser.toolchain_argdict)
 

--- a/litex_boards/targets/redpitaya.py
+++ b/litex_boards/targets/redpitaya.py
@@ -91,6 +91,12 @@ class BaseSoC(SoCCore):
             # Enable Ethernet.
             self.cpu.add_ethernet(0, "MIO 16 .. 27", "MIO 52 .. 53")
 
+            self.cpu.set_libxil({
+                "STDOUT_BASEADDRESS"            : "XPS_UART0_BASEADDR",
+                "XPAR_PS7_DDR_0_S_AXI_BASEADDR" : "0x00100000",
+                "XPAR_PS7_DDR_0_S_AXI_HIGHADDR" : "0x1FFFFFFF",
+            })
+
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:
             self.leds = LedChaser(

--- a/litex_boards/targets/xilinx_kv260.py
+++ b/litex_boards/targets/xilinx_kv260.py
@@ -16,15 +16,11 @@
 # Relies on https://github.com/lucaceresoli/zynqmp-pmufw-builder to create a generic PMU firmware;
 # first build will take a while because it includes a cross-toolchain.
 
-import os
-
 from migen import *
 
 from litex.gen import *
 
 from litex_boards.platforms import xilinx_kv260
-from litex.build.tools import write_to_file
-
 
 from litex.soc.cores.clock import *
 from litex.soc.integration.soc import *
@@ -133,63 +129,15 @@ class BaseSoC(SoCCore):
                 linker = True)
             )
             self.constants["CONFIG_CLOCK_FREQUENCY"] = 1333333008
-
-    def finalize(self, *args, **kwargs):
-        super(BaseSoC, self).finalize(*args, **kwargs)
-        if self.cpu_type != "zynqmp":
-            return
-
-        libxil_path = os.path.join(self.builder.software_dir, 'libxil')
-        os.makedirs(os.path.realpath(libxil_path), exist_ok=True)
-        lib = os.path.join(libxil_path, 'embeddedsw')
-        if not os.path.exists(lib):
-            os.system("git clone --depth 1 https://github.com/Xilinx/embeddedsw {}".format(lib))
-
-        os.makedirs(os.path.realpath(self.builder.include_dir), exist_ok=True)
-
-        for header in [
-            'XilinxProcessorIPLib/drivers/uartps/src/xuartps_hw.h',
-            'lib/bsp/standalone/src/common/xil_types.h',
-            'lib/bsp/standalone/src/common/xil_assert.h',
-            'lib/bsp/standalone/src/common/xil_io.h',
-            'lib/bsp/standalone/src/common/xil_printf.h',
-            'lib/bsp/standalone/src/common/xstatus.h',
-            'lib/bsp/standalone/src/common/xdebug.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/xpseudo_asm.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/xreg_cortexa53.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/xil_cache.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/xil_errata.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/platform/ZynqMP/xparameters_ps.h',
-            'lib/bsp/standalone/src/arm/common/xil_exception.h',
-            'lib/bsp/standalone/src/arm/common/gcc/xpseudo_asm_gcc.h',
-        ]:
-            shutil.copy(os.path.join(lib, header), self.builder.include_dir)
-
-        write_to_file(os.path.join(self.builder.include_dir, 'bspconfig.h'), """
-#ifndef BSPCONFIG_H
-#define BSPCONFIG_H
-
-#define EL3 1
-#define EL1_NONSECURE 0
-
-#endif
-""")
-        write_to_file(os.path.join(self.builder.include_dir, 'xparameters.h'), '''
-#ifndef XPARAMETERS_H
-#define XPARAMETERS_H
-
-#include "xparameters_ps.h"
-
-#define STDIN_BASEADDRESS 0xFF010000
-#define STDOUT_BASEADDRESS 0xFF010000
-#define XPAR_PSU_DDR_0_S_AXI_BASEADDR 0x00000000
-#define XPAR_PSU_DDR_0_S_AXI_HIGHADDR 0x7FFFFFFF
-#define XPAR_PSU_DDR_1_S_AXI_BASEADDR 0x800000000
-#define XPAR_PSU_DDR_1_S_AXI_HIGHADDR 0x87FFFFFFF
-#define XPAR_CPU_CORTEXA53_0_TIMESTAMP_CLK_FREQ 99999001
-
-#endif
-''')
+            self.cpu.set_libxil({
+                "STDIN_BASEADDRESS"                         : "0xFF010000",
+                "STDOUT_BASEADDRESS"                        : "0xFF010000",
+                "XPAR_PSU_DDR_0_S_AXI_BASEADDR"             : "0x00000000",
+                "XPAR_PSU_DDR_0_S_AXI_HIGHADDR"             : "0x7FFFFFFF",
+                "XPAR_PSU_DDR_1_S_AXI_BASEADDR"             : "0x800000000",
+                "XPAR_PSU_DDR_1_S_AXI_HIGHADDR"             : "0x87FFFFFFF",
+                "XPAR_CPU_CORTEXA53_0_TIMESTAMP_CLK_FREQ"   : "99999001",
+            })
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -206,10 +154,6 @@ def main():
         **parser.soc_argdict
     )
     builder = Builder(soc, **parser.builder_argdict)
-    if args.cpu_type == "zynqmp":
-        soc.builder = builder
-        builder.add_software_package('libxil')
-        builder.add_software_library('libxil')
     if args.build:
         builder.build(**parser.toolchain_argdict)
 

--- a/litex_boards/targets/xilinx_zcu216.py
+++ b/litex_boards/targets/xilinx_zcu216.py
@@ -12,9 +12,6 @@ from litex.gen import *
 
 from litex_boards.platforms import xilinx_zcu216
 
-from litex.build.tools import write_to_file
-
-
 from litex.soc.cores.clock import *
 from litex.soc.integration.soc import *
 from litex.soc.integration.soc import SoCRegion
@@ -114,69 +111,21 @@ class BaseSoC(SoCCore):
                 linker = True)
             )
             self.constants["CONFIG_CLOCK_FREQUENCY"] = 1200000000
+            self.cpu.set_libxil({
+                "STDIN_BASEADDRESS"                         : "0xFF000000",
+                "STDOUT_BASEADDRESS"                        : "0xFF000000",
+                "XPAR_PSU_DDR_0_S_AXI_BASEADDR"             : "0x00000000",
+                "XPAR_PSU_DDR_0_S_AXI_HIGHADDR"             : "0x7FFFFFFF",
+                "XPAR_PSU_DDR_1_S_AXI_BASEADDR"             : "0x800000000",
+                "XPAR_PSU_DDR_1_S_AXI_HIGHADDR"             : "0x87FFFFFFF",
+                "XPAR_CPU_CORTEXA53_0_TIMESTAMP_CLK_FREQ"   : "99999001",
+            })
 
         # LEDs -------------------------------------------------------------------------------------
         if with_led_chaser:
             self.leds = LedChaser(
                 pads         = platform.request_all("user_led"),
                 sys_clk_freq = sys_clk_freq)
-
-    def finalize(self, *args, **kwargs):
-        super(BaseSoC, self).finalize(*args, **kwargs)
-        if self.cpu_type != "zynqmp":
-            return
-
-        libxil_path = os.path.join(self.builder.software_dir, 'libxil')
-        os.makedirs(os.path.realpath(libxil_path), exist_ok=True)
-        lib = os.path.join(libxil_path, 'embeddedsw')
-        if not os.path.exists(lib):
-            os.system("git clone --depth 1 https://github.com/Xilinx/embeddedsw {}".format(lib))
-
-        os.makedirs(os.path.realpath(self.builder.include_dir), exist_ok=True)
-
-        for header in [
-            'XilinxProcessorIPLib/drivers/uartps/src/xuartps_hw.h',
-            'lib/bsp/standalone/src/common/xil_types.h',
-            'lib/bsp/standalone/src/common/xil_assert.h',
-            'lib/bsp/standalone/src/common/xil_io.h',
-            'lib/bsp/standalone/src/common/xil_printf.h',
-            'lib/bsp/standalone/src/common/xstatus.h',
-            'lib/bsp/standalone/src/common/xdebug.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/xpseudo_asm.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/xreg_cortexa53.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/xil_cache.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/xil_errata.h',
-            'lib/bsp/standalone/src/arm/ARMv8/64bit/platform/ZynqMP/xparameters_ps.h',
-            'lib/bsp/standalone/src/arm/common/xil_exception.h',
-            'lib/bsp/standalone/src/arm/common/gcc/xpseudo_asm_gcc.h',
-        ]:
-            shutil.copy(os.path.join(lib, header), self.builder.include_dir)
-
-        write_to_file(os.path.join(self.builder.include_dir, 'bspconfig.h'), """
-#ifndef BSPCONFIG_H
-#define BSPCONFIG_H
-
-#define EL3 1
-#define EL1_NONSECURE 0
-
-#endif
-""")
-        write_to_file(os.path.join(self.builder.include_dir, 'xparameters.h'), '''
-#ifndef XPARAMETERS_H
-#define XPARAMETERS_H
-
-#include "xparameters_ps.h"
-
-#define STDIN_BASEADDRESS 0xFF000000
-#define STDOUT_BASEADDRESS 0xFF000000
-#define XPAR_PSU_DDR_0_S_AXI_BASEADDR 0x00000000
-#define XPAR_PSU_DDR_0_S_AXI_HIGHADDR 0x7FFFFFFF
-#define XPAR_PSU_DDR_1_S_AXI_BASEADDR 0x800000000
-#define XPAR_PSU_DDR_1_S_AXI_HIGHADDR 0x87FFFFFFF
-#define XPAR_CPU_CORTEXA53_0_TIMESTAMP_CLK_FREQ 99999001
-
-#endif
-''')
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -193,10 +142,6 @@ def main():
         **parser.soc_argdict
     )
     builder = Builder(soc, **parser.builder_argdict)
-    if args.cpu_type == "zynqmp":
-        soc.builder = builder
-        builder.add_software_package('libxil')
-        builder.add_software_library('libxil')
     if args.build:
         builder.build(**parser.toolchain_argdict)
 

--- a/litex_boards/targets/xilinx_zybo_z7.py
+++ b/litex_boards/targets/xilinx_zybo_z7.py
@@ -85,6 +85,11 @@ class BaseSoC(SoCCore):
                 size = 0x4_0000,
                 mode = "rwx")
             )
+            self.cpu.set_libxil({
+                "STDOUT_BASEADDRESS"            : "XPS_UART1_BASEADDR",
+                "XPAR_PS7_DDR_0_S_AXI_BASEADDR" : "0x00100000",
+                "XPAR_PS7_DDR_0_S_AXI_HIGHADDR" : "0x3FFFFFFF",
+            })
 
         # PS7 as Slave Integration ---------------------------------------------------------------------
         elif with_ps7:
@@ -112,49 +117,6 @@ class BaseSoC(SoCCore):
                 pads         = platform.request_all("user_led"),
                 sys_clk_freq = sys_clk_freq)
 
-    def finalize(self, *args, **kwargs):
-        super(BaseSoC, self).finalize(*args, **kwargs)
-        if self.cpu_type != "zynq7000":
-            return
-        libxil_path = os.path.join(self.builder.software_dir, 'libxil')
-        os.makedirs(os.path.realpath(libxil_path), exist_ok=True)
-        lib = os.path.join(libxil_path, 'embeddedsw')
-        if not os.path.exists(lib):
-            os.system("git clone --depth 1 https://github.com/Xilinx/embeddedsw {}".format(lib))
-
-        os.makedirs(os.path.realpath(self.builder.include_dir), exist_ok=True)
-        for header in [
-            'XilinxProcessorIPLib/drivers/uartps/src/xuartps_hw.h',
-            'lib/bsp/standalone/src/common/xil_types.h',
-            'lib/bsp/standalone/src/common/xil_assert.h',
-            'lib/bsp/standalone/src/common/xil_io.h',
-            'lib/bsp/standalone/src/common/xil_printf.h',
-            'lib/bsp/standalone/src/common/xstatus.h',
-            'lib/bsp/standalone/src/common/xdebug.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xpseudo_asm.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xreg_cortexa9.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xil_cache.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xparameters_ps.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xil_errata.h',
-            'lib/bsp/standalone/src/arm/cortexa9/xtime_l.h',
-            'lib/bsp/standalone/src/arm/common/xil_exception.h',
-            'lib/bsp/standalone/src/arm/common/gcc/xpseudo_asm_gcc.h',
-        ]:
-            shutil.copy(os.path.join(lib, header), self.builder.include_dir)
-        write_to_file(os.path.join(self.builder.include_dir, 'bspconfig.h'),
-                      '#define FPU_HARD_FLOAT_ABI_ENABLED 1')
-        write_to_file(os.path.join(self.builder.include_dir, 'xparameters.h'), '''
-#ifndef __XPARAMETERS_H
-#define __XPARAMETERS_H
-
-#include "xparameters_ps.h"
-
-#define STDOUT_BASEADDRESS            XPS_UART1_BASEADDR
-#define XPAR_PS7_DDR_0_S_AXI_BASEADDR 0x00100000
-#define XPAR_PS7_DDR_0_S_AXI_HIGHADDR 0x3FFFFFFF
-#endif
-''')
-
 # Build --------------------------------------------------------------------------------------------
 
 def main():
@@ -172,10 +134,6 @@ def main():
         **soc_core_argdict(args)
     )
     builder = Builder(soc, **builder_argdict(args))
-    if args.cpu_type == "zynq7000":
-        soc.builder = builder
-        builder.add_software_package('libxil')
-        builder.add_software_library('libxil')
     if args.build:
         builder.build(**parser.toolchain_argdict)
     if args.load:


### PR DESCRIPTION
This PR depends on https://github.com/enjoy-digital/litex/pull/2548

With the LiteX's PR the libxil logic has been moved to LiteX at software, soc and build levels.
The only remaining part required because specific is the `#define` required to fill `xparameters.h`. 