### PR TITLE
targets/gowin5: centralize DDR3 and SDRAM selection

### DIFF
--- a/litex_boards/targets/sipeed_tang_console.py
+++ b/litex_boards/targets/sipeed_tang_console.py
@@ -169,8 +169,10 @@ class BaseSoC(SoCCore):
         platform = sipeed_tang_console.Platform(toolchain=toolchain, device=device)
 
         # Memory configuration ---------------------------------------------------------------------
-        with_ddr3  = with_ddr3 and not (with_sdram or without_pll or kwargs.get("integrated_main_ram_size", 0))
-        with_sdram = with_sdram and not kwargs.get("integrated_main_ram_size", 0)
+        integrated_main_ram_size = kwargs.get("integrated_main_ram_size", 0)
+
+        with_ddr3  = with_ddr3 and not (with_sdram or without_pll or integrated_main_ram_size)
+        with_sdram = with_sdram and not integrated_main_ram_size
 
         assert not with_sdram or (sdram_model in ["sipeed", "mister"])
 

--- a/litex_boards/targets/sipeed_tang_console.py
+++ b/litex_boards/targets/sipeed_tang_console.py
@@ -168,6 +168,10 @@ class BaseSoC(SoCCore):
 
         platform = sipeed_tang_console.Platform(toolchain=toolchain, device=device)
 
+        # Memory configuration ---------------------------------------------------------------------
+        with_ddr3  = with_ddr3 and not (with_sdram or without_pll or kwargs.get("integrated_main_ram_size", 0))
+        with_sdram = with_sdram and not kwargs.get("integrated_main_ram_size", 0)
+
         assert not with_sdram or (sdram_model in ["sipeed", "mister"])
 
         if with_sdram:
@@ -177,7 +181,6 @@ class BaseSoC(SoCCore):
             )
 
         # CRG --------------------------------------------------------------------------------------
-        with_ddr3 = with_ddr3 and not (with_sdram or without_pll or kwargs.get("integrated_main_ram_size", 0))
         self.crg = _CRG(platform, sys_clk_freq,
             with_sdram     = with_sdram,
             sdram_rate     = sdram_rate,
@@ -190,7 +193,7 @@ class BaseSoC(SoCCore):
         SoCCore.__init__(self, platform, sys_clk_freq, ident="LiteX SoC on Tang Console", **kwargs)
 
         # DDR3 SDRAM -------------------------------------------------------------------------------
-        if with_ddr3 and not self.integrated_main_ram_size:
+        if with_ddr3:
             # At CK <= 125 MHz, use DDR3 DLL-off mode (CL6/CWL6, no ODT).
             self.ddrphy = GW5DDRPHY(
                 pads         = platform.request("ddram"),
@@ -208,7 +211,7 @@ class BaseSoC(SoCCore):
             )
 
         # SDR SDRAM --------------------------------------------------------------------------------
-        if with_sdram and not self.integrated_main_ram_size:
+        if with_sdram:
             module_cls = {
                 "sipeed": W9825G6KH6,
                 "mister": AS4C32M16}[sdram_model]

--- a/litex_boards/targets/sipeed_tang_mega_138k.py
+++ b/litex_boards/targets/sipeed_tang_mega_138k.py
@@ -194,6 +194,10 @@ class BaseSoC(SoCCore):
 
         platform = sipeed_tang_mega_138k.Platform(toolchain="gowin")
 
+        # Memory configuration ---------------------------------------------------------------------
+        with_ddr3  = with_ddr3 and not (with_sdram or kwargs.get("integrated_main_ram_size", 0))
+        with_sdram = with_sdram and not kwargs.get("integrated_main_ram_size", 0)
+
         assert not with_sdram or (sdram_model in ["sipeed", "mister"])
 
         if with_sdram:
@@ -203,7 +207,6 @@ class BaseSoC(SoCCore):
             )
 
         # CRG --------------------------------------------------------------------------------------
-        with_ddr3 = with_ddr3 and not (with_sdram or kwargs.get("integrated_main_ram_size", 0))
         cpu_clk_freq = int(800e6) if kwargs["cpu_type"] == "gowin_ae350" else 0
         self.crg = _CRG(platform, sys_clk_freq, cpu_clk_freq,
             with_sdram     = with_sdram,
@@ -220,7 +223,7 @@ class BaseSoC(SoCCore):
             self.add_config("CPU_CLK_FREQ", cpu_clk_freq)
 
         # DDR3 SDRAM -------------------------------------------------------------------------------
-        if with_ddr3 and not self.integrated_main_ram_size:
+        if with_ddr3:
             # At CK <= 125 MHz, use DDR3 DLL-off mode (CL6/CWL6, no ODT).
             self.ddrphy = GW5DDRPHY(
                 pads         = platform.request("ddram"),
@@ -276,7 +279,7 @@ class BaseSoC(SoCCore):
                     software_debug = False)
 
         # SDR SDRAM --------------------------------------------------------------------------------
-        if with_sdram and not self.integrated_main_ram_size:
+        if with_sdram:
             module_cls = {
                 "sipeed": W9825G6KH6,
                 "mister": AS4C32M16}[sdram_model]

--- a/litex_boards/targets/sipeed_tang_mega_138k.py
+++ b/litex_boards/targets/sipeed_tang_mega_138k.py
@@ -195,8 +195,10 @@ class BaseSoC(SoCCore):
         platform = sipeed_tang_mega_138k.Platform(toolchain="gowin")
 
         # Memory configuration ---------------------------------------------------------------------
-        with_ddr3  = with_ddr3 and not (with_sdram or kwargs.get("integrated_main_ram_size", 0))
-        with_sdram = with_sdram and not kwargs.get("integrated_main_ram_size", 0)
+        integrated_main_ram_size = kwargs.get("integrated_main_ram_size", 0)
+
+        with_ddr3  = with_ddr3 and not (with_sdram or integrated_main_ram_size)
+        with_sdram = with_sdram and not integrated_main_ram_size
 
         assert not with_sdram or (sdram_model in ["sipeed", "mister"])
 

--- a/litex_boards/targets/sipeed_tang_mega_138k_pro.py
+++ b/litex_boards/targets/sipeed_tang_mega_138k_pro.py
@@ -174,8 +174,10 @@ class BaseSoC(SoCCore):
         platform = sipeed_tang_mega_138k_pro.Platform(toolchain="gowin")
 
         # Memory configuration ---------------------------------------------------------------------
-        with_ddr3  = with_ddr3 and not (with_sdram or kwargs.get("integrated_main_ram_size", 0))
-        with_sdram = with_sdram and not kwargs.get("integrated_main_ram_size", 0)
+        integrated_main_ram_size = kwargs.get("integrated_main_ram_size", 0)
+
+        with_ddr3  = with_ddr3 and not (with_sdram or integrated_main_ram_size)
+        with_sdram = with_sdram and not integrated_main_ram_size
 
         assert not with_sdram or (sdram_model in ["sipeed", "mister"])
 

--- a/litex_boards/targets/sipeed_tang_mega_138k_pro.py
+++ b/litex_boards/targets/sipeed_tang_mega_138k_pro.py
@@ -173,6 +173,10 @@ class BaseSoC(SoCCore):
 
         platform = sipeed_tang_mega_138k_pro.Platform(toolchain="gowin")
 
+        # Memory configuration ---------------------------------------------------------------------
+        with_ddr3  = with_ddr3 and not (with_sdram or kwargs.get("integrated_main_ram_size", 0))
+        with_sdram = with_sdram and not kwargs.get("integrated_main_ram_size", 0)
+
         assert not with_sdram or (sdram_model in ["sipeed", "mister"])
 
         if with_sdram:
@@ -182,7 +186,6 @@ class BaseSoC(SoCCore):
             )
 
         # CRG --------------------------------------------------------------------------------------
-        with_ddr3 = with_ddr3 and not (with_sdram or kwargs.get("integrated_main_ram_size", 0))
         cpu_clk_freq = int(800e6) if kwargs["cpu_type"] == "gowin_ae350" else 0
         self.crg = _CRG(platform, sys_clk_freq, cpu_clk_freq,
             with_sdram     = with_sdram,
@@ -197,7 +200,7 @@ class BaseSoC(SoCCore):
             self.add_config("CPU_CLK_FREQ", cpu_clk_freq)
 
         # DDR3 SDRAM -------------------------------------------------------------------------------
-        if with_ddr3 and not self.integrated_main_ram_size:
+        if with_ddr3:
             # At CK <= 125 MHz, use DDR3 DLL-off mode (CL6/CWL6, no ODT).
             self.ddrphy = GW5DDRPHY(
                 pads         = platform.request("ddram"),
@@ -250,7 +253,7 @@ class BaseSoC(SoCCore):
                 self.add_ethernet(phy=self.ethphy, dynamic_ip=eth_dynamic_ip, local_ip=eth_ip, remote_ip=remote_ip, data_width=32, software_debug=True)
 
         # SDR SDRAM --------------------------------------------------------------------------------
-        if with_sdram and not self.integrated_main_ram_size:
+        if with_sdram:
             module_cls = {
                 "sipeed": W9825G6KH6,
                 "mister": AS4C32M16}[sdram_model]


### PR DESCRIPTION
Follow-up to #792: determine the effective DDR3 and SDR SDRAM selections once, before adding platform extensions or creating the clock generator, on Tang Console, Tang Mega 138K, and Tang Mega 138K Pro.

The existing DDR3 selection already excludes integrated main RAM, so the later `and not self.integrated_main_ram_size` check is redundant. Apply the same selection logic to SDR SDRAM, then use `if with_ddr3:` and `if with_sdram:` for the PHY/controller blocks.

With `--with-sdram --integrated-main-ram-size=8192`, the target now also skips the SDRAM extension, output clock pin, and SDRAM clock domains. The integrated RAM selection takes effect consistently for both the clock generator and the memory controller.

Validation:

- All six repository guardrail checks and 134 tests passed (`python3 -m pytest -q test --ignore=test/test_targets.py`).
- 34 SoC/Verilog-generation configurations passed with `--build --no-compile` across Mega 138K, Mega 138K Pro, Console 60K, and Console 138K: default DDR3, DDR3 disabled, integrated RAM, both SDRAM module models with and without integrated RAM, DDR3 1:4 at 25 MHz, and both Console variants without a PLL.
- Checked generated PHY/controller CSRs, DDR3 pins/DLL, SDRAM pins/clock domains, and main RAM regions. In particular, integrated RAM suppresses both external-memory paths and their clocks.
