### PR TITLE
targets/gowin5: constrain DDR3 clocks and fix Console 60K PFD limits

### DIFF
--- a/litex_boards/targets/sipeed_tang_console.py
+++ b/litex_boards/targets/sipeed_tang_console.py
@@ -136,6 +136,16 @@ class _CRG(LiteXModule):
                 o_CLKOUT   = self.cd_hdmi.clk
             )
 
+        if with_ddr3:
+            # Preserve the PLL/CLKDIV relationship for timing analysis.
+            config  = pll.compute_config()
+            ddr_clk = pll.clkouts[0].clk
+            platform.add_generated_clock_constraint(ddr_clk, clk50,
+                multiply_by = config["fdiv"]*config["mdiv"],
+                divide_by   = config["idiv"]*config["odiv0"])
+            platform.add_generated_clock_constraint(self.cd_sys.clk, ddr_clk,
+                divide_by = ddr3_nphases)
+
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):

--- a/litex_boards/targets/sipeed_tang_console.py
+++ b/litex_boards/targets/sipeed_tang_console.py
@@ -82,6 +82,8 @@ class _CRG(LiteXModule):
                 "GW5AT-60B":   (700e6, 1400e6),
                 "GW5AST-138C": (650e6, 1300e6),
             }[platform.devicename]
+            if platform.devicename == "GW5AT-60B":
+                pll.pfd_freq_range = (19e6, 87.5e6)
             self.comb += pll.reset.eq(~por_done | rst)
             pll.register_clkin(clk50, 50e6)
             if with_ddr3:

--- a/litex_boards/targets/sipeed_tang_mega_138k.py
+++ b/litex_boards/targets/sipeed_tang_mega_138k.py
@@ -157,6 +157,16 @@ class _CRG(LiteXModule):
                 o_CLKOUT   = clk50_half)
             self.specials += DDROutput(1, 0, platform.request("eth_ref_clk"), clk50_half)
 
+        if with_ddr3:
+            # Preserve the PLL/CLKDIV relationship for timing analysis.
+            config  = pll.compute_config()
+            ddr_clk = pll.clkouts[0].clk
+            platform.add_generated_clock_constraint(ddr_clk, clk50,
+                multiply_by = config["fdiv"]*config["mdiv"],
+                divide_by   = config["idiv"]*config["odiv0"])
+            platform.add_generated_clock_constraint(self.cd_sys.clk, ddr_clk,
+                divide_by = ddr3_nphases)
+
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):

--- a/litex_boards/targets/sipeed_tang_mega_138k_pro.py
+++ b/litex_boards/targets/sipeed_tang_mega_138k_pro.py
@@ -138,6 +138,16 @@ class _CRG(LiteXModule):
         if with_pcie:
             pll.create_clkout(self.cd_crg_pcie, 125e6, with_reset=False)
 
+        if with_ddr3:
+            # Preserve the PLL/CLKDIV relationship for timing analysis.
+            config  = pll.compute_config()
+            ddr_clk = pll.clkouts[0].clk
+            platform.add_generated_clock_constraint(ddr_clk, clk50,
+                multiply_by = config["fdiv"]*config["mdiv"],
+                divide_by   = config["idiv"]*config["odiv0"])
+            platform.add_generated_clock_constraint(self.cd_sys.clk, ddr_clk,
+                divide_by = ddr3_nphases)
+
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):


### PR DESCRIPTION
The Console 60K can select an invalid PLL divider at intermediate frequencies: requesting 83⅓ MHz system clock in DDR3 1:4 mode selected a 16⅔ MHz PFD, which Gowin rejects with PA2078. Apply the GW5AT-60B PFD range of 19–87.5 MHz. The same request then selects a valid 50 MHz PFD / 1 GHz VCO.

For all Gowin5 DDR3 targets, constrain the PLL output and the divided system clock as generated clocks. Use the actual PLL divider configuration and output signal, preserving the PLL → CLKDIV relationship through synthesis. This requires https://github.com/enjoy-digital/litex/pull/2577. Default frequencies are unchanged.

Full Gowin 1.9.12 builds pass for Console 60K, Console 138K, Mega 138K and Mega 138K Pro at 83⅓ MHz / 1:4. With https://github.com/enjoy-digital/litex/pull/2574 and https://github.com/enjoy-digital/litedram/pull/403, the connected Console 60K passes repeated boots and a full 512 MiB DDR3 write/read test with its DLL enabled. The other devices are build-tested only. The Console's system and memory clock domains have no internal setup/hold violations at this operating point; startup/delay-control crossings remain reported. 100 MHz is not qualified.

Build through the normal target after installing the companion changes:

```sh
python3 -m litex_boards.targets.sipeed_tang_console \
  --device GW5AT-60B --with-ddr3 --ddr3-rate 1:4 \
  --sys-clk-freq 83.333333e6 --uart-name crossover+uartbone --build
```

`crossover+uartbone` is used for the paced console through the connected Sipeed USB debugger. The design uses on-board DDR3, not the separate SDR SDRAM interface.
