### PR TITLE
targets/radiona_ulx4m_ld_v2: Disable DDR3 DM

### DIFF
--- a/litex_boards/targets/radiona_ulx4m_ld_v2.py
+++ b/litex_boards/targets/radiona_ulx4m_ld_v2.py
@@ -147,6 +147,9 @@ class BaseSoC(SoCCore):
                 "MT41K512M16": MT41K512M16,
             }
             sdram_module = available_sdram_modules.get(sdram_device)
+            l2_cache_size = kwargs.get("l2_size", 8192)
+            if not l2_cache_size:
+                raise ValueError("ULX4M-LD DDR3 requires an L2 cache when DM is disabled.")
 
             self.submodules.ddrphy = ECP5DDRPHY(
                 pads         = PHYPadsReducer(platform.request("ddram"), [0, 1]),
@@ -158,7 +161,7 @@ class BaseSoC(SoCCore):
             self.add_sdram("sdram",
                 phy           = self.ddrphy,
                 module        = sdram_module(sys_clk_freq, "1:4"),
-                l2_cache_size = kwargs.get("l2_size", 8192)
+                l2_cache_size = l2_cache_size,
             )
 
         # Ethernet / Etherbone ---------------------------------------------------------------------

--- a/litex_boards/targets/radiona_ulx4m_ld_v2.py
+++ b/litex_boards/targets/radiona_ulx4m_ld_v2.py
@@ -150,7 +150,9 @@ class BaseSoC(SoCCore):
 
             self.submodules.ddrphy = ECP5DDRPHY(
                 pads = PHYPadsReducer(platform.request("ddram"), [0, 1]),
-                sys_clk_freq=sys_clk_freq)
+                    sys_clk_freq = sys_clk_freq,
+                    dm_skip      = True,
+                )
             self.comb += self.crg.stop.eq(self.ddrphy.init.stop)
             self.comb += self.crg.reset.eq(self.ddrphy.init.reset)
             self.add_sdram("sdram",

--- a/litex_boards/targets/radiona_ulx4m_ld_v2.py
+++ b/litex_boards/targets/radiona_ulx4m_ld_v2.py
@@ -149,10 +149,10 @@ class BaseSoC(SoCCore):
             sdram_module = available_sdram_modules.get(sdram_device)
 
             self.submodules.ddrphy = ECP5DDRPHY(
-                pads = PHYPadsReducer(platform.request("ddram"), [0, 1]),
-                    sys_clk_freq = sys_clk_freq,
-                    dm_skip      = True,
-                )
+                pads         = PHYPadsReducer(platform.request("ddram"), [0, 1]),
+                sys_clk_freq = sys_clk_freq,
+                with_dm      = False,
+            )
             self.comb += self.crg.stop.eq(self.ddrphy.init.stop)
             self.comb += self.crg.reset.eq(self.ddrphy.init.reset)
             self.add_sdram("sdram",


### PR DESCRIPTION
ULX4M-LD routes its DDR3 DM pins outside the DQS groups, so the ECP5 DDR output primitive cannot drive them. This uses with_dm=False from https://github.com/enjoy-digital/litedram/pull/401 to hold DM low. Since masked writes are unavailable, the target requires a non-zero L2 cache so memory writes remain full-width. Depends on enjoy-digital/litedram#401.