### PR TITLE
targets/efinix_ti375_c529_dev_kit: check for a CPU JTAG TAP

### DIFF
--- a/litex_boards/targets/efinix_ti375_c529_dev_kit.py
+++ b/litex_boards/targets/efinix_ti375_c529_dev_kit.py
@@ -142,7 +142,7 @@ class BaseSoC(SoCCore):
             self.comb += self.cpu.interrupt[16].eq(self.usb_ohci.interrupt)
 
         # JTAG -------------------------------------------------------------------------------------
-        if hasattr(self.cpu, "jtag_clk"):
+        if hasattr(self.cpu, "jtag_tms"):
             _jtag_io = [
                 ("jtag", 0,
                     Subsignal("tck", Pins("pmod0:0")),

--- a/test/test_targets.py
+++ b/test/test_targets.py
@@ -238,6 +238,23 @@ class TestTargets(unittest.TestCase):
                 ]
                 subprocess.check_call(cmd)
 
+    def test_efinity_cpu_jtag_interfaces(self):
+        if not efinity_available():
+            self.skipTest("Efinity toolchain not available.")
+
+        for args in [[], ["--jtag-tap"]]:
+            with self.subTest(args=args):
+                result = subprocess_run_quiet([
+                    sys.executable,
+                    "-m", "litex_boards.targets.efinix_ti375_c529_dev_kit",
+                    "--cpu-type=vexriscv_smp",
+                    "--integrated-main-ram-size=0x10000",
+                    "--uart-name=stub",
+                    *args,
+                ])
+                if result.returncode != 0:
+                    self.fail(result.stdout)
+
     # Exercise target imports and parser setup for board targets, including no-compile exclusions.
     def test_target_parsers_smoke(self):
         targets = [name for name in python_module_names("./litex_boards/targets/") if name != "simple"]


### PR DESCRIPTION
The Ti375 target treats any CPU with `jtag_clk` as an external JTAG TAP. The CPU instruction interface also exposes that clock but has no `jtag_tms`, so calling `add_jtag()` raises `AttributeError`.

Check for `jtag_tms` before connecting the PMOD pins. Add an Efinity-dependent constructor smoke test for both VexRiscvSMP interfaces.

Validation: reproduced the failure on master; both interface configurations pass after the change with the local Efinity installation. All CI lint checks passed. No synthesis or hardware programming was performed.
