### PR TITLE
targets/aliexpress_xc7k420t: fix SPI flash and bitstream loading

### DIFF
--- a/litex_boards/targets/aliexpress_xc7k420t.py
+++ b/litex_boards/targets/aliexpress_xc7k420t.py
@@ -53,8 +53,9 @@ class BaseSoC(SoCCore):
 
         # SPI Flash --------------------------------------------------------------------------------
         if with_spi_flash:
+            from litespi.modules import W25Q256
             from litespi.opcodes import SpiNorFlashOpCodes as Codes
-            self.add_spi_flash(mode="4x", module=W25Q256(Codes.READ_1_1_4))
+            self.add_spi_flash(mode="4x", module=W25Q256(Codes.READ_1_1_4_4B))
 
         # Leds -------------------------------------------------------------------------------------
         if with_led_chaser:
@@ -72,7 +73,8 @@ def main():
     args = parser.parse_args()
 
     soc = BaseSoC(
-        sys_clk_freq = args.sys_clk_freq,
+        sys_clk_freq   = args.sys_clk_freq,
+        with_spi_flash = args.with_spi_flash,
         **parser.soc_argdict
     )
     builder = Builder(soc, **parser.builder_argdict)
@@ -81,7 +83,7 @@ def main():
 
     if args.load:
         prog = soc.platform.create_programmer()
-        prog.load_bitstream(obuilder.get_bitstream_filename(mode="sram"))
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
 
 if __name__ == "__main__":
     main()

--- a/test/test_xc7k420t.py
+++ b/test/test_xc7k420t.py
@@ -1,0 +1,25 @@
+import sys
+from unittest.mock import Mock
+
+from litex_boards.targets import aliexpress_xc7k420t
+
+
+def test_spi_flash_constructor():
+    soc = aliexpress_xc7k420t.BaseSoC(with_spi_flash=True, uart_name="stub")
+    assert soc.bus.regions["spiflash"].size == 32 * 1024 * 1024
+    assert soc.constants["SPIFLASH_MODULE_NAME"] == "w25q256"
+    assert soc.spiflash.phy.flash.addr_bits == 32
+
+
+def test_spi_flash_option_and_load(monkeypatch, tmp_path):
+    soc = Mock()
+    builder = Mock()
+    bitstream = str(tmp_path / "custom.bit")
+    builder.return_value.get_bitstream_filename.return_value = bitstream
+    monkeypatch.setattr(aliexpress_xc7k420t, "BaseSoC", soc)
+    monkeypatch.setattr(aliexpress_xc7k420t, "Builder", builder)
+    monkeypatch.setattr(sys, "argv", ["aliexpress_xc7k420t", "--with-spi-flash", "--load"])
+    aliexpress_xc7k420t.main()
+    assert soc.call_args.kwargs["with_spi_flash"] is True
+    builder.return_value.get_bitstream_filename.assert_called_once_with(mode="sram")
+    soc.return_value.platform.create_programmer.return_value.load_bitstream.assert_called_once_with(bitstream)


### PR DESCRIPTION
`--load` references undefined `obuilder`, and `--with-spi-flash` is never passed to the SoC. Enabling flash through Python also fails because `W25Q256` is not imported.

Fix these paths and use the module's four-byte quad-read command to address the full 32 MiB flash.

Validation: constructor and CLI/load regression tests, gateware generation with SPI flash enabled (`--no-compile`), and all CI lint checks passed. Loading was mocked; no synthesis or hardware programming was performed.
