### PR TITLE
targets/ice40: honor build paths and BIOS flash offsets

### DIFF
--- a/litex_boards/targets/lattice_ice40up5k_evn.py
+++ b/litex_boards/targets/lattice_ice40up5k_evn.py
@@ -91,30 +91,26 @@ class BaseSoC(SoCCore):
 
 # Flash --------------------------------------------------------------------------------------------
 
-def flash(bios_flash_offset, target="lattice_ice40up5k_evn"):
-    prog = IceStormProgrammer()
-    bitstream  = open("build/"+target+"/gateware/"+target+".bin",  "rb")
-    bios       = open("build/"+target+"/software/bios/bios.bin", "rb")
-    image      = open("build/"+target+"/image.bin", "wb")
-    # Copy bitstream at 0x00000000
-    for i in range(0x00000000, 0x0020000):
-        b = bitstream.read(1)
-        if not b:
-            image.write(0xff.to_bytes(1, "big"))
-        else:
-            image.write(b)
-    # Copy bios at 0x00020000
-    for i in range(0x00000000, 0x00010000):
-        b = bios.read(1)
-        if not b:
-            image.write(0xff.to_bytes(1, "big"))
-        else:
-            image.write(b)
-    bitstream.close()
-    bios.close()
-    image.close()
+def flash(builder, bios_flash_offset):
+    with open(builder.get_bitstream_filename(mode="flash"), "rb") as f:
+        bitstream = f.read()
+    with open(builder.get_bios_filename(), "rb") as f:
+        bios = f.read()
+    bios_size = 0x10000
+    if len(bitstream) > bios_flash_offset:
+        raise ValueError("Bitstream overlaps the BIOS flash offset.")
+    if len(bios) > builder.soc.bus.regions["rom"].size:
+        raise ValueError("BIOS exceeds the ROM region size.")
+    if bios_flash_offset + bios_size > builder.soc.bus.regions["spiflash"].size:
+        raise ValueError("BIOS image exceeds the SPI flash size.")
+    os.makedirs(builder.output_dir, exist_ok=True)
+    image_file = os.path.join(builder.output_dir, "image.bin")
+    with open(image_file, "wb") as f:
+        f.write(bitstream.ljust(bios_flash_offset, b"\xff"))
+        f.write(bios.ljust(bios_size, b"\xff"))
     print("Flashing bitstream (+bios)")
-    prog.flash(0x0, "build/"+target+"/image.bin")
+    prog = IceStormProgrammer()
+    prog.flash(0x0, image_file)
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -136,7 +132,7 @@ def main():
         builder.build(**parser.toolchain_argdict)
 
     if args.flash:
-        flash(args.bios_flash_offset)
+        flash(builder, int(args.bios_flash_offset, 0))
 
 if __name__ == "__main__":
     main()

--- a/litex_boards/targets/muselab_icesugar.py
+++ b/litex_boards/targets/muselab_icesugar.py
@@ -97,11 +97,20 @@ class BaseSoC(SoCCore):
 
 # Flash --------------------------------------------------------------------------------------------
 
-def flash(bios_flash_offset):
+def flash(builder, bios_flash_offset):
     from litex.build.lattice.programmer import IceSugarProgrammer
+    bitstream_file = builder.get_bitstream_filename(mode="flash")
+    bios_file      = builder.get_bios_filename()
+    if os.path.getsize(bitstream_file) > bios_flash_offset:
+        raise ValueError("Bitstream overlaps the BIOS flash offset.")
+    bios_size = os.path.getsize(bios_file)
+    if bios_size > builder.soc.bus.regions["rom"].size:
+        raise ValueError("BIOS exceeds the ROM region size.")
+    if bios_flash_offset + bios_size > builder.soc.bus.regions["spiflash"].size:
+        raise ValueError("BIOS exceeds the SPI flash size.")
     prog = IceSugarProgrammer()
-    prog.flash(bios_flash_offset, "build/muselab_icesugar/software/bios/bios.bin")
-    prog.flash(0x00000000,        "build/muselab_icesugar/gateware/muselab_icesugar.bin")
+    prog.flash(bios_flash_offset, bios_file)
+    prog.flash(0x00000000,        bitstream_file)
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -127,7 +136,7 @@ def main():
         prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
 
     if args.flash:
-        flash(int(args.bios_flash_offset, 0))
+        flash(builder, int(args.bios_flash_offset, 0))
 
 if __name__ == "__main__":
     main()

--- a/test/test_flash_images.py
+++ b/test/test_flash_images.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+from unittest.mock import Mock, call
+
+import pytest
+
+from litex.soc.integration.builder import Builder
+from litex_boards.targets import lattice_ice40up5k_evn, muselab_icesugar
+
+
+@pytest.fixture(params=[lattice_ice40up5k_evn, muselab_icesugar])
+def flash_target(request, tmp_path, monkeypatch):
+    target = request.param
+    soc = target.BaseSoC(bios_flash_offset=0x40000, cpu_variant="minimal")
+    soc.build_name = "custom"
+    builder = Builder(soc,
+        output_dir=tmp_path / "output",
+        gateware_dir=tmp_path / "gateware",
+        software_dir=tmp_path / "software",
+    )
+    bitstream = Path(builder.get_bitstream_filename(mode="flash"))
+    bios = Path(builder.get_bios_filename())
+    bitstream.parent.mkdir(parents=True)
+    bios.parent.mkdir(parents=True)
+    bitstream.write_bytes(b"bitstream")
+    bios.write_bytes(b"bios")
+    programmer = Mock()
+    if target is lattice_ice40up5k_evn:
+        monkeypatch.setattr(target, "IceStormProgrammer", lambda: programmer)
+    else:
+        monkeypatch.setattr("litex.build.lattice.programmer.IceSugarProgrammer", lambda: programmer)
+    return target, builder, bitstream, bios, programmer
+
+
+@pytest.mark.parametrize("offset", [0x20000, 0x40000])
+def test_flash_paths_and_bios_offset(flash_target, offset):
+    target, builder, bitstream, bios, programmer = flash_target
+    target.flash(builder, offset)
+    if target is lattice_ice40up5k_evn:
+        image = Path(builder.output_dir) / "image.bin"
+        assert image.read_bytes() == (
+            b"bitstream" + b"\xff" * (offset - 9) + b"bios" + b"\xff" * (0x10000 - 4)
+        )
+        programmer.flash.assert_called_once_with(0, str(image))
+    else:
+        assert programmer.flash.call_args_list == [
+            call(offset, str(bios)), call(0, str(bitstream)),
+        ]
+
+
+@pytest.mark.parametrize("problem", ["overlap", "bios_size", "flash_size", "negative_offset", "missing_bios"])
+def test_invalid_flash_image_does_not_program(flash_target, problem):
+    target, builder, bitstream, bios, programmer = flash_target
+    offset = 0x40000
+    error = ValueError
+    if problem == "overlap":
+        bitstream.write_bytes(b"\x00" * (offset + 1))
+    elif problem == "bios_size":
+        bios.write_bytes(b"\x00" * (builder.soc.bus.regions["rom"].size + 1))
+    elif problem == "flash_size":
+        offset = builder.soc.bus.regions["spiflash"].size
+    elif problem == "negative_offset":
+        offset = -1
+    elif problem == "missing_bios":
+        bios.unlink()
+        error = FileNotFoundError
+    with pytest.raises(error):
+        target.flash(builder, offset)
+    programmer.flash.assert_not_called()
+    assert not (Path(builder.output_dir) / "image.bin").exists()


### PR DESCRIPTION
Flashing iCESugar or iCE40UP5K EVN builds currently reads hard-coded build paths. The EVN image also ignores `--bios-flash-offset` and silently truncates oversized input files.

Use Builder paths for the bitstream and BIOS, place the EVN BIOS at the requested offset, and reject overlaps or images that exceed the ROM/flash size before programming. Preserve the EVN image's existing 64 KiB BIOS padding.

Validation: 14 regression tests using real target/Builder instances and mocked programmers; all five CI lint scripts and 14 lint tests passed. No hardware flashing was performed.
