### PR TITLE
aliexpress_rk_xcku5p: initial basic support

### DIFF
--- a/litex_boards/platforms/aliexpress_rk_xcku5p.py
+++ b/litex_boards/platforms/aliexpress_rk_xcku5p.py
@@ -1,0 +1,95 @@
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2026 Aria Wegrzyn <git@ariac.at>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Documentation for the board can be found here:
+# https://github.com/tommythorn/rk-xcku5p-f-v1.2/
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import XilinxUSPPlatform
+from litex.build.openfpgaloader import OpenFPGALoader
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # Clk.
+    ("clk200", 0,
+        Subsignal("p", Pins("T24"), IOStandard("DIFF_SSTL12")),
+        Subsignal("n", Pins("U24"), IOStandard("DIFF_SSTL12"))
+    ),
+
+    # LEDs.
+    ("user_led", 0, Pins("H9"), IOStandard("LVCMOS33")),
+    ("user_led", 1, Pins("J9"), IOStandard("LVCMOS33")),
+    ("user_led", 2, Pins("G11"), IOStandard("LVCMOS33")),
+    ("user_led", 3, Pins("H11"), IOStandard("LVCMOS33")),
+
+    # UART.
+    ("serial", 0,
+        Subsignal("tx", Pins("AC14")),
+        Subsignal("rx", Pins("AD13")),
+        IOStandard("LVCMOS33")
+    ),
+
+    # DDR4
+    ("ddram", 0,
+        Subsignal("a",       Pins(
+                "Y22  Y25  W23  V26  R26  U26 R21 W25",
+                "R20  Y26  R25  V23  AA24 W26"),
+            IOStandard("SSTL12_DCI")),
+        Subsignal("ba",      Pins("P21 P26"), IOStandard("SSTL12_DCI")),
+        Subsignal("bg",      Pins("R22"), IOStandard("SSTL12_DCI")),
+        Subsignal("ras_n",   Pins("T25"), IOStandard("SSTL12_DCI")),  # A16
+        Subsignal("cas_n",   Pins("AA25"), IOStandard("SSTL12_DCI")), # A15
+        Subsignal("we_n",    Pins("P23"), IOStandard("SSTL12_DCI")),  # A14
+        Subsignal("cs_n",    Pins("P25"), IOStandard("SSTL12_DCI")),
+        Subsignal("act_n",   Pins("P24"), IOStandard("SSTL12_DCI")),
+        Subsignal("alert_n", Pins("U25"), IOStandard("SSTL12_DCI")),
+        Subsignal("par",     Pins("Y23"), IOStandard("SSTL12_DCI")),
+        Subsignal("dq",      Pins(
+                "AF24 AF25 AD24 AB26 AC24 AB25 AD25 AB24",
+                "AC21 AD23 AD21 AC22 AB21 AE23 AE21 AC23",
+                "AE16 AD19 AD16 AF17 AC19 AF19 AF18 AE17",
+                "AA20 AA18 AA19 Y18  AB20 Y17  AB19 AA17"),
+            IOStandard("POD12_DCI")),
+        Subsignal("dqs_p",   Pins(
+                "AC26 AA22 AC18 AB17"),
+            IOStandard("DIFF_POD12")),
+        Subsignal("dqs_n",   Pins(
+                "AD26 AB22 AD18 AC17"),
+            IOStandard("DIFF_POD12")),
+        Subsignal("dm",     Pins(
+                "AE25 AE22 AD20 Y20"), # also selects chip
+            IOStandard("POD12_DCI")),
+        Subsignal("clk_p",   Pins("V24"), IOStandard("DIFF_SSTL12_DCI")),
+        Subsignal("clk_n",   Pins("W24"), IOStandard("DIFF_SSTL12_DCI")),
+        Subsignal("cke",     Pins("P20"), IOStandard("SSTL12_DCI")),
+        Subsignal("odt",     Pins("R23"), IOStandard("SSTL12_DCI")),
+        Subsignal("reset_n", Pins("P19"), IOStandard("SSTL12")),
+        Misc("SLEW=FAST"),
+    ),
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(XilinxUSPPlatform):
+    default_clk_name   = "clk200"
+    default_clk_period = 1e9/200e6
+
+    def __init__(self, toolchain="vivado"):
+        XilinxUSPPlatform.__init__(self, "xcku5p-ffvb676-2-i", _io, toolchain=toolchain)
+
+    def create_programmer(self):
+        return OpenFPGALoader(cable="ft2232", fpga_part="xcku5p-2ffvb676")
+
+    def do_finalize(self, fragment):
+        XilinxUSPPlatform.do_finalize(self, fragment)
+        self.add_period_constraint(self.lookup_request("clk200", loose=True), 1e9/200e6)
+
+        # Shutdown on overheating
+        self.add_platform_command("set_property BITSTREAM.CONFIG.OVERTEMPSHUTDOWN ENABLE [current_design]")
+
+        # Reduce programming time
+        self.add_platform_command("set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]")

--- a/litex_boards/targets/aliexpress_rk_xcku5p.py
+++ b/litex_boards/targets/aliexpress_rk_xcku5p.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2026 Aria Węgrzyn <git@ariac.at>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Documentation and photos of the board can be found here:
+# https://github.com/tommythorn/rk-xcku5p-f-v1.2/
+
+import os
+
+from migen import *
+
+from litex.gen import *
+
+from litex_boards.platforms import aliexpress_rk_xcku5p
+
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder  import *
+
+from litex.soc.cores.clock import *
+from litex.soc.cores.led   import LedChaser
+
+from litedram.modules import MT40A512M16
+from litedram.phy import usddrphy
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst    = Signal()
+        self.cd_sys = ClockDomain()
+        self.cd_eth = ClockDomain()
+        # DDR4
+        self.cd_sys4x  = ClockDomain()
+        self.cd_pll4x  = ClockDomain()
+        self.cd_idelay = ClockDomain()
+
+        # Clk.
+        clk200 = platform.request("clk200")
+
+        # PLL.
+        self.pll = pll = USPMMCM(speedgrade=-2)
+        self.comb += pll.reset.eq(self.rst)
+        pll.register_clkin(clk200, 200e6)
+        platform.add_false_path_constraints(self.cd_sys.clk, pll.clkin) # Ignore sys_clk to pll.clkin path created by SoC's rst.
+
+        # DDR4
+        pll.create_clkout(self.cd_pll4x, sys_clk_freq*4, buf=None, with_reset=False)
+        pll.create_clkout(self.cd_idelay, 500e6)
+
+        self.specials += [
+            Instance("BUFGCE_DIV",
+                p_BUFGCE_DIVIDE=4,
+                i_CE=1, i_I=self.cd_pll4x.clk, o_O=self.cd_sys.clk),
+            Instance("BUFGCE",
+                i_CE=1, i_I=self.cd_pll4x.clk, o_O=self.cd_sys4x.clk),
+        ]
+
+        self.idelayctrl = USIDELAYCTRL(cd_ref=self.cd_idelay, cd_sys=self.cd_sys)
+
+# BaseSoC ------------------------------------------------------------------------------------------
+
+class BaseSoC(SoCCore):
+    def __init__(self, sys_clk_freq=200e6,
+        with_led_chaser = True,
+        **kwargs):
+        platform = aliexpress_rk_xcku5p.Platform()
+
+        # CRG --------------------------------------------------------------------------------------
+        self.crg = _CRG(platform, sys_clk_freq)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on RK-XCKU5P Board", **kwargs)
+        
+        # DDR4 SDRAM -------------------------------------------------------------------------------
+        if not self.integrated_main_ram_size:
+            self.ddrphy = usddrphy.USPDDRPHY(
+                pads             = platform.request("ddram"),
+                memtype          = "DDR4",
+                sys_clk_freq     = sys_clk_freq,
+                iodelay_clk_freq = 500e6)
+            self.add_sdram("sdram",
+                phy           = self.ddrphy,
+                module        = MT40A512M16(sys_clk_freq, "1:4"),
+                # there is 0x80000000 of main ram but we don't want to take all of the upper address space
+                # for default configurations. All targets use smaller sizes.
+                size          = 0x40000000,
+                l2_cache_size = kwargs.get("l2_size", 8192)
+            )
+
+        # LEDs -------------------------------------------------------------------------------------
+        if with_led_chaser:
+            self.leds = LedChaser(
+                pads         = platform.request_all("user_led"),
+                sys_clk_freq = sys_clk_freq)
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    from litex.build.parser import LiteXArgumentParser
+    parser = LiteXArgumentParser(platform=alibaba_rk_xcku5p.Platform, description="LiteX SoC on Alibaba Cloud KU3P board.")
+    parser.add_target_argument("--sys-clk-freq",        default=100e6, type=float, help="System clock frequency.")
+    args = parser.parse_args()
+
+    soc = BaseSoC(
+        sys_clk_freq   = args.sys_clk_freq,
+        **parser.soc_argdict
+    )
+
+    builder = Builder(soc, **parser.builder_argdict)
+    if args.build:
+        builder.build(**parser.toolchain_argdict)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add support for nice, unbranded rk_xcku5p dev board, widely available from China on ebay and aliexpress.

Documentation for the board can be found here:
https://github.com/tommythorn/rk-xcku5p-f-v1.2/

All added features are verified on physical board (the same variant as on photo in github repo).

Support for now is incomplete and contains only essential features, it can be improved in future.
Included: clock, UART, DDR4, leds.