### PR TITLE
targets/efinix_ti375_c529_dev_kit: reuse CPU JTAG helper

### DIFF
--- a/litex_boards/targets/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/targets/efinix_ti375_c529_dev_kit.py
@@ -154,12 +154,7 @@ class BaseSoC(SoCCore):
             ]
             self.platform.add_extension(_jtag_io)
             jtag_pads = platform.request("jtag")
-            self.comb += [
-                self.cpu.jtag_clk.eq(jtag_pads.tck),
-                self.cpu.jtag_tms.eq(jtag_pads.tms),
-                self.cpu.jtag_tdi.eq(jtag_pads.tdi),
-                jtag_pads.tdo.eq(self.cpu.jtag_tdo),
-            ]
+            self.cpu.add_jtag(jtag_pads)
             platform.add_false_path_constraints(self.crg.cd_sys.clk, jtag_pads.tck)
 
         # Ethernet / Etherbone ---------------------------------------------------------------------


### PR DESCRIPTION
The Ti375 target duplicates the CPU's JTAG pad wiring. Use the existing `cpu.add_jtag()` helper to connect its external TAP on PMOD0, preserving the pinout and sys/TCK false-path constraint.

Validation: all five CI lint scripts and 14 fast lint tests passed; the target's `--help` command and `git diff --check` passed. The helper was inspected to confirm it makes the same four signal connections. Efinity synthesis and hardware validation were not performed.
