### PR TITLE
targets: forward UART and reset options

### DIFF
--- a/litex_boards/targets/antmicro_datacenter_ddr4_test_board.py
+++ b/litex_boards/targets/antmicro_datacenter_ddr4_test_board.py
@@ -214,6 +214,7 @@ def main():
         eth_ip                 = args.eth_ip,
         remote_ip              = args.remote_ip,
         eth_dynamic_ip         = args.eth_dynamic_ip,
+        eth_reset_time         = args.eth_reset_time,
         with_hyperram          = args.with_hyperram,
         with_sdcard            = args.with_sdcard,
         with_spi_flash         = args.with_spi_flash,

--- a/litex_boards/targets/berkeleylab_marble.py
+++ b/litex_boards/targets/berkeleylab_marble.py
@@ -44,7 +44,7 @@ from liteeth.phy.s7rgmii import LiteEthPHYRGMII
 # CRG ----------------------------------------------------------------------------------------------
 
 class _CRG(LiteXModule):
-    def __init__(self, platform, sys_clk_freq, resets=[]):
+    def __init__(self, platform, sys_clk_freq):
         self.rst          = Signal()
         self.cd_sys       = ClockDomain()
         self.cd_sys4x     = ClockDomain()
@@ -55,8 +55,7 @@ class _CRG(LiteXModule):
 
         self.pll = pll = S7MMCM(speedgrade=-2)
 
-        resets.append(self.rst)
-        self.comb += pll.reset.eq(reduce(or_, resets))
+        self.comb += pll.reset.eq(self.rst)
         pll.register_clkin(platform.request("clk125"), 125e6)
         pll.create_clkout(self.cd_sys, sys_clk_freq)
         pll.create_clkout(self.cd_sys4x, 4*sys_clk_freq)
@@ -83,14 +82,16 @@ class BaseSoC(SoCCore):
         platform = berkeleylab_marble.Platform()
 
         # CRG, resettable over USB serial RTS signal -----------------------------------------------
-        resets = []
-        if with_rts_reset:
-            ser_pads = platform.lookup_request('serial')
-            resets.append(ser_pads.rts)
-        self.crg = _CRG(platform, sys_clk_freq, resets)
+        self.crg = _CRG(platform, sys_clk_freq)
 
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Berkeley-Lab Marble", **kwargs)
+
+        if with_rts_reset:
+            serial_pads = platform.lookup_request("serial", loose=True)
+            if serial_pads is None:
+                serial_pads = platform.request("serial")
+            self.comb += self.crg.rst.eq(serial_pads.rts)
 
         # DDR3 SDRAM -------------------------------------------------------------------------------
         if not self.integrated_main_ram_size:
@@ -173,6 +174,7 @@ def main():
         eth_dynamic_ip = args.eth_dynamic_ip,
         remote_ip      = args.remote_ip,
         with_etherbone = args.with_etherbone,
+        with_rts_reset = args.with_rts_reset,
         with_bist      = args.with_bist,
         spd_dump       = args.spd_dump,
         **parser.soc_argdict

--- a/litex_boards/targets/lattice_crosslink_nx_evn.py
+++ b/litex_boards/targets/lattice_crosslink_nx_evn.py
@@ -105,7 +105,7 @@ def main():
     parser = LiteXArgumentParser(platform=lattice_crosslink_nx_evn.Platform, description="LiteX SoC on Crosslink-NX Eval Board.")
     parser.add_target_argument("--device",         default="LIFCL-40-9BG400C", help="FPGA device (LIFCL-40-9BG400C, LIFCL-40-8BG400CES, or LIFCL-40-8BG400CES2).")
     parser.add_target_argument("--sys-clk-freq",   default=75e6, type=float,   help="System clock frequency.")
-    parser.add_target_argument("--serial",         default="serial",           help="UART Pins (serial (requires R15 and R17 to be soldered) or serial_pmod[0-2]).")
+    parser.add_target_argument("--serial", dest="uart_name", default="serial", help="Alias for --uart-name: serial (requires R15 and R17 to be soldered) or serial_pmod[0-2].")
     parser.add_target_argument("--programmer",     default="radiant",          help="Programmer (radiant or ecpprog or openocd).")
     parser.add_target_argument("--address", default=0x0, type=lambda x: int(x, 0), help="Flash address to program bitstream at.")
     parser.add_target_argument("--prog-target",    default="direct",           help="Programming Target (direct or flash).")

--- a/test/test_target_forwarding.py
+++ b/test/test_target_forwarding.py
@@ -1,0 +1,59 @@
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+from migen import Module, run_simulation
+
+from litex_boards.targets import (
+    antmicro_datacenter_ddr4_test_board, berkeleylab_marble, lattice_crosslink_nx_evn,
+)
+
+
+@pytest.mark.parametrize("args, uart_name", [
+    ([], "serial"),
+    (["--serial", "serial_pmod0"], "serial_pmod0"),
+    (["--uart-name", "serial_pmod1"], "serial_pmod1"),
+    (["--serial", "serial_pmod0", "--uart-name", "stub"], "stub"),
+    (["--uart-name", "stub", "--serial", "serial_pmod2"], "serial_pmod2"),
+])
+def test_crosslink_serial_alias(monkeypatch, args, uart_name):
+    soc = Mock()
+    monkeypatch.setattr(lattice_crosslink_nx_evn, "BaseSoC", soc)
+    monkeypatch.setattr(lattice_crosslink_nx_evn, "Builder", Mock())
+    monkeypatch.setattr(sys, "argv", ["lattice_crosslink_nx_evn", *args])
+    lattice_crosslink_nx_evn.main()
+    assert soc.call_args.kwargs["uart_name"] == uart_name
+
+
+@pytest.mark.parametrize("target, args, keyword, value", [
+    (berkeleylab_marble, [], "with_rts_reset", False),
+    (berkeleylab_marble, ["--with-rts-reset"], "with_rts_reset", True),
+    (antmicro_datacenter_ddr4_test_board, ["--eth-reset-time", "0.25"], "eth_reset_time", "0.25"),
+])
+def test_target_option_forwarding(monkeypatch, target, args, keyword, value):
+    soc = Mock()
+    monkeypatch.setattr(target, "BaseSoC", soc)
+    monkeypatch.setattr(target, "Builder", Mock())
+    monkeypatch.setattr(sys, "argv", [target.__name__, *args])
+    target.main()
+    assert soc.call_args.kwargs[keyword] == value
+
+
+@pytest.mark.parametrize("uart_name", ["serial", "crossover"])
+def test_marble_rts_and_software_reset(uart_name):
+    soc = berkeleylab_marble.BaseSoC(
+        with_rts_reset=True, uart_name=uart_name, integrated_main_ram_size=0x10000)
+    serial = soc.platform.lookup_request("serial")
+    soc._finalize_reset()
+    dut = Module()
+    dut.comb += soc._fragment.comb
+
+    def stimulus():
+        for rts, software in [(0, 0), (1, 0), (0, 1), (1, 1), (0, 0)]:
+            yield serial.rts.eq(rts)
+            yield soc.ctrl.soc_rst.eq(software)
+            yield
+            assert (yield soc.crg.rst) == (rts or software)
+
+    run_simulation(dut, stimulus())


### PR DESCRIPTION
CrossLink-NX's `--serial`, Marble's `--with-rts-reset`, and the Antmicro datacenter DDR4 board's `--eth-reset-time` are accepted but ignored.

Make `--serial` an alias for `--uart-name` and forward the reset options. Connect Marble's RTS reset after UART allocation so enabling it does not fail on an unrequested resource; retain software reset through the CRG reset input.

Validation: 10 tests cover forwarding, alias ordering and simulation of Marble's RTS/software resets. Gateware generation passed for all three options; the Antmicro output uses 25,000,000 reset cycles for 0.25 seconds at 100 MHz. All CI lint checks passed. No synthesis or hardware programming was performed.
