### PR TITLE
targets: fix standalone flashing and custom build paths

### DIFF
--- a/litex_boards/targets/alchitry_cu.py
+++ b/litex_boards/targets/alchitry_cu.py
@@ -87,11 +87,20 @@ class BaseSoC(SoCCore):
 
 # Flash --------------------------------------------------------------------------------------------
 
-def flash(build_dir, build_name, bios_flash_offset):
+def flash(builder, bios_flash_offset):
     from litex.build.lattice.programmer import IceStormProgrammer
+    bitstream_file = builder.get_bitstream_filename(mode="flash")
+    bios_file      = builder.get_bios_filename()
+    if os.path.getsize(bitstream_file) > bios_flash_offset:
+        raise ValueError("Bitstream overlaps the BIOS flash offset.")
+    bios_size = os.path.getsize(bios_file)
+    if bios_size > builder.soc.bus.regions["rom"].size:
+        raise ValueError("BIOS exceeds the ROM region size.")
+    if bios_flash_offset + bios_size > builder.soc.bus.regions["spiflash"].size:
+        raise ValueError("BIOS exceeds the SPI flash size.")
     prog = IceStormProgrammer()
-    prog.flash(bios_flash_offset, f"{build_dir}/software/bios/bios.bin")
-    prog.flash(0x00000000,        f"{build_dir}/gateware/{build_name}.bin")
+    prog.flash(bios_flash_offset, bios_file)
+    prog.flash(0x00000000,        bitstream_file)
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -114,7 +123,7 @@ def main():
         builder.build(**parser.toolchain_argdict)
 
     if args.flash:
-        flash(builder.output_dir, soc.build_name, args.bios_flash_offset)
+        flash(builder, int(args.bios_flash_offset, 0))
 
 if __name__ == "__main__":
     main()

--- a/litex_boards/targets/icebreaker.py
+++ b/litex_boards/targets/icebreaker.py
@@ -122,11 +122,20 @@ class BaseSoC(SoCCore):
 
 # Flash --------------------------------------------------------------------------------------------
 
-def flash(build_dir, build_name, bios_flash_offset):
+def flash(builder, bios_flash_offset):
     from litex.build.lattice.programmer import IceStormProgrammer
+    bitstream_file = builder.get_bitstream_filename(mode="flash")
+    bios_file      = builder.get_bios_filename()
+    if os.path.getsize(bitstream_file) > bios_flash_offset:
+        raise ValueError("Bitstream overlaps the BIOS flash offset.")
+    bios_size = os.path.getsize(bios_file)
+    if bios_size > builder.soc.bus.regions["rom"].size:
+        raise ValueError("BIOS exceeds the ROM region size.")
+    if bios_flash_offset + bios_size > builder.soc.bus.regions["spiflash"].size:
+        raise ValueError("BIOS exceeds the SPI flash size.")
     prog = IceStormProgrammer()
-    prog.flash(bios_flash_offset, f"{build_dir}/software/bios/bios.bin")
-    prog.flash(0x00000000,        f"{build_dir}/gateware/{build_name}.bin")
+    prog.flash(bios_flash_offset, bios_file)
+    prog.flash(0x00000000,        bitstream_file)
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -154,7 +163,7 @@ def main():
         prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
 
     if args.flash:
-        flash(builder.output_dir, soc.build_name, args.bios_flash_offset)
+        flash(builder, int(args.bios_flash_offset, 0))
 
 if __name__ == "__main__":
     main()

--- a/litex_boards/targets/kosagi_fomu.py
+++ b/litex_boards/targets/kosagi_fomu.py
@@ -129,31 +129,30 @@ class BaseSoC(SoCCore):
 
 # Flash --------------------------------------------------------------------------------------------
 
-def flash(build_dir, build_name, bios_flash_offset):
+DFU_FLASH_OFFSET = 0x40000
+
+def flash(builder, bios_flash_offset):
     from litex.build.dfu import DFUProg
+    with open(builder.get_bitstream_filename(mode="flash"), "rb") as f:
+        bitstream = f.read()
+    with open(builder.get_bios_filename(), "rb") as f:
+        bios = f.read()
+    bios_size = builder.soc.bus.regions["rom"].size
+    if bios_flash_offset < 128 * KILOBYTE:
+        raise ValueError("BIOS offset must leave at least 128 KiB for the bitstream.")
+    if len(bitstream) > bios_flash_offset:
+        raise ValueError("Bitstream overlaps the BIOS flash offset.")
+    if len(bios) > bios_size:
+        raise ValueError("BIOS exceeds the ROM region size.")
+    if DFU_FLASH_OFFSET + bios_flash_offset + bios_size > builder.soc.bus.regions["spiflash"].size:
+        raise ValueError("DFU image exceeds the SPI flash size.")
+    os.makedirs(builder.output_dir, exist_ok=True)
+    image_file = os.path.join(builder.output_dir, "image.bin")
+    with open(image_file, "wb") as f:
+        f.write(bitstream.ljust(bios_flash_offset, b"\xff"))
+        f.write(bios.ljust(bios_size, b"\xff"))
     prog = DFUProg(vid="1209", pid="5bf0")
-    bitstream = open(f"{build_dir}/gateware/{build_name}.bin",  "rb")
-    bios      = open(f"{build_dir}/software/bios/bios.bin", "rb")
-    image     = open(f"{build_dir}/image.bin", "wb")
-    # Copy bitstream at 0.
-    assert bios_flash_offset >= 128 * KILOBYTE
-    for i in range(0, bios_flash_offset):
-        b = bitstream.read(1)
-        if not b:
-            image.write(0xff.to_bytes(1, "big"))
-        else:
-            image.write(b)
-    # Copy bios at bios_flash_offset.
-    for i in range(0, 32 * KILOBYTE):
-        b = bios.read(1)
-        if not b:
-            image.write(0xff.to_bytes(1, "big"))
-        else:
-            image.write(b)
-    bitstream.close()
-    bios.close()
-    image.close()
-    prog.load_bitstream(f"{build_dir}/image.bin")
+    prog.load_bitstream(image_file)
 
 # Build --------------------------------------------------------------------------------------------
 
@@ -165,10 +164,8 @@ def main():
     parser.add_target_argument("--flash",             action="store_true",      help="Flash bitstream.")
     args = parser.parse_args()
 
-    dfu_flash_offset = 0x40000
-
     soc = BaseSoC(
-        bios_flash_offset = dfu_flash_offset + int(args.bios_flash_offset, 0),
+        bios_flash_offset = DFU_FLASH_OFFSET + int(args.bios_flash_offset, 0),
         sys_clk_freq      = args.sys_clk_freq,
         **parser.soc_argdict
     )
@@ -177,7 +174,7 @@ def main():
         builder.build(**parser.toolchain_argdict)
 
     if args.flash:
-        flash(builder.output_dir, soc.build_name, int(args.bios_flash_offset, 0))
+        flash(builder, int(args.bios_flash_offset, 0))
 
 if __name__ == "__main__":
     main()

--- a/litex_boards/targets/signaloid_c0_microsd.py
+++ b/litex_boards/targets/signaloid_c0_microsd.py
@@ -120,14 +120,14 @@ class BaseSoC(SoCCore):
 
 # Flash --------------------------------------------------------------------------------------------
 
-def flash(build_dir, build_name, bios_flash_offset):
+def flash(builder):
     print("\033[93m")
     print("-------------------------------------------------------------------------------")
     print("Programming is not supported for this platform.")
     print("Please use the official Signaloid C0-microSD utilities for flashing the device.")
     print("https://github.com/signaloid/C0-microSD-utilities")
-    print(f"Bitstream path: {build_dir}/gateware/{build_name}.bin")
-    print(f"Binary path   : {build_dir}/software/bios/bios.bin")
+    print(f"Bitstream path: {builder.get_bitstream_filename(mode='flash')}")
+    print(f"Binary path   : {builder.get_bios_filename()}")
     print("-------------------------------------------------------------------------------")
     print("\033[0m")
 
@@ -164,7 +164,7 @@ def main():
         print("\033[0m")
 
     if args.flash:
-        flash(builder.output_dir, soc.build_name, args.bios_flash_offset)
+        flash(builder)
 
 if __name__ == "__main__":
     main()

--- a/test/test_flash_images.py
+++ b/test/test_flash_images.py
@@ -1,16 +1,20 @@
+import sys
 from pathlib import Path
 from unittest.mock import Mock, call
 
 import pytest
 
 from litex.soc.integration.builder import Builder
-from litex_boards.targets import lattice_ice40up5k_evn, muselab_icesugar
+from litex_boards.targets import (
+    alchitry_cu, icebreaker, kosagi_fomu, lattice_ice40up5k_evn, muselab_icesugar,
+    signaloid_c0_microsd,
+)
 
 
-@pytest.fixture(params=[lattice_ice40up5k_evn, muselab_icesugar])
+@pytest.fixture(params=[lattice_ice40up5k_evn, muselab_icesugar, icebreaker, alchitry_cu, kosagi_fomu])
 def flash_target(request, tmp_path, monkeypatch):
     target = request.param
-    soc = target.BaseSoC(bios_flash_offset=0x40000, cpu_variant="minimal")
+    soc = target.BaseSoC(bios_flash_offset=0x40000, cpu_variant="minimal", uart_name="stub")
     soc.build_name = "custom"
     builder = Builder(soc,
         output_dir=tmp_path / "output",
@@ -26,6 +30,10 @@ def flash_target(request, tmp_path, monkeypatch):
     programmer = Mock()
     if target is lattice_ice40up5k_evn:
         monkeypatch.setattr(target, "IceStormProgrammer", lambda: programmer)
+    elif target in [icebreaker, alchitry_cu]:
+        monkeypatch.setattr("litex.build.lattice.programmer.IceStormProgrammer", lambda: programmer)
+    elif target is kosagi_fomu:
+        monkeypatch.setattr("litex.build.dfu.DFUProg", lambda **kwargs: programmer)
     else:
         monkeypatch.setattr("litex.build.lattice.programmer.IceSugarProgrammer", lambda: programmer)
     return target, builder, bitstream, bios, programmer
@@ -35,12 +43,16 @@ def flash_target(request, tmp_path, monkeypatch):
 def test_flash_paths_and_bios_offset(flash_target, offset):
     target, builder, bitstream, bios, programmer = flash_target
     target.flash(builder, offset)
-    if target is lattice_ice40up5k_evn:
+    if target in [lattice_ice40up5k_evn, kosagi_fomu]:
         image = Path(builder.output_dir) / "image.bin"
+        bios_size = 0x8000 if target is kosagi_fomu else 0x10000
         assert image.read_bytes() == (
-            b"bitstream" + b"\xff" * (offset - 9) + b"bios" + b"\xff" * (0x10000 - 4)
+            b"bitstream" + b"\xff" * (offset - 9) + b"bios" + b"\xff" * (bios_size - 4)
         )
-        programmer.flash.assert_called_once_with(0, str(image))
+        if target is kosagi_fomu:
+            programmer.load_bitstream.assert_called_once_with(str(image))
+        else:
+            programmer.flash.assert_called_once_with(0, str(image))
     else:
         assert programmer.flash.call_args_list == [
             call(offset, str(bios)), call(0, str(bitstream)),
@@ -66,4 +78,53 @@ def test_invalid_flash_image_does_not_program(flash_target, problem):
     with pytest.raises(error):
         target.flash(builder, offset)
     programmer.flash.assert_not_called()
+    programmer.load_bitstream.assert_not_called()
     assert not (Path(builder.output_dir) / "image.bin").exists()
+
+
+def test_flash_without_build(flash_target, monkeypatch):
+    target, builder, bitstream, bios, programmer = flash_target
+    del builder.soc.build_name
+    bitstream.rename(builder.get_bitstream_filename(mode="flash"))
+    monkeypatch.setattr(sys, "argv", [target.__name__, "--flash",
+        "--bios-flash-offset=0x40000",
+        "--uart-name=stub",
+        "--output-dir", builder.output_dir,
+        "--gateware-dir", builder.gateware_dir,
+        "--software-dir", builder.software_dir,
+    ])
+    target.main()
+    if target is kosagi_fomu:
+        programmer.load_bitstream.assert_called_once_with(str(Path(builder.output_dir) / "image.bin"))
+    else:
+        assert programmer.flash.called
+
+
+def test_fomu_image_keeps_space_for_dfu_bootloader(tmp_path, monkeypatch):
+    soc = kosagi_fomu.BaseSoC(bios_flash_offset=0x60000, uart_name="stub")
+    builder = Builder(soc, output_dir=tmp_path)
+    bitstream = Path(builder.get_bitstream_filename(mode="flash"))
+    bios = Path(builder.get_bios_filename())
+    bitstream.parent.mkdir(parents=True)
+    bios.parent.mkdir(parents=True)
+    bitstream.write_bytes(b"bitstream")
+    bios.write_bytes(b"bios")
+    programmer = Mock()
+    monkeypatch.setattr("litex.build.dfu.DFUProg", lambda **kwargs: programmer)
+    offset = soc.bus.regions["spiflash"].size - soc.bus.regions["rom"].size
+    with pytest.raises(ValueError, match="DFU image exceeds"):
+        kosagi_fomu.flash(builder, offset)
+    programmer.load_bitstream.assert_not_called()
+
+
+def test_signaloid_flash_instructions_without_build(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["signaloid_c0_microsd", "--flash",
+        "--output-dir", str(tmp_path / "output"),
+        "--gateware-dir", str(tmp_path / "gateware"),
+        "--software-dir", str(tmp_path / "software"),
+    ])
+    signaloid_c0_microsd.main()
+    output = capsys.readouterr().out
+    assert str(tmp_path / "gateware" / "signaloid_c0_microsd.bin") in output
+    assert str(tmp_path / "software" / "bios" / "bios.bin") in output
+    assert "Programming is not supported" in output


### PR DESCRIPTION
`--flash` without `--build` raises `AttributeError` on iCEBreaker, Alchitry Cu, Fomu and Signaloid C0-microSD because `soc.build_name` has not been set. Their helpers also construct paths that ignore custom gateware/software directories.

Use Builder's filenames, reject overlapping or oversized flash images before programming, and preserve Fomu's DFU offset and BIOS padding. Signaloid continues to print instructions for its external programming utility, now with the correct filenames.

Validation: 42 flash tests passed, including standalone CLI calls, custom directories, image contents and invalid sizes. Programmers were mocked. All five CI lint scripts and 14 lint tests passed.
