### PR TITLE
targets: allow construction without CLI defaults

### DIFF
--- a/litex_boards/targets/limesdr_mini_v2.py
+++ b/litex_boards/targets/limesdr_mini_v2.py
@@ -80,8 +80,9 @@ class BaseSoC(SoCCore):
         platform = limesdr_mini_v2.Platform(toolchain=toolchain)
 
         # SoCCore ----------------------------------------------------------------------------------
-        if kwargs["uart_name"] != "jtag_uart":
-            if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "crossover"
+        if kwargs.get("uart_name", "serial") != "jtag_uart":
+            if kwargs.get("uart_name", "serial") == "serial":
+                kwargs["uart_name"] = "crossover"
             kwargs["with_jtagbone"] = True
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on LimeSDR-Mini-V2", **kwargs)
 

--- a/litex_boards/targets/microsoft_catapult_v3.py
+++ b/litex_boards/targets/microsoft_catapult_v3.py
@@ -52,14 +52,8 @@ class BaseSoC(SoCCore):
 
         # SoCCore ----------------------------------------------------------------------------------
         # Defaults to JTAG-UART since no hardware UART.
-        real_uart_name = kwargs["uart_name"]
-        if real_uart_name == "serial":
-            if kwargs["with_jtagbone"]:
-                if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "crossover"
-            else:
-                if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "jtag_uart"
-        if kwargs["with_uartbone"]:
-            if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "crossover"
+        if kwargs.get("uart_name", "serial") == "serial":
+            kwargs["uart_name"] = "crossover" if kwargs.get("with_jtagbone", False) else "jtag_uart"
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Microsoft Catapult v3 SmartNIC", **kwargs)
 
         # Leds -------------------------------------------------------------------------------------

--- a/litex_boards/targets/microsoft_storey_peak.py
+++ b/litex_boards/targets/microsoft_storey_peak.py
@@ -9,7 +9,7 @@
 # Bring-up SoC for the Microsoft/HP "Storey Peak" Catapult v2 card (P/N X930613-001).
 #
 # There is no hardware UART on this board, so as with Catapult v3 the console falls back to
-# jtag_uart, or to crossover when jtagbone/uartbone is enabled.
+# jtag_uart, or to crossover when jtagbone is enabled.
 #
 # The DDR3, PCIe and QSFP+ pins are declared in the platform file but are not driven here. This
 # target is the hardware-verified bring-up SoC only.
@@ -66,14 +66,8 @@ class BaseSoC(SoCCore):
 
         # SoCCore ----------------------------------------------------------------------------------
         # Defaults to JTAG-UART since no hardware UART.
-        real_uart_name = kwargs["uart_name"]
-        if real_uart_name == "serial":
-            if kwargs["with_jtagbone"]:
-                if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "crossover"
-            else:
-                if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "jtag_uart"
-        if kwargs["with_uartbone"]:
-            if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "crossover"
+        if kwargs.get("uart_name", "serial") == "serial":
+            kwargs["uart_name"] = "crossover" if kwargs.get("with_jtagbone", False) else "jtag_uart"
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Microsoft Storey Peak", **kwargs)
 
         # JTAG -------------------------------------------------------------------------------------
@@ -86,7 +80,7 @@ class BaseSoC(SoCCore):
         ]
 
         # JTAGBone ---------------------------------------------------------------------------------
-        if kwargs["with_jtagbone"]:
+        if kwargs.get("with_jtagbone", False):
             platform.add_period_constraint(self.jtagbone_phy.cd_jtag.clk, 1e9/20e6)
             platform.add_false_path_constraints(self.jtagbone_phy.cd_jtag.clk, self.crg.cd_sys.clk)
 

--- a/litex_boards/targets/terasic_deca.py
+++ b/litex_boards/targets/terasic_deca.py
@@ -73,14 +73,8 @@ class BaseSoC(SoCCore):
 
         # SoCCore ----------------------------------------------------------------------------------
         # Defaults to JTAG-UART since no hardware UART.
-        real_uart_name = kwargs["uart_name"]
-        if real_uart_name == "serial":
-            if kwargs["with_jtagbone"]:
-                if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "crossover"
-            else:
-                if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "jtag_uart"
-        if kwargs["with_uartbone"]:
-            if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "crossover"
+        if kwargs.get("uart_name", "serial") == "serial":
+            kwargs["uart_name"] = "crossover" if kwargs.get("with_jtagbone", False) else "jtag_uart"
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Terasic DECA", **kwargs)
 
         # Ethernet ---------------------------------------------------------------------------------

--- a/litex_boards/targets/xilinx_zc706.py
+++ b/litex_boards/targets/xilinx_zc706.py
@@ -93,8 +93,8 @@ class BaseSoC(SoCCore):
 
         # When nor jtagbone, nor etherbone are set forces jtagbone.
         if kwargs.get("uart_name", "serial") == "serial":
-            if kwargs.get("uart_name", "serial") == "serial": kwargs["uart_name"] = "crossover"
-        if not (kwargs["with_jtagbone"] or with_etherbone):
+            kwargs["uart_name"] = "crossover"
+        if not (kwargs.get("with_jtagbone", False) or with_etherbone):
             kwargs["with_jtagbone"] = True
 
         # CRG --------------------------------------------------------------------------------------

--- a/test/test_target_defaults.py
+++ b/test/test_target_defaults.py
@@ -1,0 +1,48 @@
+import pytest
+
+from litex.soc.cores.uart import UART, UARTCrossover
+from litex_boards.targets import (
+    limesdr_mini_v2, microsoft_catapult_v3, microsoft_storey_peak, terasic_deca, xilinx_zc706,
+)
+
+
+TARGETS = [limesdr_mini_v2, microsoft_catapult_v3, microsoft_storey_peak, terasic_deca, xilinx_zc706]
+JTAG_UART_TARGETS = [microsoft_catapult_v3, microsoft_storey_peak, terasic_deca]
+
+
+@pytest.mark.parametrize("target", TARGETS)
+def test_default_constructor(target, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    soc = target.BaseSoC()
+    with_jtagbone = target not in JTAG_UART_TARGETS
+    assert isinstance(soc.uart, UARTCrossover if with_jtagbone else UART)
+    assert hasattr(soc, "jtagbone") == with_jtagbone
+
+
+@pytest.mark.parametrize("target", TARGETS)
+def test_explicit_uart_is_preserved(target, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    soc = target.BaseSoC(uart_name="crossover")
+    assert isinstance(soc.uart, UARTCrossover)
+
+
+@pytest.mark.parametrize("target", JTAG_UART_TARGETS)
+def test_jtagbone_selects_crossover_uart(target, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    soc = target.BaseSoC(with_jtagbone=True)
+    assert isinstance(soc.uart, UARTCrossover)
+    assert hasattr(soc, "jtagbone")
+
+
+def test_limesdr_jtag_uart_disables_default_jtagbone(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    soc = limesdr_mini_v2.BaseSoC(uart_name="jtag_uart")
+    assert isinstance(soc.uart, UART)
+    assert not hasattr(soc, "jtagbone")
+
+
+def test_zc706_etherbone_disables_default_jtagbone(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    soc = xilinx_zc706.BaseSoC(with_etherbone=True)
+    assert hasattr(soc, "etherbone")
+    assert not hasattr(soc, "jtagbone")


### PR DESCRIPTION
Calling `BaseSoC()` without CLI-generated keyword arguments raises `KeyError` on ZC706, DECA, Catapult v3, Storey Peak and LimeSDR Mini v2.

Use defaults when reading UART/JTAGBone options and remove redundant UART-selection branches. Preserve the existing CLI console choices and explicit UART overrides.

Validation: 15 tests instantiate the real targets and cover defaults, explicit console selection and JTAGBone/Etherbone selection. All five CI lint scripts and 14 lint tests passed. No synthesis or hardware programming was performed.
