### PR TITLE
targets/gowin5: enable onboard DDR3 by default

### DIFF
--- a/litex_boards/targets/sipeed_tang_console.py
+++ b/litex_boards/targets/sipeed_tang_console.py
@@ -151,7 +151,7 @@ class _CRG(LiteXModule):
 class BaseSoC(SoCCore):
     def __init__(self, toolchain="gowin", device="GW5AT-60B", sys_clk_freq=50e6,
         with_video_terminal = False,
-        with_ddr3           = False,
+        with_ddr3           = True,
         ddr3_rate           = "1:2",
         with_sdram          = False,
         sdram_model         = "sipeed",
@@ -173,10 +173,11 @@ class BaseSoC(SoCCore):
         if with_sdram:
             platform.add_extension({
                 "sipeed": sipeed_tang_console.sipeedSDRAM(),
-                "mister": sipeed_tang_console.misterSDRAM}[sdram_model]
+                "mister": sipeed_tang_console.misterSDRAM()}[sdram_model]
             )
 
         # CRG --------------------------------------------------------------------------------------
+        with_ddr3 = with_ddr3 and not (with_sdram or without_pll or kwargs.get("integrated_main_ram_size", 0))
         self.crg = _CRG(platform, sys_clk_freq,
             with_sdram     = with_sdram,
             sdram_rate     = sdram_rate,
@@ -263,14 +264,14 @@ def main():
     parser.add_target_argument("--with-spi-flash",  action="store_true",      help="Enable memory-mapped SPI flash.")
     parser.add_target_argument("--with-sdcard",     action="store_true",      help="Enable SDCard support.")
     parser.add_target_argument("--with-spi-sdcard", action="store_true",      help="Enable SPI-mode SDCard support.")
-    parser.add_target_argument("--with-sdram",      action="store_true",      help="Enable optional SDRAM module.")
+    parser.add_target_argument("--with-sdram",      action="store_true",      help="Use the optional SDRAM module instead of DDR3.")
     parser.add_target_argument("--without-pll",     action="store_true",      help="Disable use of PLL.")
     parser.add_target_argument("--sdram-model",     default="sipeed",
         choices=[
             "sipeed",
             "mister"
     ], help="SDRAM module model.")
-    parser.add_target_argument("--with-ddr3",           action="store_true", help="Enable optional DDR3 module.")
+    parser.add_target_argument("--without-ddr3",        action="store_true", help="Disable DDR3 SDRAM.")
     parser.add_target_argument("--ddr3-rate",           default="1:2", choices=["1:2", "1:4"],
         help="DDR3 PHY clock ratio. For 1:4, use --sys-clk-freq=25e6 (DLL-off) or 100e6 (DLL-on).")
     parser.add_target_argument("--with-video-terminal", action="store_true", help="Enable Video Terminal (HDMI).")
@@ -280,7 +281,7 @@ def main():
         sys_clk_freq        = args.sys_clk_freq,
         device              = args.device,
         with_video_terminal = args.with_video_terminal,
-        with_ddr3           = args.with_ddr3,
+        with_ddr3           = not args.without_ddr3,
         ddr3_rate           = args.ddr3_rate,
         with_sdram          = args.with_sdram,
         sdram_model         = args.sdram_model,

--- a/litex_boards/targets/sipeed_tang_mega_138k.py
+++ b/litex_boards/targets/sipeed_tang_mega_138k.py
@@ -179,7 +179,7 @@ class BaseSoC(SoCCore):
         with_video_colorbars   = False,
         with_video_terminal    = False,
         with_video_framebuffer = False,
-        with_ddr3              = False,
+        with_ddr3              = True,
         ddr3_rate              = "1:2",
         with_sdram             = False,
         sdram_model            = "sipeed",
@@ -198,11 +198,12 @@ class BaseSoC(SoCCore):
 
         if with_sdram:
             platform.add_extension({
-                "sipeed": sipeed_tang_mega_138k_pro.sipeedSDRAM(),
-                "mister": sipeed_tang_mega_138k_pro.misterSDRAM()}[sdram_model]
+                "sipeed": sipeed_tang_mega_138k.sipeedSDRAM(),
+                "mister": sipeed_tang_mega_138k.misterSDRAM()}[sdram_model]
             )
 
         # CRG --------------------------------------------------------------------------------------
+        with_ddr3 = with_ddr3 and not (with_sdram or kwargs.get("integrated_main_ram_size", 0))
         cpu_clk_freq = int(800e6) if kwargs["cpu_type"] == "gowin_ae350" else 0
         self.crg = _CRG(platform, sys_clk_freq, cpu_clk_freq,
             with_sdram     = with_sdram,
@@ -304,10 +305,10 @@ def main():
     parser.add_target_argument("--sys-clk-freq",   default=50e6, type=float, help="System clock frequency.")
 
     # Memory.
-    parser.add_target_argument("--with-ddr3",      action="store_true", help="Enable optional DDR3 module.")
+    parser.add_target_argument("--without-ddr3",   action="store_true", help="Disable DDR3 SDRAM.")
     parser.add_target_argument("--ddr3-rate",      default="1:2", choices=["1:2", "1:4"],
         help="DDR3 PHY clock ratio. For 1:4, use --sys-clk-freq=25e6 (DLL-off) or 100e6 (DLL-on).")
-    parser.add_target_argument("--with-sdram",     action="store_true", help="Enable optional SDRAM module.")
+    parser.add_target_argument("--with-sdram",     action="store_true", help="Use the optional SDRAM module instead of DDR3.")
     parser.add_target_argument("--sdram-model",    default="sipeed",
         choices=[
             "sipeed",
@@ -339,7 +340,7 @@ def main():
         with_video_colorbars   = args.with_video_colorbars,
         with_video_terminal    = args.with_video_terminal,
         with_video_framebuffer = args.with_video_framebuffer,
-        with_ddr3              = args.with_ddr3,
+        with_ddr3              = not args.without_ddr3,
         ddr3_rate              = args.ddr3_rate,
         with_sdram             = args.with_sdram,
         sdram_model            = args.sdram_model,

--- a/litex_boards/targets/sipeed_tang_mega_138k_pro.py
+++ b/litex_boards/targets/sipeed_tang_mega_138k_pro.py
@@ -158,7 +158,7 @@ class BaseSoC(SoCCore):
         remote_ip           = "",
         eth_dynamic_ip      = False,
         with_video_terminal = False,
-        with_ddr3           = False,
+        with_ddr3           = True,
         ddr3_rate           = "1:2",
         with_sdram          = False,
         sdram_model         = "sipeed",
@@ -178,10 +178,11 @@ class BaseSoC(SoCCore):
         if with_sdram:
             platform.add_extension({
                 "sipeed": sipeed_tang_mega_138k_pro.sipeedSDRAM(),
-                "mister": sipeed_tang_mega_138k_pro.misterSDRAM}[sdram_model]
+                "mister": sipeed_tang_mega_138k_pro.misterSDRAM()}[sdram_model]
             )
 
         # CRG --------------------------------------------------------------------------------------
+        with_ddr3 = with_ddr3 and not (with_sdram or kwargs.get("integrated_main_ram_size", 0))
         cpu_clk_freq = int(800e6) if kwargs["cpu_type"] == "gowin_ae350" else 0
         self.crg = _CRG(platform, sys_clk_freq, cpu_clk_freq,
             with_sdram     = with_sdram,
@@ -276,13 +277,13 @@ def main():
     parser = LiteXArgumentParser(platform=sipeed_tang_mega_138k_pro.Platform, description="LiteX SoC on Tang Mega 138K Pro.")
     parser.add_target_argument("--flash",               action="store_true",      help="Flash bitstream.")
     parser.add_target_argument("--sys-clk-freq",        default=50e6, type=float, help="System clock frequency.")
-    parser.add_target_argument("--with-sdram",          action="store_true",      help="Enable optional SDRAM module.")
+    parser.add_target_argument("--with-sdram",          action="store_true",      help="Use the optional SDRAM module instead of DDR3.")
     parser.add_target_argument("--sdram-model",         default="sipeed",
         choices=[
             "sipeed",
             "mister"
     ], help="SDRAM module model.")
-    parser.add_target_argument("--with-ddr3",           action="store_true",      help="Enable optional DDR3 module.")
+    parser.add_target_argument("--without-ddr3",        action="store_true",      help="Disable DDR3 SDRAM.")
     parser.add_target_argument("--ddr3-rate",           default="1:2", choices=["1:2", "1:4"],
         help="DDR3 PHY clock ratio. For 1:4, use --sys-clk-freq=25e6 (DLL-off) or 100e6 (DLL-on).")
     parser.add_target_argument("--with-video-terminal", action="store_true",      help="Enable Video Terminal (HDMI).")
@@ -300,7 +301,7 @@ def main():
     soc = BaseSoC(
         sys_clk_freq        = args.sys_clk_freq,
         with_video_terminal = args.with_video_terminal,
-        with_ddr3           = args.with_ddr3,
+        with_ddr3           = not args.without_ddr3,
         ddr3_rate           = args.ddr3_rate,
         with_sdram          = args.with_sdram,
         sdram_model         = args.sdram_model,


### PR DESCRIPTION
Tang Mega 138K, Tang Mega 138K Pro, and Tang Console still require `--with-ddr3` even though their onboard DDR3 now works. Enable DDR3 by default in both `BaseSoC` and the command line, and replace `--with-ddr3` with `--without-ddr3` to follow the usual external-memory default of LiteX board targets.

Build with DDR3 using the regular commands:

```sh
python3 -m litex_boards.targets.sipeed_tang_mega_138k --build
python3 -m litex_boards.targets.sipeed_tang_mega_138k_pro --build
python3 -m litex_boards.targets.sipeed_tang_console --build
python3 -m litex_boards.targets.sipeed_tang_console --device=GW5AST-138C --build
```

Existing scripts should remove `--with-ddr3`. Add `--without-ddr3` to build without external DDR3. The default remains 50 MHz system clock with a 1:2 PHY ratio; `--ddr3-rate=1:4` remains available.

Explicit alternative configurations take precedence before creating the clock generator:

- `--with-sdram` selects the optional SDRAM module instead of DDR3.
- A nonzero `--integrated-main-ram-size` disables the DDR3 PHY and its clocks.
- Tang Console's `--without-pll` also disables DDR3, preserving the direct-clock configuration.

Checking the SDRAM alternative exposed incorrect extension references: use the Mega's own platform helpers, and call `misterSDRAM()` on Console and Mega Pro.

Validation:

- All six repository guardrail checks and 134 tests passed (`python3 -m pytest -q test --ignore=test/test_targets.py`).
- 26 SoC/Verilog-generation configurations passed with `--build --no-compile`: six configurations on each of the four board variants (default DDR3, DDR3 disabled, integrated RAM, Sipeed SDRAM, MiSTer SDRAM, and DDR3 1:4 at 25 MHz), plus both Console variants without a PLL. Checked the generated PHY/controller CSRs, DDR3 pins/DLL, and main RAM regions.
- Default BIOS builds passed for Tang Console 60K and Tang Mega 138K Pro with `--build --no-compile-gateware`.

This validation covers generation and software compilation; FPGA synthesis and a fresh hardware run were not performed for this default-selection change.
