### PR TITLE
platforms/targets: add ALINX AX7035B support

### DIFF
--- a/docs/boards_inventory.md
+++ b/docs/boards_inventory.md
@@ -23,6 +23,7 @@ python3 .github/scripts/generate_board_inventory.py --write
 | `aliexpress_xc7k70t` | aliexpress_xc7k70t | vivado | `90000000.0` | Ethernet, PCIe, Video Terminal, Video Framebuffer, Video Colorbars | included |
 | `alinx_ax7010` | alinx_ax7010 | - | `100000000.0` | - | included |
 | `alinx_ax7020` | alinx_ax7020 | - | `100000000.0` | - | included |
+| `alinx_ax7035` | alinx_ax7035 | - | `50000000.0` | Ethernet, SDCard, SPI Flash, Video Terminal, Video Framebuffer | included |
 | `alinx_ax7203` | alinx_ax7203 | - | `50000000.0` | PCIe, Video Framebuffer | included |
 | `alinx_axau15` | alinx_axau15 | vivado | `125000000.0` | Ethernet, Etherbone, SDCard, PCIe | included |
 | `alinx_axu2cga` | alinx_axu2cga | vivado | `25000000.0` | - | included |

--- a/litex_boards/platforms/alinx_ax7035.py
+++ b/litex_boards/platforms/alinx_ax7035.py
@@ -1,0 +1,376 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Aaron Hagan <amhagan@kent.edu>
+# Copyright (c) 2026 Richard Vodden <richard@vodden.com>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# The ALINX AX7035B FPGA development board, equipped with an AMD Artix-7
+# XC7A35T-2FGG484I.
+# https://www.en.alinx.com/Product/FPGA-Development-Boards/Artix-7/AX7035B.html
+#
+# This platform also describes the earlier AX7035: the two differ only in the
+# Ethernet PHY fitted and are otherwise pin compatible. Only the AX7035B is
+# still sold - the AX7035 and board revision V1.0 are discontinued.
+
+import subprocess
+
+from litex.build.generic_platform import *
+from litex.build.xilinx           import Xilinx7SeriesPlatform
+from litex.build.openfpgaloader   import OpenFPGALoader
+
+# IOs ----------------------------------------------------------------------------------------------
+_io = [
+    # Clock
+    ("clk50", 0, Pins("Y18"), IOStandard("LVCMOS33")),
+
+    # DDR3 SDRAM
+    ("ddram", 0,
+        Subsignal("a",     Pins("AA8 U5 Y9 Y8 V5 W7 U6 V7 T5 W9 AA6 T6 Y6 R6"), IOStandard("SSTL15")),
+        Subsignal("ba",    Pins("AB8 W5 Y7"), IOStandard("SSTL15")),
+        Subsignal("ras_n", Pins("AB7"), IOStandard("SSTL15")),
+        Subsignal("cas_n", Pins("T4"), IOStandard("SSTL15")),
+        Subsignal("we_n",  Pins("W6"), IOStandard("SSTL15")),
+        Subsignal("dm",    Pins("AB1 W2"), IOStandard("SSTL15")),
+        Subsignal("dq",    Pins("V4 AB2 AB3 AA1 AA5 Y4 AB5 AA4", 
+                                "V2 Y1 U1 Y2 T1 W1 U2 U3"),
+            IOStandard("SSTL15"),
+            Misc("IN_TERM=UNTUNED_SPLIT_50")),
+        Subsignal("dqs_p", Pins("Y3 R3"), IOStandard("DIFF_SSTL15"), Misc("IN_TERM=UNTUNED_SPLIT_50")),
+        Subsignal("dqs_n", Pins("AA3 R2"), IOStandard("DIFF_SSTL15"), Misc("IN_TERM=UNTUNED_SPLIT_50")),
+        Subsignal("clk_p", Pins("V9"), IOStandard("DIFF_SSTL15")),
+        Subsignal("clk_n", Pins("V8"), IOStandard("DIFF_SSTL15")),
+        Subsignal("cke",   Pins("R4"), IOStandard("SSTL15")),
+        Subsignal("odt",   Pins("AB6"), IOStandard("SSTL15")),
+        Subsignal("reset_n", Pins("T3"), IOStandard("LVCMOS15")),
+        Subsignal("cs_n",  Pins("U7"), IOStandard("SSTL15")), # Fix me
+        Misc("SLEW=FAST"),
+    ),
+
+    # RGMII Ethernet
+    ("eth_clocks", 0,
+        Subsignal("tx", Pins("L14"), Misc("SLEW=FAST")),
+        Subsignal("rx", Pins("K18")),
+        IOStandard("LVCMOS33")
+    ),
+    ("eth", 0,
+        Subsignal("rst_n",   Pins("L15")),
+        Subsignal("mdio",    Pins("K16")),
+        Subsignal("mdc",     Pins("K17")),
+        Subsignal("rx_ctl",   Pins("M21")),
+        Subsignal("rx_data", Pins("K19 M15 J17 J20")),
+        Subsignal("tx_ctl",  Pins("L19"), Misc("SLEW=FAST")), # labelled txen in the manual
+        Subsignal("tx_data", Pins("J21 M20 L18 L20"), Misc("SLEW=FAST")),
+        IOStandard("LVCMOS33"),
+    ),
+
+    # HDMI In -- UNVERIFIED, left commented. The available pin-assignment table covers the output
+    # only, and the equivalent output block needed two corrections, so treat these as unchecked.
+    # ("hdmi_in", 0,
+    #     Subsignal("clk_p",   Pins("K4"), IOStandard("TMDS_33")),
+    #     Subsignal("clk_n",   Pins("J4"), IOStandard("TMDS_33")),
+    #     Subsignal("data0_p", Pins("M1"), IOStandard("TMDS_33")),
+    #     Subsignal("data0_n", Pins("L1"), IOStandard("TMDS_33")),
+    #     Subsignal("data1_p", Pins("P2"), IOStandard("TMDS_33")),
+    #     Subsignal("data1_n", Pins("N2"), IOStandard("TMDS_33")),
+    #     Subsignal("data2_p", Pins("R1"), IOStandard("TMDS_33")),
+    #     Subsignal("data2_n", Pins("P1"), IOStandard("TMDS_33")),
+    #     Subsignal("scl",     Pins("N5"), IOStandard("LVCMOS33")),
+    #     Subsignal("sda",     Pins("L6"), IOStandard("LVCMOS33")),
+    #     Subsignal("hpd_en",  Pins("P6"), IOStandard("LVCMOS33")),
+    #     Subsignal("cec",     Pins("M5"), IOStandard("LVCMOS33")),
+    # ),
+
+    # HDMI Out (manual part 9, connector J6).
+    #
+    # Direct FPGA TMDS -- there is no transmitter chip, so this pairs with VideoS7HDMIPHY, not
+    # VideoDVIPHY. Bank 35 carries all of these pins and its TMDS termination to +3.3V sets
+    # VCCO_35 = 3.3V, as TMDS_33 requires.
+    #
+    # out_en (M6) gates the TPS2051B supplying HDMI_5V to the connector. It must be asserted for
+    # the sink to be powered, and also for DDC/EDID to work at all: scl/sda cross a level
+    # translator whose far side is pulled up to that switched rail.
+    #
+    # CEC is absent deliberately: the connector pin exists but no CEC net reaches the FPGA.
+    ("hdmi_out", 0,
+        Subsignal("clk_p",   Pins("E1"), IOStandard("TMDS_33")),
+        Subsignal("clk_n",   Pins("D1"), IOStandard("TMDS_33")),
+        Subsignal("data0_p", Pins("G1"), IOStandard("TMDS_33")),
+        Subsignal("data0_n", Pins("F1"), IOStandard("TMDS_33")),
+        Subsignal("data1_p", Pins("H2"), IOStandard("TMDS_33")),
+        Subsignal("data1_n", Pins("G2"), IOStandard("TMDS_33")),
+        Subsignal("data2_p", Pins("K1"), IOStandard("TMDS_33")),
+        Subsignal("data2_n", Pins("J1"), IOStandard("TMDS_33")),
+        Subsignal("scl",     Pins("P4"), IOStandard("LVCMOS33")),
+        Subsignal("sda",     Pins("N3"), IOStandard("LVCMOS33")),
+        Subsignal("out_en",  Pins("M6"), IOStandard("LVCMOS33")),
+        Subsignal("hpd",     Pins("P5"), IOStandard("LVCMOS33")),
+    ),
+
+    # USB FIFO - 
+    # ("usb_fifo", 0, 
+    #     Subsignal("data",   Pins("K22 K21 J22 H18 H22 J15 H20 G20")),
+    #     Subsignal("rxf_n",  Pins("H19")),
+    #     Subsignal("txe_n",  Pins("H15")),
+    #     Subsignal("rd_n",   Pins("L21")),
+    #     Subsignal("wr_n",   Pins("G17")),
+    #     Subsignal("siwua",  Pins("H17")),
+    #     Subsignal("clkout", Pins("J19")),
+    #     Subsignal("oe_n",   Pins("G18")),
+    #     Misc("SLEW=FAST"),
+    #     Drive(8),
+    #     IOStandard("LVCMOS33"),
+    # ),
+
+    # USB JTAG
+    # ("usb_jtag", 0,
+    #     Subsignal("tck", Pins("K22")),
+    #     Subsignal("tdi", Pins("K21")),
+    #     Subsignal("tdo", Pins("J22")),
+    #     Subsignal("tms", Pins("H18")),
+    #     IOStandard("LVCMOS33")
+    # ),
+
+    # SDCard.
+    ("sdcard", 0,
+        Subsignal("data", Pins("P16 R17 N14 N13")),
+        Subsignal("cmd",  Pins("P15")),
+        Subsignal("clk",  Pins("N15")),
+        Subsignal("cd_n",   Pins("R16")),
+        Misc("SLEW=FAST"),
+        IOStandard("LVCMOS33"),
+    ),
+
+    # USB UART
+    ("serial", 0,
+        Subsignal("tx", Pins("G16"), IOStandard("LVCMOS33")),
+        Subsignal("rx", Pins("G15"), IOStandard("LVCMOS33")),
+    ),
+
+    # QSPI Flash - Micron N25Q128, 128 Mbit (16 MB), 3.3V CMOS.
+    #
+    # Pins per the AX7035B manual, part 7. Note QSPI_CLK is CCLK_0 (L12), a
+    # dedicated configuration pin in BANK0: it is deliberately NOT declared
+    # here, because on 7-series the clock is driven through the STARTUPE2
+    # primitive, which litespi instantiates itself (litespi/clkgen.py,
+    # `if device.startswith("xc7")`). Constraining L12 as a user IO would fail.
+    # The remaining signals are on BANK14 dedicated pins D00-D03 and FCS_B.
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("T19")),
+        Subsignal("mosi", Pins("P22")),  # QSPI_DQ0
+        Subsignal("miso", Pins("R22")),  # QSPI_DQ1
+        Subsignal("wp",   Pins("P21")),  # QSPI_DQ2
+        Subsignal("hold", Pins("R21")),  # QSPI_DQ3
+        IOStandard("LVCMOS33"),
+    ),
+    ("spiflash4x", 0,
+        Subsignal("cs_n", Pins("T19")),
+        Subsignal("dq",   Pins("P22 R22 P21 R21")),
+        IOStandard("LVCMOS33"),
+    ),
+
+    # EEPROM (Microchip 24LC04, manual part 14). Separate bus from the
+    # temperature sensor below, and a different IO standard.
+    #
+    # Deliberately NO internal pull-up here, unlike i2c_tmp: the schematic shows
+    # R81/R82, 4.7k to +3.3V, on EEPROM_I2C_SCL/SDA. This bus is properly
+    # terminated on the board and needs no help from the FPGA.
+    ("i2c_eeprom", 0,
+        Subsignal("sda", Pins("N19")),
+        Subsignal("scl", Pins("N18")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # Temperature sensor (LM75-compatible, manual part 16).
+    #
+    # LVCMOS33, not LVCMOS25: these pins share bank 15 with the Ethernet RGMII clock, so VCCO is
+    # 3.3V and Vivado rejects the mixture with a DRC BIVC-1 conflicting-Vcc error.
+    #
+    # PULLUP is required, not belt-and-braces: this bus has no pull-up on the board at all (the
+    # EEPROM bus does, R81/R82). Without it SDA recovers only on pin leakage, taking ~1.3 ms, and
+    # i2c-litex samples the ACK far sooner -- so every address appears to ACK and all reads return
+    # zero. Manual part 16 claims pull-ups here and is wrong.
+    ("i2c_tmp", 0,
+        Subsignal("sda", Pins("N22")),
+        Subsignal("scl", Pins("M22")),
+        IOStandard("LVCMOS33"),
+        Misc("PULLUP TRUE")
+    ),
+
+    # 7-segment display, 6 digits (manual part 15, "Digital Tube").
+    #
+    # Collapsed from 14 separate single-pin resources into one grouped resource --
+    # that is the litex-boards convention and it lets the target request the whole
+    # display in one call.
+    #
+    # ✅ PINS VERIFIED against the manual's part 15 pin table (2026-08-15) -- and for
+    # once the inherited commented-out block was RIGHT. That is one correct out of
+    # six; the other five (MIPI lane pins, the LVCMOS25 bank conflict, the flash
+    # pinout, the LM75 pull-ups, HDMI's cec/out_en swap) were all wrong, so the
+    # check was still worth making.
+    #
+    # Banks verified from Vivado too: M16/M17 are in bank 15 and the other twelve in
+    # bank 35 -- both 3.3V, so LVCMOS33 coexists with the HDMI TMDS_33 pins sharing
+    # bank 35, and none of these collide with the HDMI pins.
+    #
+    # "seg" is segment order a b c d e f g dp -- the manual calls these DIG0..DIG7,
+    # which is thoroughly confusing since DIG normally means digit-select.
+    #
+    # ⚠️ "an" is ordered RIGHT TO LEFT: the manual's SEL0 (M2) is "the first digital
+    # tube from the right". So an[0] / digit0 is the RIGHTMOST digit and an[5] the
+    # leftmost -- write a 6-digit number with the most significant value in digit5.
+    ("seven_seg", 0,
+        Subsignal("an",  Pins("M2 N4 L5 L4 M16 M17")),
+        Subsignal("seg", Pins("J5 M3 J6 H5 G4 K6 K3 H4")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # MIPI 0 - FPC expansion port (camera). Pins per the AX7035B user manual,
+    # "FPC Expansion Ports Pin Assignment":
+    #   MIPI_LAN0_N D2 / MIPI_LAN0_P E2   MIPI_LAN1_N E3 / MIPI_LAN1_P F3
+    #   MIPI_CLK_N  G3 / MIPI_CLK_P  H3
+    #
+    # NOTE: IOStandard is unverified. MIPI_DPHY is an UltraScale+ standard; the
+    # only 7-series precedent in litex-boards (seeedstudio_spartan_edge_
+    # accelerator, xc7s15) is marked "Untested" and splits p/n across
+    # MIPI_DPHY and LVCMOS12H. On Artix-7 MIPI RX is normally LVDS_25 plus an
+    # external resistor network. Check the bank VCCO before enabling.
+    # ("camera", 0,
+    #     Subsignal("clkp",    Pins("H3")),
+    #     Subsignal("clkn",    Pins("G3")),
+    #     Subsignal("dp",      Pins("E2 F3")),
+    #     Subsignal("dn",      Pins("D2 E3")),
+    #     IOStandard("MIPI_DPHY")
+    # ),
+    # ("mipi_gpio", 0,
+    #     Subsignal("gpio",    Pins("H13")),
+    #     IOStandard("LVCMOS33")
+    # ),
+    # ("mipi_clk", 0,
+    #     Subsignal("clk",     Pins("H14")),
+    #     IOStandard("LVCMOS33")
+    # ),
+    # ("mipi_i2c", 0,
+    #     Subsignal("scl",     Pins("J14")),
+    #     Subsignal("sda",     Pins("G13")),
+    #     IOStandard("LVCMOS33")
+    # ),
+
+    # User Buttons
+
+    ("user_btn", 0, Pins("M13"), IOStandard("LVCMOS33")),
+    ("user_btn", 1, Pins("K14"), IOStandard("LVCMOS33")),
+    ("user_btn", 2, Pins("K13"), IOStandard("LVCMOS33")),
+    ("user_btn", 3, Pins("L13"), IOStandard("LVCMOS33")),
+
+    ("cpu_reset_n", 0, Pins("F20"), IOStandard("LVCMOS33")),
+
+    # Leds
+    ("user_led", 0, Pins("F19"), IOStandard("LVCMOS33")),
+    ("user_led", 1, Pins("E21"), IOStandard("LVCMOS33")),
+    ("user_led", 2, Pins("D20"), IOStandard("LVCMOS33")),
+    ("user_led", 3, Pins("C20"), IOStandard("LVCMOS33")),
+]
+
+# Expansion headers J9 and J10 (manual part 17): 40-pin 0.1" headers, 34 signal
+# pins each, all on 3.3V banks.
+#
+# Keys are the PHYSICAL pin numbers off the silkscreen, NOT a 1..34 sequence.
+# Pins 1/2 are GND/+5V and 37-40 are GND/GND/+3.3V/+3.3V, so the first signal pin
+# is 3. These were originally drafted as "io1".."io34", which silently shifted
+# everything by two -- platform.request("J9:io1") would hand you the pin labelled
+# 3 on the board. Integer keys matching the silkscreen follow the convention in
+# enclustra_mercury_kx2.py and remove the trap.
+#
+# All 68 signal pins verified against the manual's pin table, and audited clash-free
+# against _io, 2026-08-15.
+_connectors = [
+    ("J9", {
+         3 : "D16",       4 : "E16",
+         5 : "F14",       6 : "F13",
+         7 : "E14",       8 : "E13",
+         9 : "D15",      10 : "D14",
+        11 : "B13",      12 : "C13",
+        13 : "A14",      14 : "A13",
+        15 : "C15",      16 : "C14",
+        17 : "A16",      18 : "A15",
+        19 : "B16",      20 : "B15",
+        21 : "B18",      22 : "B17",
+        23 : "A19",      24 : "A18",
+        25 : "C19",      26 : "C18",
+        27 : "A20",      28 : "B20",
+        29 : "C17",      30 : "D17",
+        31 : "D19",      32 : "E19",
+        33 : "E18",      34 : "F18",
+        35 : "E17",      36 : "F16",
+    }),
+    ("J10", {
+         3 : "P17",       4 : "N17",
+         5 : "R19",       6 : "P19",
+         7 : "T18",       8 : "R18",
+         9 : "U21",      10 : "T21",
+        11 : "V22",      12 : "U22",
+        13 : "V20",      14 : "U20",
+        15 : "W22",      16 : "W21",
+        17 : "Y22",      18 : "Y21",
+        19 : "AA21",     20 : "AA20",
+        21 : "AB22",     22 : "AB21",
+        23 : "AB20",     24 : "AA19",
+        25 : "W20",      26 : "W19",
+        27 : "AB18",     28 : "AA18",
+        29 : "V19",      30 : "V18",
+        31 : "W17",      32 : "V17",
+        33 : "U18",      34 : "U17",
+        35 : "R14",      36 : "P14",
+    }),
+]
+
+# Platform -----------------------------------------------------------------------------------------
+class Platform(Xilinx7SeriesPlatform):
+    default_clk_name   = "clk50"
+    default_clk_period = 1e9/50e6
+
+    def __init__(self):
+        Xilinx7SeriesPlatform.__init__(self, "xc7a35t-fgg484-2", _io, toolchain="vivado")
+        self.toolchain.additional_commands = ["write_cfgmem -force -format bin -interface spix4 -size 16 -loadbit \"up 0x0 {build_name}.bit\" -file {build_name}.bin"]
+        self.add_platform_command("set_property INTERNAL_VREF 0.750 [get_iobanks 34]")
+
+        self.toolchain.bitstream_commands = [
+            "set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]",
+            "set_property BITSTREAM.CONFIG.CONFIGRATE 16 [current_design]",
+            "set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]",
+            "set_property CFGBVS VCCO [current_design]",
+            "set_property CONFIG_VOLTAGE 3.3 [current_design]",
+        ]
+
+        self.toolchain.additional_commands = [
+            # Non-Multiboot SPI-Flash bitstream generation.
+            "write_cfgmem -force -format bin -interface spix4 -size 16 -loadbit \"up 0x0 {build_name}.bit\" -file {build_name}.bin",
+
+            # Multiboot SPI-Flash Operational bitstream generation.
+            "set_property BITSTREAM.CONFIG.TIMER_CFG 0x0001fbd0 [current_design]",
+            "set_property BITSTREAM.CONFIG.CONFIGFALLBACK Enable [current_design]",
+            "write_bitstream -force {build_name}_operational.bit ",
+            "write_cfgmem -force -format bin -interface spix4 -size 16 -loadbit \"up 0x0 {build_name}_operational.bit\" -file {build_name}_operational.bin",
+
+            # Multiboot SPI-Flash Fallback bitstream generation.
+            "set_property BITSTREAM.CONFIG.NEXT_CONFIG_ADDR 0x00400000 [current_design]",
+            "write_bitstream -force {build_name}_fallback.bit ",
+            "write_cfgmem -force -format bin -interface spix4 -size 16 -loadbit \"up 0x0 {build_name}_fallback.bit\" -file {build_name}_fallback.bin"
+        ]
+
+    def detect_ftdi_chip(self):
+        lsusb_log = subprocess.run(['lsusb'], capture_output=True, text=True)
+        for ftdi_chip in ["ft232", "ft2232", "ft4232"]:
+            if f"Future Technology Devices International, Ltd {ftdi_chip.upper()}" in lsusb_log.stdout:
+                return ftdi_chip
+        return None
+
+    def create_programmer(self, name="openfpgaloader"):
+        ftdi_chip = self.detect_ftdi_chip()
+        return OpenFPGALoader(cable=ftdi_chip, fpga_part=f"xc7a35tfgg484", freq=30e6)
+
+    def do_finalize(self, fragment):
+        Xilinx7SeriesPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk50", loose=True), 1e9/50e6)
+

--- a/litex_boards/targets/alinx_ax7035.py
+++ b/litex_boards/targets/alinx_ax7035.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2025 Aaron Hagan <amhagan@kent.edu>
+# Copyright (c) 2026 Richard Vodden <richard@vodden.com>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# The ALINX AX7035B FPGA development board (also covers the earlier AX7035).
+# https://www.en.alinx.com/Product/FPGA-Development-Boards/Artix-7/AX7035B.html
+
+from migen import *
+
+from litex.gen import *
+
+from litex_boards.platforms import alinx_ax7035
+
+from litex.soc.cores.clock import *
+from litex.soc.interconnect.csr import *
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.led import LedChaser
+from litex.soc.cores.gpio import GPIOIn
+
+from litedram.modules import MT41J128M16
+from litedram.phy import s7ddrphy
+
+from litex.soc.cores.video import VideoS7HDMIPHY
+from litex.soc.cores.bitbang import I2CMaster
+
+from litespi.modules import N25Q128A13
+from litespi.opcodes import SpiNorFlashOpCodes as Codes
+
+from liteeth.phy.s7rgmii import LiteEthPHYRGMII
+
+# CRG ----------------------------------------------------------------------------------------------
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq, with_video_pll=False, video_pix_clk=74.25e6):
+        self.rst          = Signal()
+        self.cd_sys       = ClockDomain()
+        self.cd_sys4x     = ClockDomain()
+        self.cd_sys4x_dqs = ClockDomain()
+        self.cd_idelay    = ClockDomain()
+        if with_video_pll:
+            self.cd_hdmi   = ClockDomain()
+            self.cd_hdmi5x = ClockDomain()
+
+        # Clk/Rst.
+        clk50 = platform.request("clk50")
+        rst_n  = platform.request("cpu_reset_n")
+
+        # Main PLL.
+        self.pll = pll = S7PLL(speedgrade=-2)
+        self.comb += pll.reset.eq(~rst_n | self.rst)
+        pll.register_clkin(clk50, 50e6)
+        pll.create_clkout(self.cd_sys,       sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x,     4*sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x_dqs, 4*sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_idelay,    200e6)
+        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin)
+
+        # IDELAY Ctrl.
+        self.idelayctrl = S7IDELAYCTRL(self.cd_idelay)
+
+        # Video PLL ------------------------------------------------------------------------------
+        # hdmi5x is the 10:1 serialiser clock (two coupled OSERDESE2 per channel). A separate MMCM
+        # is needed because the pixel clock is unrelated to sys_clk_freq; MMCMs are hard blocks, so
+        # this costs no logic.
+        #
+        # video_pix_clk defaults to 74.25 MHz (1280x720@60) rather than 40 MHz (800x600@60) because
+        # add_video_framebuffer selects between two pipelines on `pix_clk >= sys_clk_freq`. Below
+        # sys_clk it converts width in the sys domain and crosses a narrow CDC, which cannot sustain
+        # the pixel rate here; above it, it crosses at full DRAM width and converts in the video
+        # domain.
+        if with_video_pll:
+            self.video_pll = video_pll = S7MMCM(speedgrade=-2)
+            # `self.comb +=` matters: a bare `video_pll.reset.eq(...)` builds an expression and
+            # discards it, leaving the reset unconnected.
+            self.comb += video_pll.reset.eq(~rst_n | self.rst)
+            video_pll.register_clkin(clk50, 50e6)
+            # 74.25 MHz is not reachable from a 50 MHz reference: LiteX searches integer feedback
+            # multipliers only, so the best fit is M=59/D=4 -> 73.75 MHz pixel and ~59.6 Hz refresh.
+            # Tightening the margin does not improve it, it just fails to find a config.
+            video_pll.create_clkout(self.cd_hdmi,   video_pix_clk)
+            video_pll.create_clkout(self.cd_hdmi5x, 5*video_pix_clk)
+
+# 7-Segment Display --------------------------------------------------------------------------------
+
+class SevenSegmentDisplay(LiteXModule):
+    """Hardware-multiplexed 6-digit 7-segment driver.
+
+    Multiplexing is done in gateware rather than by bit-banging GPIOs from Linux:
+    the display needs a few kHz of scanning to look steady, and a userspace loop
+    would visibly flicker whenever the system is busy.
+
+    Software writes one raw segment byte per digit and the scan runs by itself.
+    Raw segments (not a BCD decoder) so arbitrary patterns and the decimal point
+    are possible.
+
+    The display is common anode and both the segment and select lines are active
+    low (manual part 15), so the polarity reset value 0b11 is correct. Polarity is
+    a runtime CSR rather than hardcoded so it can be corrected without a rebuild.
+
+    CSRs:
+      digit0..5 : 8-bit raw segments, bit order a b c d e f g dp (bit0 = a)
+                  digit0 is the RIGHTMOST tube (manual SEL0 = "first from the right")
+      enable    : 1 = scan, 0 = all digits blanked
+      polarity  : bit0 = invert anodes, bit1 = invert segments (reset 0b11 = correct)
+    """
+    def __init__(self, pads, sys_clk_freq, refresh_freq=1e3):
+        # Each digit CSR must be its own attribute: LiteX's CSR gatherer walks attributes
+        # and does not descend into a list, so `self.digits = [CSRStorage(8), ...]`
+        # elaborates cleanly but produces no digit registers at all.
+        n_digits = len(pads.an)
+        digits   = []
+        for i in range(n_digits):
+            csr = CSRStorage(8, name=f"digit{i}",
+                description=f"Digit {i} raw segments: bit0=a .. bit6=g, bit7=dp. "
+                            f"digit0 is the RIGHTMOST tube.")
+            setattr(self, f"digit{i}", csr)
+            digits.append(csr)
+
+        self.enable   = CSRStorage(1, reset=1, description="Enable the scan.")
+        self.polarity = CSRStorage(2, reset=0b11,
+            description="bit0: invert anodes. bit1: invert segments. Reset 0b11 = both active-low, "
+                        "which manual part 15 confirms for this common-anode display.")
+
+        # # #
+
+        # Scan counter: refresh_freq is the per-digit rate, so a full pass over all
+        # digits happens refresh_freq/n_digits times a second. 1 kHz per digit gives
+        # ~167 Hz whole-display refresh, well above flicker.
+        tick_max = int(sys_clk_freq / refresh_freq) - 1
+        tick     = Signal(max=tick_max + 1)
+        index    = Signal(max=n_digits)
+
+        self.sync += [
+            If(tick == tick_max,
+                tick.eq(0),
+                If(index == (n_digits - 1),
+                    index.eq(0),
+                ).Else(
+                    index.eq(index + 1),
+                ),
+            ).Else(
+                tick.eq(tick + 1),
+            ),
+        ]
+
+        # Select the active digit and its segment pattern.
+        an_raw  = Signal(n_digits)
+        seg_raw = Signal(8)
+
+        self.comb += [
+            If(self.enable.storage,
+                an_raw.eq(1 << index),
+            ),
+            Case(index, {
+                i: seg_raw.eq(digits[i].storage) for i in range(n_digits)
+            }),
+        ]
+
+        # Apply the runtime polarity.
+        self.comb += [
+            pads.an.eq(Mux(self.polarity.storage[0], ~an_raw, an_raw)),
+            pads.seg.eq(Mux(self.polarity.storage[1], ~seg_raw, seg_raw)),
+        ]
+
+# BaseSoC ------------------------------------------------------------------------------------------
+class BaseSoC(SoCCore):
+    def __init__(self,
+                 sys_clk_freq           = int(50e6),
+                 with_ethernet          = False,
+                 eth_ip                 = "192.168.1.50",
+                 remote_ip              = "192.168.1.100",
+                 eth_dynamic_ip         = False,
+                 with_led_chaser        = True,
+                 with_buttons           = True,
+                 with_video_terminal    = False,
+                 with_video_framebuffer = False,
+                 video_timings          = "1280x720@60Hz",
+                 with_spi_flash         = False,
+                 with_i2c               = False,
+                 with_i2c_eeprom        = False,
+                 with_xadc              = False,
+                 with_seven_seg         = False,
+                 **kwargs):
+
+        self.platform = alinx_ax7035.Platform()
+        platform = self.platform
+
+        # CRG --------------------------------------------------------------------------------------
+        # Derive the video PLL frequency from the SAME timings string the framebuffer uses, so the
+        # two can never disagree -- a hand-set pixel clock that does not match the mode is exactly
+        # the kind of silent mismatch this board has been bitten by before.
+        from litex.soc.cores.video import video_timings as _video_timings
+        with_video = with_video_terminal or with_video_framebuffer
+        video_pix_clk = _video_timings[video_timings]["pix_clk"]
+        self.crg = _CRG(platform, sys_clk_freq, with_video_pll=with_video,
+            video_pix_clk=video_pix_clk)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on ALINX AX7035", **kwargs)
+
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        self.ddrphy = s7ddrphy.A7DDRPHY(platform.request("ddram"),
+            memtype          = "DDR3",
+            nphases          = 4,
+            sys_clk_freq     = sys_clk_freq,
+            iodelay_clk_freq = 200e6)
+
+        self.add_sdram("sdram",
+            phy           = self.ddrphy,
+            module        = MT41J128M16(sys_clk_freq, "1:4"),
+            l2_cache_size = kwargs.get("l2_size", 8192)
+        )
+
+        # SPI Flash --------------------------------------------------------------------------------
+        if with_spi_flash:
+            # Micron N25Q128, 128 Mbit, 3.3V (A13 is the 3V part; A11 is 1.8V). The default
+            # clk_freq is kept: the BIOS calibration settles on the divisor floor (25 MHz) here.
+            #
+            # Needs LiteSPI 6dbbc66 or later ("Fix STARTUPE2 issue with en_int"); before it the
+            # clock free-ran between transfers and the PHY deadlocked in XFER-END on roughly half
+            # of cold boots.
+            self.add_spi_flash(mode="4x", module=N25Q128A13(Codes.READ_1_1_4), with_master=True)
+
+        # I2C --------------------------------------------------------------------------------------
+        if with_i2c:
+            # Bit-banged I2C: this CSR layout is the one Linux's i2c-litex driver expects.
+            # add_i2c_master() instantiates litei2c, which has a different layout the driver
+            # will not drive.
+            #
+            # Attributes must be named i2c0, i2c1, ...: json2dts emits one "litex,i2c" node per
+            # i2c<N> CSR base and uses that name as the DT label, so &i2cN resolves in overlays.
+            # i2c0 is the LM75 (part 16), i2c1 the EEPROM (part 14).
+            self.i2c0 = I2CMaster(pads=platform.request("i2c_tmp"))
+
+        if with_i2c_eeprom:
+            self.i2c1 = I2CMaster(pads=platform.request("i2c_eeprom"))
+
+        # XADC -------------------------------------------------------------------------------------
+        if with_xadc:
+            # On-die system monitor (junction temperature and supply rails). A hard macro, so it
+            # costs no BRAM, almost no logic and no pins. The attribute must be named xadc:
+            # json2dts keys its "litex,hwmon-xadc" node on exactly that CSR base name.
+            from litex.soc.cores.xadc import S7SystemMonitor
+            self.xadc = S7SystemMonitor()
+
+        # 7-Segment Display ------------------------------------------------------------------------
+        if with_seven_seg:
+            # Plain CSR peripheral: no device tree node and no kernel driver, driven by writing
+            # one raw segment byte per digit.
+            self.seven_seg = SevenSegmentDisplay(
+                pads         = platform.request("seven_seg"),
+                sys_clk_freq = sys_clk_freq)
+
+        # Ethernet ---------------------------------------------------------------------------------
+        if with_ethernet:
+            self.ethphy = LiteEthPHYRGMII(
+                clock_pads = self.platform.request("eth_clocks"),
+                pads       = self.platform.request("eth"))
+            # The PHY's own constraints are replaced by the two below: the RX clock is sourced by
+            # the 88E1518 rather than the FPGA, so it is constrained as a plain 125 MHz input and
+            # declared asynchronous to the system clock.
+            self.add_ethernet(
+                phy                     = self.ethphy,
+                dynamic_ip              = eth_dynamic_ip,
+                local_ip                = eth_ip,
+                remote_ip               = remote_ip,
+                with_timing_constraints = False,
+            )
+            platform.add_period_constraint(self.platform.lookup_request("eth_clocks").rx, 8.0)
+            platform.add_false_path_constraints(
+                self.platform.lookup_request("clk50"),
+                self.platform.lookup_request("eth_clocks").rx
+            )
+
+        # Video ------------------------------------------------------------------------------------
+        # The FPGA drives TMDS directly (no HDMI transmitter on this board), so this is
+        # VideoS7HDMIPHY, which serialises 10:1 through paired OSERDESE2 and needs the hdmi and
+        # hdmi5x domains from the video PLL above.
+        if with_video:
+            hdmi_pads = platform.request("hdmi_out")
+
+            # HDMI1_OUT_EN gates U16 (TPS2051B), which supplies HDMI1_5V to connector pin 18. It
+            # must be high or the sink is unpowered -- and the DDC/EDID bus dies with it, since
+            # scl/sda cross U17 (NVT2002DP) whose far side is pulled up to that same switched rail.
+            # Tied on here; move it to a CSR if EDID hot-plug sequencing is ever wanted.
+            self.comb += hdmi_pads.out_en.eq(1)
+
+            self.videophy = VideoS7HDMIPHY(hdmi_pads, clock_domain="hdmi")
+            if with_video_terminal:
+                self.add_video_terminal(phy=self.videophy, timings=video_timings, clock_domain="hdmi")
+            if with_video_framebuffer:
+                # Place the framebuffer explicitly, high in DRAM. LiteX's 0x40c00000 default
+                # declares a region that overlaps the DTB, OpenSBI and initramfs load addresses
+                # used here. Setting mem_map also makes add_video_framebuffer skip its own
+                # bus.add_region(), so that region is never declared.
+                self.mem_map["video_framebuffer"] = 0x4f000000
+
+                # rgb565 rather than the rgb888 default: it halves the DRAM read bandwidth and the
+                # framebuffer size, and json2dts emits "r5g6b5" for 16-bit depth automatically.
+                #
+                # A deep FIFO matters more than it looks. VideoFrameBuffer advances the video timing
+                # generator only while pixel data flows (vtg_sink.ready.eq(source.valid &
+                # source.ready)), so a DMA underrun does not merely tear -- it stretches hsync/vsync
+                # until the mode is out of spec and the sink rejects it outright.
+                self.add_video_framebuffer(phy=self.videophy, timings=video_timings,
+                    clock_domain="hdmi", format="rgb565", fifo_depth=65536)
+
+        # Leds -------------------------------------------------------------------------------------
+        if with_led_chaser:
+           self.leds = LedChaser(
+               pads         = platform.request_all("user_led"),
+               sys_clk_freq = sys_clk_freq)
+
+        # Buttons ----------------------------------------------------------------------------------
+        if with_buttons:
+            # Named switches rather than buttons: litex_json2dts_linux emits a "litex,gpio" input
+            # node only for a CSR base called switches (or leds for outputs), so any other name
+            # leaves Linux with no node for the four keys.
+            self.switches = GPIOIn(
+                pads     = platform.request_all("user_btn"),
+                with_irq = self.irq.enabled
+            )
+            if self.irq.enabled:
+                # GPIOIn(with_irq=True) builds the event manager but does not route an interrupt;
+                # only an add_*() helper does that. Without this the IRQ is never allocated.
+                self.irq.add("switches", use_loc_if_exists=True)
+
+# Build --------------------------------------------------------------------------------------------
+def main():
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=alinx_ax7035.Platform, description="LiteX SoC on ALINX AX7035B.")
+    parser.add_target_argument("--flash",           action="store_true",       help="Flash bitstream.")
+    parser.add_target_argument("--sys-clk-freq",    default=50e6, type=float,  help="System clock frequency.")
+    parser.add_target_argument("--with-ethernet",   action="store_true",       help="Enable Ethernet support.")
+    parser.add_target_argument("--eth-ip",          default="192.168.1.50",    help="Ethernet/Etherbone IP address.")
+    parser.add_target_argument("--remote-ip",       default="192.168.1.100",   help="Remote IP address of TFTP server.")
+    parser.add_target_argument("--eth-dynamic-ip",  action="store_true",       help="Enable dynamic Ethernet IP assignment.")
+    parser.add_target_argument("--with-spi-flash",  action="store_true",       help="Enable SPI Flash (MMAPed).")
+    parser.add_target_argument("--with-i2c",        action="store_true",       help="Enable I2C master on the LM75 bus.")
+    parser.add_target_argument("--with-i2c-eeprom", action="store_true",       help="Enable I2C master on the EEPROM bus.")
+    parser.add_target_argument("--with-xadc",       action="store_true",       help="Enable XADC system monitor.")
+    parser.add_target_argument("--with-seven-seg",  action="store_true",       help="Enable the 6-digit 7-segment display.")
+    parser.add_target_argument("--with-sdcard",     action="store_true",       help="Enable SDCard support.")
+    viopts = parser.target_group.add_mutually_exclusive_group()
+    viopts.add_argument("--with-video-terminal",    action="store_true", help="Enable Video Terminal (HDMI).")
+    viopts.add_argument("--with-video-framebuffer", action="store_true", help="Enable Video Framebuffer (HDMI).")
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq           = args.sys_clk_freq,
+        with_ethernet          = args.with_ethernet,
+        eth_ip                 = args.eth_ip,
+        remote_ip              = args.remote_ip,
+        eth_dynamic_ip         = args.eth_dynamic_ip,
+        with_video_terminal    = args.with_video_terminal,
+        with_video_framebuffer = args.with_video_framebuffer,
+        with_spi_flash         = args.with_spi_flash,
+        with_i2c               = args.with_i2c,
+        with_i2c_eeprom        = args.with_i2c_eeprom,
+        with_xadc              = args.with_xadc,
+        with_seven_seg         = args.with_seven_seg,
+        **parser.soc_argdict
+    )
+    if args.with_sdcard:
+        soc.add_sdcard()
+
+    builder = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+    if args.flash:
+        prog = soc.platform.create_programmer()
+        prog.flash(0, builder.get_bitstream_filename(mode="flash"))
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
The AX7035B is an Artix-7 XC7A35T-2FGG484I board with 256 MB of DDR3, Gigabit Ethernet, an SD card slot, QSPI flash, HDMI output driven directly from the FPGA, a 6-digit 7-segment display, an LM75 temperature sensor, a 24LC04 EEPROM and four user keys. The platform also covers the earlier AX7035, which differs only in the Ethernet PHY fitted.

Peripherals worth a note:

* HDMI is direct FPGA TMDS with no transmitter chip, so it uses VideoS7HDMIPHY and a dedicated video MMCM. Connector J6's out_en gates the 5V supply to the sink and, through a level translator pulled up to that switched rail, the DDC/EDID bus as well, so it is tied high.

* The LM75 bus has no pull-ups fitted on the board (the EEPROM bus does), so the platform requests PULLUP on those two pins. Without it SDA recovers only on pin leakage and every address appears to ACK.

* The I2C masters are the bit-banged ones rather than add_i2c_master(), because that CSR layout is the one Linux's i2c-litex driver expects.

* The 7-segment display is multiplexed in gateware; software writes one raw segment byte per digit. Its polarity is a CSR rather than hardcoded.

* The J9/J10 expansion headers are keyed by the physical pin numbers printed on the silkscreen, which start at 3 because pins 1 and 2 are GND and +5V.

Built with Vivado 2025.2 and run under linux-on-litex-vexriscv: 1280x720@60 rgb565 framebuffer at full rate, Gigabit Ethernet, SD card, QSPI flash, both I2C buses, XADC and the user keys as input events.