### PR TITLE
targets: fix peripheral selection and CLI validation

### DIFF
--- a/litex_boards/targets/digilent_arty.py
+++ b/litex_boards/targets/digilent_arty.py
@@ -86,6 +86,8 @@ class BaseSoC(SoCCore):
         with_pmod_gpio  = False,
         with_can        = False,
         **kwargs):
+        if with_etherbone and (eth_dynamic_ip or eth_dhcp):
+            raise ValueError("Etherbone requires a static IP; disable eth_dynamic_ip and eth_dhcp.")
         platform = digilent_arty.Platform(variant=variant, toolchain=toolchain)
 
         # CRG --------------------------------------------------------------------------------------
@@ -226,7 +228,8 @@ def main():
     parser.add_target_argument("--with-can",       action="store_true", help="Enable CAN support (Through CTU-CAN-FD Core and SN65HVD230 'PMOD'.")
     args = parser.parse_args()
 
-    assert not (args.with_etherbone and (args.eth_dynamic_ip or args.eth_dhcp))
+    if args.with_etherbone and (args.eth_dynamic_ip or args.eth_dhcp):
+        parser.error("--with-etherbone requires a static IP; remove --eth-dynamic-ip and --eth-dhcp.")
 
     soc = BaseSoC(
         variant        = args.variant,

--- a/litex_boards/targets/lattice_crosslink_nx_evn.py
+++ b/litex_boards/targets/lattice_crosslink_nx_evn.py
@@ -107,7 +107,7 @@ def main():
     parser.add_target_argument("--sys-clk-freq",   default=75e6, type=float,   help="System clock frequency.")
     parser.add_target_argument("--serial",         default="serial",           help="UART Pins (serial (requires R15 and R17 to be soldered) or serial_pmod[0-2]).")
     parser.add_target_argument("--programmer",     default="radiant",          help="Programmer (radiant or ecpprog or openocd).")
-    parser.add_target_argument("--address",        default=0x0,                help="Flash address to program bitstream at.")
+    parser.add_target_argument("--address", default=0x0, type=lambda x: int(x, 0), help="Flash address to program bitstream at.")
     parser.add_target_argument("--prog-target",    default="direct",           help="Programming Target (direct or flash).")
     parser.add_target_argument("--with-spi-flash", action="store_true",        help="Enable memory-mapped SPI flash.")
     args = parser.parse_args()

--- a/litex_boards/targets/microsoft_catapult_v3.py
+++ b/litex_boards/targets/microsoft_catapult_v3.py
@@ -80,6 +80,7 @@ def main():
     parser.add_target_argument("--variant",         default="pcie",                    help="Board variant (pcie or ocp).")
     parser.add_target_argument("--sys-clk-freq",    default=100e6, type=float,         help="System clock frequency.")
     parser.add_target_argument("--with-led-chaser", action="store_true", default=True, help="Enable LED Chaser.")
+    parser.add_target_argument("--no-led-chaser", dest="with_led_chaser", action="store_false", help="Disable LED Chaser.")
     args = parser.parse_args()
 
     soc = BaseSoC(

--- a/litex_boards/targets/microsoft_storey_peak.py
+++ b/litex_boards/targets/microsoft_storey_peak.py
@@ -112,7 +112,9 @@ def main():
     parser = LiteXArgumentParser(platform=microsoft_storey_peak.Platform, description="LiteX SoC on Microsoft Storey Peak.")
     parser.add_target_argument("--sys-clk-freq",    default=100e6, type=float,         help="System clock frequency.")
     parser.add_target_argument("--with-led-chaser", action="store_true", default=True,  help="Enable LED Chaser.")
+    parser.add_target_argument("--no-led-chaser", dest="with_led_chaser", action="store_false", help="Disable LED Chaser.")
     parser.add_target_argument("--with-i2c",        action="store_true", default=True,  help="Enable I2C masters.")
+    parser.add_target_argument("--no-i2c", dest="with_i2c", action="store_false", help="Disable I2C masters.")
     args = parser.parse_args()
 
     soc = BaseSoC(

--- a/litex_boards/targets/mnt_rkx7.py
+++ b/litex_boards/targets/mnt_rkx7.py
@@ -88,6 +88,8 @@ class BaseSoC(SoCCore):
         with_usb_host  = True,
         with_analyzer  = False,
         **kwargs):
+        if with_etherbone and eth_dynamic_ip:
+            raise ValueError("Etherbone requires a static IP; disable eth_dynamic_ip.")
         platform = mnt_rkx7.Platform()
 
         # CRG --------------------------------------------------------------------------------------
@@ -125,7 +127,7 @@ class BaseSoC(SoCCore):
             platform.add_platform_command("set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets {{soclinux_ethphy_eth_rx_clk_ibuf}}]")
             if with_etherbone:
                 self.add_etherbone(phy=self.ethphy, ip_address=eth_ip, with_ethmac=with_ethernet)
-            if with_ethernet:
+            elif with_ethernet:
                 self.add_ethernet(
                     phy=self.ethphy,
                     dynamic_ip=eth_dynamic_ip,
@@ -215,17 +217,28 @@ def main():
     parser = LiteXArgumentParser(platform=mnt_rkx7.Platform, description="LiteX SoC on MNT-RKX7.")
     parser.add_target_argument("--sys-clk-freq",   default=100e6, type=float,         help="System clock frequency.")
     parser.add_target_argument("--with-spi-flash", action="store_true", default=True, help="Enable memory-mapped SPI flash.")
-    parser.add_target_argument("--with-usb-host",  action="store_true", default=True, help="Enable USB host support.")
+    parser.add_target_argument("--no-spi-flash", dest="with_spi_flash", action="store_false", help="Disable memory-mapped SPI flash.")
+    parser.add_target_argument("--with-usb-host", action="store_true", default=True, help="Enable USB host support.")
+    parser.add_target_argument("--no-usb-host", dest="with_usb_host", action="store_false", help="Disable USB host support.")
     sdopts = parser.target_group.add_mutually_exclusive_group()
-    sdopts.add_argument("--with-spi-sdcard", action="store_true",               help="Enable SPI-mode SDCard support.")
-    sdopts.add_argument("--with-sdcard",     action="store_true", default=True, help="Enable SDCard support.")
+    sdopts.add_argument("--with-spi-sdcard", action="store_true", help="Enable SPI-mode SDCard support.")
+    sdopts.add_argument("--with-sdcard", action="store_true", default=None, help="Enable native SDCard support (default mode).")
+    sdopts.add_argument("--no-sdcard", dest="with_sdcard", action="store_false", help="Disable SDCard support.")
     ethopts = parser.target_group.add_mutually_exclusive_group()
-    ethopts.add_argument("--with-ethernet",  action="store_true", default=True, help="Enable Ethernet support.")
-    ethopts.add_argument("--with-etherbone", action="store_true",               help="Enable Etherbone support.")
+    ethopts.add_argument("--with-ethernet", action="store_true", default=None, help="Enable Ethernet support (default mode).")
+    ethopts.add_argument("--with-etherbone", action="store_true",                     help="Enable Etherbone support.")
+    ethopts.add_argument("--no-ethernet", dest="with_ethernet", action="store_false", help="Disable Ethernet support.")
     parser.add_target_argument("--eth-ip",         default="192.168.1.50",  help="Ethernet/Etherbone IP address.")
     parser.add_target_argument("--remote-ip",      default="192.168.1.100", help="Remote IP address of TFTP server.")
     parser.add_target_argument("--eth-dynamic-ip", action="store_true",     help="Enable dynamic Ethernet IP assignment.")
     args = parser.parse_args()
+
+    if args.with_sdcard is None:
+        args.with_sdcard = not args.with_spi_sdcard
+    if args.with_ethernet is None:
+        args.with_ethernet = not args.with_etherbone
+    if args.with_etherbone and args.eth_dynamic_ip:
+        parser.error("--with-etherbone requires a static IP; remove --eth-dynamic-ip.")
 
     soc = BaseSoC(
         sys_clk_freq   = args.sys_clk_freq,
@@ -242,8 +255,6 @@ def main():
         soc.add_spi_sdcard()
     if args.with_sdcard:
         soc.add_sdcard()
-
-    args.csr_csv="csr.csv"
 
     builder = Builder(soc, **parser.builder_argdict)
     if args.build:

--- a/litex_boards/targets/qmtech_wukong.py
+++ b/litex_boards/targets/qmtech_wukong.py
@@ -137,7 +137,7 @@ def main():
     from litex.build.parser import LiteXArgumentParser
     parser = LiteXArgumentParser(platform=qmtech_wukong.Platform, description="LiteX SoC on QMTECH Wukong Board.")
     parser.add_target_argument("--sys-clk-freq", default=100e6, type=float, help="System clock frequency.")
-    parser.add_target_argument("--revision",     default=1,                 help="Board version (1 , 2 or 3).")
+    parser.add_target_argument("--revision", default=1, type=int, choices=[1, 2, 3], help="Board revision.")
     parser.add_target_argument("--speedgrade",   default=-1, type=int,      help="FPGA speedgrade (-1 or -2).")
     ethopts = parser.target_group.add_mutually_exclusive_group()
     ethopts.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support.")
@@ -155,7 +155,7 @@ def main():
 
     soc = BaseSoC(
         sys_clk_freq           = args.sys_clk_freq,
-        revision               = int(args.revision),
+        revision               = args.revision,
         speedgrade             = args.speedgrade,
         with_ethernet          = args.with_ethernet,
         with_etherbone         = args.with_etherbone,
@@ -170,7 +170,7 @@ def main():
         soc.platform.add_extension(qmtech_wukong._sdcard_pmod_io)
         soc.add_spi_sdcard()
     if args.with_sdcard:
-        if int(args.revision) == 1:
+        if args.revision == 1:
             soc.platform.add_extension(qmtech_wukong._sdcard_pmod_io)
         soc.add_sdcard()
 

--- a/test/test_target_options.py
+++ b/test/test_target_options.py
@@ -1,0 +1,115 @@
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+from litex_boards.targets import (
+    digilent_arty, lattice_crosslink_nx_evn, microsoft_catapult_v3,
+    microsoft_storey_peak, mnt_rkx7, qmtech_wukong,
+)
+
+
+def run_target(monkeypatch, target, args):
+    soc = Mock()
+    builder = Mock()
+    monkeypatch.setattr(target, "BaseSoC", soc)
+    monkeypatch.setattr(target, "Builder", builder)
+    monkeypatch.setattr(sys, "argv", [target.__name__, *args])
+    target.main()
+    return soc, builder
+
+
+@pytest.mark.parametrize("args, spi, native, ethernet, etherbone", [
+    ([], False, True, True, False),
+    (["--with-spi-sdcard"], True, False, True, False),
+    (["--with-sdcard"], False, True, True, False),
+    (["--no-sdcard"], False, False, True, False),
+    (["--with-etherbone"], False, True, False, True),
+    (["--with-ethernet"], False, True, True, False),
+    (["--no-ethernet"], False, True, False, False),
+])
+def test_rkx7_modes(monkeypatch, args, spi, native, ethernet, etherbone):
+    soc, _ = run_target(monkeypatch, mnt_rkx7, args)
+    assert soc.return_value.add_spi_sdcard.called == spi
+    assert soc.return_value.add_sdcard.called == native
+    assert soc.call_args.kwargs["with_ethernet"] == ethernet
+    assert soc.call_args.kwargs["with_etherbone"] == etherbone
+
+
+@pytest.mark.parametrize("args", [
+    ["--with-spi-sdcard", "--with-sdcard"],
+    ["--with-sdcard", "--no-sdcard"],
+    ["--with-ethernet", "--with-etherbone"],
+    ["--with-etherbone", "--no-ethernet"],
+])
+def test_rkx7_rejects_conflicting_modes(monkeypatch, args):
+    with pytest.raises(SystemExit) as error:
+        run_target(monkeypatch, mnt_rkx7, args)
+    assert error.value.code == 2
+    mnt_rkx7.BaseSoC.assert_not_called()
+
+
+@pytest.mark.parametrize("target, flags, fields", [
+    (mnt_rkx7, ["--no-spi-flash", "--no-usb-host"], ["with_spi_flash", "with_usb_host"]),
+    (microsoft_catapult_v3, ["--no-led-chaser"], ["with_led_chaser"]),
+    (microsoft_storey_peak, ["--no-led-chaser", "--no-i2c"], ["with_led_chaser", "with_i2c"]),
+])
+@pytest.mark.parametrize("enabled", [True, False])
+def test_default_features_can_be_disabled(monkeypatch, target, flags, fields, enabled):
+    soc, _ = run_target(monkeypatch, target, [] if enabled else flags)
+    assert all(soc.call_args.kwargs[field] == enabled for field in fields)
+
+
+def test_rkx7_preserves_csr_path(monkeypatch, tmp_path):
+    path = str(tmp_path / "custom.csv")
+    _, builder = run_target(monkeypatch, mnt_rkx7, ["--csr-csv", path])
+    assert builder.call_args.kwargs["csr_csv"] == path
+
+
+@pytest.mark.parametrize("target, flag", [
+    (digilent_arty, "--eth-dynamic-ip"),
+    (digilent_arty, "--eth-dhcp"),
+    (mnt_rkx7, "--eth-dynamic-ip"),
+])
+def test_etherbone_rejects_dynamic_ip(monkeypatch, capsys, target, flag):
+    with pytest.raises(SystemExit) as error:
+        run_target(monkeypatch, target, ["--with-etherbone", flag])
+    assert error.value.code == 2
+    assert "requires a static IP" in capsys.readouterr().err
+    target.BaseSoC.assert_not_called()
+
+
+@pytest.mark.parametrize("target, kwargs", [
+    (digilent_arty, {"eth_dynamic_ip": True}),
+    (digilent_arty, {"eth_dhcp": True}),
+    (mnt_rkx7, {"eth_dynamic_ip": True}),
+])
+def test_etherbone_constructor_rejects_dynamic_ip(target, kwargs):
+    with pytest.raises(ValueError, match="static IP"):
+        target.BaseSoC(with_etherbone=True, **kwargs)
+
+
+@pytest.mark.parametrize("address", ["0x10000", "65536"])
+def test_crosslink_flash_address_is_an_integer(monkeypatch, address):
+    soc, builder = run_target(monkeypatch, lattice_crosslink_nx_evn,
+        ["--load", "--programmer", "ecpprog", "--prog-target", "flash", "--address", address])
+    soc.return_value.platform.create_programmer.return_value.flash.assert_called_once_with(
+        65536, builder.return_value.get_bitstream_filename.return_value)
+
+
+@pytest.mark.parametrize("revision", ["1", "2", "3"])
+def test_wukong_revision(monkeypatch, revision):
+    soc, _ = run_target(monkeypatch, qmtech_wukong, ["--revision", revision])
+    assert soc.call_args.kwargs["revision"] == int(revision)
+
+
+@pytest.mark.parametrize("target, args", [
+    (qmtech_wukong, ["--revision", "4"]),
+    (qmtech_wukong, ["--revision", "invalid"]),
+    (lattice_crosslink_nx_evn, ["--address", "invalid"]),
+])
+def test_invalid_numeric_options(monkeypatch, target, args):
+    with pytest.raises(SystemExit) as error:
+        run_target(monkeypatch, target, args)
+    assert error.value.code == 2
+    target.BaseSoC.assert_not_called()


### PR DESCRIPTION
MNT-RKX7's mutually exclusive options can enable both SD-card controllers or both Ethernet modes because one option defaults to true. Resolve those defaults after parsing and add disable flags for peripherals enabled by default on RKX7, Catapult v3 and Storey Peak.

Also preserve RKX7's `--csr-csv`, avoid adding its Ethernet MAC twice when sharing it with Etherbone, report unsupported dynamic-IP combinations clearly on RKX7/Arty, and parse CrossLink-NX flash addresses and Wukong revisions as integers.

Validation: 32 focused tests and all CI lint checks passed. RKX7 gateware generation passed for SPI SD-card mode and Etherbone with native SD-card mode (`--no-compile`, USB host disabled); combined Ethernet/Etherbone construction also passed. No synthesis or hardware programming was performed.
