### PR TITLE
targets: reuse the Ethernet MAC created by Etherbone

### DIFF
--- a/litex_boards/targets/lambdaconcept_ecpix5.py
+++ b/litex_boards/targets/lambdaconcept_ecpix5.py
@@ -129,7 +129,7 @@ class BaseSoC(SoCCore):
                 rx_delay   = 0e-9)
             if with_etherbone:
                 self.add_etherbone(phy=self.ethphy, ip_address=eth_ip, with_ethmac=with_ethernet)
-            if with_ethernet:
+            elif with_ethernet:
                 self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip, local_ip=eth_ip, remote_ip=remote_ip)
 
         # SATA -------------------------------------------------------------------------------------

--- a/litex_boards/targets/qmtech_wukong.py
+++ b/litex_boards/targets/qmtech_wukong.py
@@ -114,7 +114,7 @@ class BaseSoC(SoCCore):
                 pads       = self.platform.request("eth"))
             if with_etherbone:
                 self.add_etherbone(phy=self.ethphy, ip_address=eth_ip, with_ethmac=with_ethernet)
-            if with_ethernet:
+            elif with_ethernet:
                 self.add_ethernet(phy=self.ethphy, nrxslots=2, dynamic_ip=eth_dynamic_ip, local_ip=eth_ip, remote_ip=remote_ip)
 
         # Leds -------------------------------------------------------------------------------------

--- a/litex_boards/targets/terasic_deca.py
+++ b/litex_boards/targets/terasic_deca.py
@@ -91,7 +91,7 @@ class BaseSoC(SoCCore):
                 pads       = self.platform.request("eth"))
             if with_etherbone:
                 self.add_etherbone(phy=self.ethphy, ip_address=eth_ip, with_ethmac=with_ethernet)
-            if with_ethernet:
+            elif with_ethernet:
                 self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip, local_ip=eth_ip, remote_ip=remote_ip)
 
         # Video ------------------------------------------------------------------------------------

--- a/test/test_shared_ethernet.py
+++ b/test/test_shared_ethernet.py
@@ -1,0 +1,21 @@
+import pytest
+
+from litex_boards.targets import lambdaconcept_ecpix5, qmtech_wukong, terasic_deca
+
+
+@pytest.mark.parametrize("target", [lambdaconcept_ecpix5, qmtech_wukong, terasic_deca])
+@pytest.mark.parametrize("ethernet, etherbone", [(True, False), (False, True), (True, True)])
+def test_ethernet_and_etherbone(target, ethernet, etherbone):
+    soc = target.BaseSoC(
+        with_ethernet=ethernet,
+        with_etherbone=etherbone,
+        uart_name="stub",
+        integrated_main_ram_size=0x10000,
+    )
+    assert hasattr(soc, "ethmac") == ethernet
+    assert hasattr(soc, "etherbone") == etherbone
+    assert ("ethmac_rx" in soc.bus.slaves) == ethernet
+    assert ("ethmac_tx" in soc.bus.slaves) == ethernet
+    assert ("etherbone" in soc.bus.masters) == etherbone
+    if ethernet and etherbone:
+        assert soc.constants["LOCALIP4"] == 51


### PR DESCRIPTION
DECA, QMTECH Wukong and ECPIX-5 fail when both `with_ethernet` and `with_etherbone` are enabled through Python: `add_etherbone(with_ethmac=True)` creates the MAC, then `add_ethernet()` tries to create it again.

Use the MAC already created by Etherbone. Ethernet-only and Etherbone-only configurations retain their existing paths.

Validation: nine tests cover all three configurations on each board. Combined Ethernet/Etherbone gateware generation passed on all three boards (`--no-compile`), as did all CI lint checks. No synthesis or hardware programming was performed.
